### PR TITLE
[Core]: Fixed internal CFs not added to address table

### DIFF
--- a/isobus/include/can_internal_control_function.hpp
+++ b/isobus/include/can_internal_control_function.hpp
@@ -13,12 +13,13 @@
 
 #include "can_control_function.hpp"
 #include "can_address_claim_state_machine.hpp"
+#include "can_badge.hpp"
 
 #include <list>
 
 namespace isobus
 {
-    
+class CANNetworkManager; 
 class InternalControlFunction : public ControlFunction
 {
 public:
@@ -28,12 +29,21 @@ public:
     static InternalControlFunction *get_internal_control_function(std::uint32_t index);
     static std::uint32_t get_number_internal_control_functions();
 
-    static void update_address_claiming();
-    void update();
+    // These tell the network manager when the address table needs to be explicitly
+    // updated for an internal control function claiming a new address.
+    // Other CF types are handled in Rx message processing.
+    static bool get_any_internal_control_function_changed_address(CANLibBadge<CANNetworkManager>);
+    bool get_changed_address_since_last_update(CANLibBadge<CANNetworkManager>) const;
+
+    static void update_address_claiming(CANLibBadge<CANNetworkManager>);
 
 private:
+    void update();
+
     static std::list<InternalControlFunction*> internalControlFunctionList;
+    static bool anyChangedAddress;
     AddressClaimStateMachine stateMachine;
+    bool objectChangedAddressSinceLastUpdate;
 };
 
 } // namespace isobus

--- a/isobus/include/can_network_manager.hpp
+++ b/isobus/include/can_network_manager.hpp
@@ -82,6 +82,7 @@ private:
     };
 
     void update_address_table(CANMessage &message);
+    void update_address_table(std::uint8_t CANPort, std::uint8_t claimedAddress);
     void update_control_functions(HardwareInterfaceCANFrame &rxFrame);
 
     HardwareInterfaceCANFrame construct_frame(std::uint32_t portIndex,


### PR DESCRIPTION
Other control function types were getting added to the address table
while doing Rx processing, but ICFs follow a different flow, so I
had to update the address table for them a little differently.