### PR TITLE
[Core]: Add parent pointer to CAN mesage callback data

### DIFF
--- a/isobus/include/can_callbacks.hpp
+++ b/isobus/include/can_callbacks.hpp
@@ -19,7 +19,7 @@ namespace isobus
     class ParameterGroupNumberCallbackData
     {
     public:
-        ParameterGroupNumberCallbackData(std::uint32_t parameterGroupNumber, CANLibCallback callback);
+        ParameterGroupNumberCallbackData(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parentPointer);
         ParameterGroupNumberCallbackData(const ParameterGroupNumberCallbackData &oldObj);
 
         bool operator==(const ParameterGroupNumberCallbackData& obj);
@@ -27,9 +27,11 @@ namespace isobus
 
         std::uint32_t get_parameter_group_number() const;
         CANLibCallback get_callback() const;
+		void *get_parent() const;
     private:
         CANLibCallback mCallback;
         std::uint32_t mParameterGroupNumber;
+		void *mParent;
     };
 } // namespace isobus
 

--- a/isobus/include/can_network_manager.hpp
+++ b/isobus/include/can_network_manager.hpp
@@ -36,8 +36,8 @@ public:
     ControlFunction *get_control_function(std::uint8_t CANPort, std::uint8_t CFAddress, CANLibBadge<AddressClaimStateMachine>) const;
     void add_control_function(std::uint8_t CANPort, ControlFunction *newControlFunction, std::uint8_t CFAddress, CANLibBadge<AddressClaimStateMachine>);
 
-    void add_global_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback);
-    void remove_global_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback);
+    void add_global_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent);
+    void remove_global_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent);
 
     std::uint32_t get_number_global_parameter_group_number_callbacks() const;
 

--- a/isobus/include/can_partnered_control_function.hpp
+++ b/isobus/include/can_partnered_control_function.hpp
@@ -28,8 +28,8 @@ public:
     PartneredControlFunction(std::uint8_t CANPort, const std::vector<NAMEFilter> NAMEFilters);
     ~PartneredControlFunction();
 
-    void add_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback);
-    void remove_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback);
+    void add_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent);
+    void remove_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent);
 
     std::uint32_t get_number_parameter_group_number_callbacks() const;
 

--- a/isobus/src/can_callbacks.cpp
+++ b/isobus/src/can_callbacks.cpp
@@ -10,9 +10,10 @@
 
 namespace isobus
 {
-    ParameterGroupNumberCallbackData::ParameterGroupNumberCallbackData(std::uint32_t parameterGroupNumber, CANLibCallback callback) :
+    ParameterGroupNumberCallbackData::ParameterGroupNumberCallbackData(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parentPointer) :
 	  mCallback(callback),
-	  mParameterGroupNumber(parameterGroupNumber)
+	  mParameterGroupNumber(parameterGroupNumber),
+	  mParent(parentPointer)
 	{
 	}
 
@@ -20,17 +21,21 @@ namespace isobus
 	{
 		mCallback = oldObj.mCallback;
 		mParameterGroupNumber = oldObj.mParameterGroupNumber;
+		mParent = oldObj.mParent;
 	}
 
 	bool ParameterGroupNumberCallbackData::operator==(const ParameterGroupNumberCallbackData &obj)
 	{
-		return ((obj.mCallback == this->mCallback) && (obj.mParameterGroupNumber == this->mParameterGroupNumber));
+		return ((obj.mCallback == this->mCallback) && 
+			(obj.mParameterGroupNumber == this->mParameterGroupNumber) &&
+			(obj.mParent == this->mParent));
 	}
 
 	ParameterGroupNumberCallbackData& ParameterGroupNumberCallbackData::operator= (const ParameterGroupNumberCallbackData &obj)
 	{
 		mCallback = obj.mCallback;
 		mParameterGroupNumber = obj.mParameterGroupNumber;
+		mParent = obj.mParent;
 		return *this;
 	}
 
@@ -42,5 +47,10 @@ namespace isobus
     CANLibCallback ParameterGroupNumberCallbackData::get_callback() const
 	{
 		return mCallback;
+	}
+
+	void *ParameterGroupNumberCallbackData::get_parent() const
+	{
+		return mParent;
 	}
 } // namespace isobus

--- a/isobus/src/can_partnered_control_function.cpp
+++ b/isobus/src/can_partnered_control_function.cpp
@@ -30,14 +30,14 @@ namespace isobus
 		partneredControlFunctionList.erase(thisObject);
 	}
 
-	void PartneredControlFunction::add_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback)
+	void PartneredControlFunction::add_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent)
 	{
-		parameterGroupNumberCallbacks.push_back(ParameterGroupNumberCallbackData(parameterGroupNumber, callback));
+		parameterGroupNumberCallbacks.push_back(ParameterGroupNumberCallbackData(parameterGroupNumber, callback, parent));
 	}
 
-	void PartneredControlFunction::remove_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback)
+	void PartneredControlFunction::remove_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent)
 	{
-		ParameterGroupNumberCallbackData tempObject(parameterGroupNumber, callback);
+		ParameterGroupNumberCallbackData tempObject(parameterGroupNumber, callback, parent);
 		auto callbackLocation = std::find(parameterGroupNumberCallbacks.begin(), parameterGroupNumberCallbacks.end(), tempObject);
 		if (parameterGroupNumberCallbacks.end() != callbackLocation)
 		{
@@ -189,7 +189,7 @@ namespace isobus
 
 	ParameterGroupNumberCallbackData PartneredControlFunction::get_parameter_group_number_callback(std::uint32_t index) const
 	{
-		ParameterGroupNumberCallbackData retVal(0, nullptr);
+		ParameterGroupNumberCallbackData retVal(0, nullptr, nullptr);
 
 		if (index < get_number_parameter_group_number_callbacks())
 		{

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -49,7 +49,7 @@ int main()
 {
     setup();
 
-    isobus::CANNetworkManager::CANNetwork.add_global_parameter_group_number_callback(static_cast<std::uint32_t>(isobus::CANLibParameterGroupNumber::ProprietaryA), &testPropACallback);
+    isobus::CANNetworkManager::CANNetwork.add_global_parameter_group_number_callback(static_cast<std::uint32_t>(isobus::CANLibParameterGroupNumber::ProprietaryA), &testPropACallback, nullptr);
 
     while (true)
     {


### PR DESCRIPTION
Added parent class context to CAN message callbacks.
This helps the recipient of a callback know what object the callback was destined for.
Fixed network manager timestamp not being updated.
Fix evicting CF address was always evicting without verifying that the address of the claim matched the table