### PR TITLE
[TP]: Added a way to transmit TP messages using data chunk callbacks …

### DIFF
--- a/isobus/include/can_callbacks.hpp
+++ b/isobus/include/can_callbacks.hpp
@@ -17,11 +17,11 @@ namespace isobus
 	class InternalControlFunction;
 	class ControlFunction;
 	typedef void (*CANLibCallback)(CANMessage *message, void *parentPointer);
-	typedef bool (*DataChunkCallback)(std::uint8_t poolIndex,
-	                                  std::uint32_t callbackIndex,
+	typedef bool (*DataChunkCallback)(std::uint32_t callbackIndex,
 	                                  std::uint32_t bytesOffset,
-	                                  std::uint8_t *&chunkBuffer,
-	                                  std::uint32_t &chunkSize);
+	                                  std::uint32_t numberOfBytesNeeded,
+	                                  std::uint8_t *chunkBuffer,
+	                                  void *parentPointer);
 	typedef void (*TransmitCompleteCallback)(std::uint32_t parameterGroupNumber,
 	                                         std::uint32_t dataLength,
 	                                         InternalControlFunction *sourceControlFunction,

--- a/isobus/include/can_managed_message.hpp
+++ b/isobus/include/can_managed_message.hpp
@@ -15,23 +15,29 @@
 
 namespace isobus
 {
-    
-class CANLibManagedMessage : public CANMessage
-{
-public:
-    CANLibManagedMessage(std::uint8_t CANPort);
 
-    void set_data(const std::uint8_t *dataBuffer, std::uint32_t length);
-    void set_data(std::uint8_t dataByte, const std::uint32_t insertPosition);
+	class CANLibManagedMessage : public CANMessage
+	{
+	public:
+		CANLibManagedMessage(std::uint8_t CANPort);
 
-    void set_data_size(std::uint32_t length);
+		void set_data(const std::uint8_t *dataBuffer, std::uint32_t length);
+		void set_data(std::uint8_t dataByte, const std::uint32_t insertPosition);
 
-    void set_source_control_function(ControlFunction *value);
+		void set_data_size(std::uint32_t length);
+		std::uint32_t get_data_length() const override;
 
-    void set_destination_control_function(ControlFunction *value);
+		void set_source_control_function(ControlFunction *value);
 
-    void set_identifier(CANIdentifier value);
-};
+		void set_destination_control_function(ControlFunction *value);
+
+		void set_identifier(CANIdentifier value);
+
+		std::uint32_t get_callback_message_size() const;
+
+	private:
+		std::uint32_t callbackMessageSize;
+	};
 
 } // namespace isobus
 

--- a/isobus/include/can_message.hpp
+++ b/isobus/include/can_message.hpp
@@ -35,7 +35,7 @@ public:
 
     std::vector<std::uint8_t> &get_data();
     
-    std::uint32_t get_data_length() const;
+    virtual std::uint32_t get_data_length() const;
 
     ControlFunction *get_source_control_function() const;
 

--- a/isobus/include/can_network_manager.hpp
+++ b/isobus/include/can_network_manager.hpp
@@ -54,8 +54,9 @@ public:
                           InternalControlFunction *sourceControlFunction,
                           ControlFunction *destinationControlFunction = nullptr,
                           CANIdentifier::CANPriority priority = CANIdentifier::CANPriority::PriorityDefault6,
-		                  TransmitCompleteCallback = nullptr,
-                          void *parentPointer = nullptr);
+		                  TransmitCompleteCallback txCompleteCallback = nullptr,
+                          void *parentPointer = nullptr,
+		                  DataChunkCallback frameChunkCallback = nullptr);
 
     void receive_can_message(CANMessage message);
 

--- a/isobus/include/can_protocol.hpp
+++ b/isobus/include/can_protocol.hpp
@@ -43,7 +43,8 @@ namespace isobus
 		                                       ControlFunction *source,
 		                                       ControlFunction *destination,
 		                                       TransmitCompleteCallback transmitCompleteCallback,
-		                                       void *parentPointer) = 0;
+		                                       void *parentPointer,
+		                                       DataChunkCallback frameChunkCallback) = 0;
 
 		virtual void update(CANLibBadge<CANNetworkManager>) = 0;
 

--- a/isobus/include/can_transport_protocol.hpp
+++ b/isobus/include/can_transport_protocol.hpp
@@ -53,6 +53,7 @@ class TransportProtocolManager : public CANLibProtocol
         StateMachineState state;
         CANLibManagedMessage sessionMessage;
 	    TransmitCompleteCallback sessionCompleteCallback;
+	    DataChunkCallback frameChunkCallback;
 		void *parent;
         std::uint32_t timestamp_ms;
         std::uint16_t lastPacketNumber;
@@ -69,7 +70,7 @@ class TransportProtocolManager : public CANLibProtocol
         Timeout = 3,
         ClearToSendReceivedWhileTransferInProgress = 4,
         MaximumRetransmitRequestLimitReached = 5,
-        UnexpedtedDataTransferPacketReceived = 6,
+        UnexpectedDataTransferPacketReceived = 6,
         BadSequenceNumber = 7,
         DuplicateSequenceNumber = 8,
         TotalMessageSizeTooBig = 9,
@@ -105,7 +106,8 @@ class TransportProtocolManager : public CANLibProtocol
 		                               ControlFunction *source,
 		                               ControlFunction *destination,
 		                               TransmitCompleteCallback transmitCompleteCallback,
-		                               void *parentPointer) override;
+		                               void *parentPointer,
+		                               DataChunkCallback frameChunkCallback) override;
 
     void update(CANLibBadge<CANNetworkManager>) override;
 

--- a/isobus/src/can_managed_message.cpp
+++ b/isobus/src/can_managed_message.cpp
@@ -13,7 +13,8 @@
 namespace isobus
 {
 	CANLibManagedMessage::CANLibManagedMessage(std::uint8_t CANPort) :
-	  CANMessage(CANPort)
+	  CANMessage(CANPort),
+	  callbackMessageSize(0)
 	{
 	}
 
@@ -22,6 +23,10 @@ namespace isobus
 		if (nullptr != dataBuffer)
 		{
 			data.insert(data.end(), dataBuffer, dataBuffer + length);
+		}
+		else
+		{
+			callbackMessageSize = length;
 		}
 	}
 
@@ -38,6 +43,21 @@ namespace isobus
 		data.resize(length);
 	}
 
+	std::uint32_t CANLibManagedMessage::get_data_length() const
+	{
+		std::uint32_t retVal;
+
+		if (0 != callbackMessageSize)
+		{
+			retVal = callbackMessageSize;
+		}
+		else
+		{
+			retVal = CANMessage::get_data_length();		
+		}
+		return retVal;
+	}
+
 	void CANLibManagedMessage::set_source_control_function(ControlFunction *value)
 	{
 		source = value;
@@ -51,6 +71,11 @@ namespace isobus
 	void CANLibManagedMessage::set_identifier(CANIdentifier value)
 	{
 		identifier = value;
+	}
+
+	std::uint32_t CANLibManagedMessage::get_callback_message_size() const
+	{
+		return callbackMessageSize;
 	}
 
 } // namespace isobus

--- a/isobus/src/can_network_manager.cpp
+++ b/isobus/src/can_network_manager.cpp
@@ -83,11 +83,13 @@ namespace isobus
 	                                         ControlFunction *destinationControlFunction,
 	                                         CANIdentifier::CANPriority priority,
 	                                         TransmitCompleteCallback transmitCompleteCallback,
-											 void *parentPointer)
+											 void *parentPointer,
+	                                         DataChunkCallback frameChunkCallback)
 	{
 		bool retVal = false;
 
-		if ((nullptr != dataBuffer) && 
+		if (((nullptr != dataBuffer) || 
+		(nullptr != frameChunkCallback)) && 
 		(dataLength > 0) && 
 		(dataLength <= CANMessage::ABSOLUTE_MAX_MESSAGE_LENGTH) && 
 		(nullptr != sourceControlFunction) && 
@@ -107,7 +109,8 @@ namespace isobus
 					                                                    sourceControlFunction,
 					                                                    destinationControlFunction,
 					                                                    transmitCompleteCallback,
-					                                                    parentPointer);
+					                                                    parentPointer,
+					                                                    frameChunkCallback);
 
 					if (retVal)
 					{
@@ -116,7 +119,9 @@ namespace isobus
 				}
 			}
 
-			if (!retVal)
+			//! @todo Allow sending 8 byte message with the frameChunkCallback
+			if ((!retVal) &&
+			    (nullptr != dataBuffer))
 			{
 				if (nullptr == destinationControlFunction)
 				{
@@ -428,7 +433,7 @@ namespace isobus
 						partner->address = CANIdentifier(rxFrame.identifier).get_source_address();
 						activeControlFunctions.push_back(partner);
 						foundControlFunction = partner;
-						CANStackLogger::CAN_stack_log("NM: A Partner Has Claimed " + std::to_string(static_cast<int>(CANIdentifier(rxFrame.identifier).get_source_address())));
+						CANStackLogger::CAN_stack_log("[NM]: A Partner Has Claimed " + std::to_string(static_cast<int>(CANIdentifier(rxFrame.identifier).get_source_address())));
 						break;
 					}
 				}
@@ -437,7 +442,7 @@ namespace isobus
 				{
 					// New device, need to start keeping track of it
 					activeControlFunctions.push_back(new ControlFunction(NAME(claimedNAME), CANIdentifier(rxFrame.identifier).get_source_address(), rxFrame.channel));
-					CANStackLogger::CAN_stack_log("NM: New Control function " + std::to_string(static_cast<int>(CANIdentifier(rxFrame.identifier).get_source_address())));
+					CANStackLogger::CAN_stack_log("[NM]: New Control function " + std::to_string(static_cast<int>(CANIdentifier(rxFrame.identifier).get_source_address())));
 				}
 			}
 


### PR DESCRIPTION
…instead of setting the data to the session all at once

This is how VT pools will be sent initially to avoid making a copy of all the data to add the mux in the first byte. This is also a good way to handle sending messages that can't be loaded in RAM all at once.