### PR TITLE
[VT]: Add Virtual Terminal Client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ Makefile
 
 # Editor
 *.vscode
+.vs
 
 # build
 *build

--- a/README.md
+++ b/README.md
@@ -11,9 +11,8 @@ The state of the project is as follows...
     - TP CM Tx: Implemented, Needs Testing :white_check_mark::question:
     - TP CM Rx: Implemented, Needs Testing :white_check_mark::question:
 - ISO11783 Extended Transport Protocol
-    - Implementation Started :hourglass:
-- ISO11783 Virtual Terminal (Up to version 3 initially, maybe up to 6 later)
-    - Currently in-development, highest priority :hourglass:
+    - In Development :hourglass:
+- ISO11783 Virtual Terminal: Implemented, Needs testing :white_check_mark: :question:
 
 ### Not yet started, but planned:
 - ISO11783 File Server

--- a/isobus/CMakeLists.txt
+++ b/isobus/CMakeLists.txt
@@ -27,6 +27,7 @@ set(ISOBUS_SRC
   "can_warning_logger.cpp"
   "can_network_configuration.cpp"
   "can_callbacks.cpp"
+  "isobus_virtual_terminal_client.cpp"
 )
 
 # Prepend the source directory path to all the source files
@@ -49,6 +50,7 @@ set(ISOBUS_INCLUDE
   "can_warning_logger.hpp"
   "can_network_configuration.hpp"
   "can_callbacks.hpp"
+  "isobus_virtual_terminal_client.hpp"
 )
 
 # Prepend the include directory path to all the include files

--- a/isobus/include/can_constants.hpp
+++ b/isobus/include/can_constants.hpp
@@ -12,12 +12,12 @@
 namespace isobus
 {
 
-	static const std::uint64_t DEFAULT_NAME = 0xFFFFFFFFFFFFFFFF;
-	static const std::uint32_t DEFAULT_IDENTIFIER = 0xFFFFFFFF;
-	static const std::uint8_t NULL_CAN_ADDRESS = 0xFE;
-	static const std::uint8_t BROADCAST_CAN_ADDRESS = 0xFF;
-	static const std::uint8_t CAN_DATA_LENGTH = 8;
-	static const std::uint32_t CAN_PORT_MAXIMUM = 4;
+	constexpr std::uint64_t DEFAULT_NAME = 0xFFFFFFFFFFFFFFFF;
+	constexpr std::uint32_t DEFAULT_IDENTIFIER = 0xFFFFFFFF;
+	constexpr std::uint8_t NULL_CAN_ADDRESS = 0xFE;
+	constexpr std::uint8_t BROADCAST_CAN_ADDRESS = 0xFF;
+	constexpr std::uint8_t CAN_DATA_LENGTH = 8;
+	constexpr std::uint32_t CAN_PORT_MAXIMUM = 4;
 
 }
 

--- a/isobus/include/can_general_parameter_group_numbers.hpp
+++ b/isobus/include/can_general_parameter_group_numbers.hpp
@@ -13,21 +13,20 @@
 namespace isobus
 {
 
-    enum class CANLibParameterGroupNumber
-    {
+	enum class CANLibParameterGroupNumber
+	{
 		Any = 0x0000,
-        WorkingSetMaster = 0xFE0D,
-        VirtualTerminalToECU = 0xE600,
+		WorkingSetMaster = 0xFE0D,
+		VirtualTerminalToECU = 0xE600,
 		ECUtoVirtualTerminal = 0xE700,
-        Acknowledge = 0xE800,
-        ParameterGroupNumberRequest = 0xEA00,
-        TransportProtocolData = 0xEB00,
-        TransportProtocolCommand = 0xEC00,
-        AddressClaim = 0xEE00,
-        ProprietaryA = 0xEF00
-    };
+		Acknowledge = 0xE800,
+		ParameterGroupNumberRequest = 0xEA00,
+		TransportProtocolData = 0xEB00,
+		TransportProtocolCommand = 0xEC00,
+		AddressClaim = 0xEE00,
+		ProprietaryA = 0xEF00
+	};
 
 } // namespace isobus
 
 #endif // CAN_GENERAL_PARAMETER_GROUP_NUMBERS_HPP
-

--- a/isobus/include/can_general_parameter_group_numbers.hpp
+++ b/isobus/include/can_general_parameter_group_numbers.hpp
@@ -16,6 +16,7 @@ namespace isobus
     enum class CANLibParameterGroupNumber
     {
 		Any = 0x0000,
+        WorkingSetMaster = 0xFE0D,
         VirtualTerminalToECU = 0xE600,
 		ECUtoVirtualTerminal = 0xE700,
         Acknowledge = 0xE800,

--- a/isobus/include/can_general_parameter_group_numbers.hpp
+++ b/isobus/include/can_general_parameter_group_numbers.hpp
@@ -13,16 +13,18 @@
 namespace isobus
 {
 
-enum class CANLibParameterGroupNumber
-{
-    Any = 0x0000,
-    Acknowledge = 0xE800,
-    ParameterGroupNumberRequest = 0xEA00,
-    TransportProtocolData = 0xEB00,
-    TransportProtocolCommand = 0xEC00,
-    AddressClaim = 0xEE00,
-    ProprietaryA = 0xEF00
-};
+    enum class CANLibParameterGroupNumber
+    {
+		Any = 0x0000,
+        VirtualTerminalToECU = 0xE600,
+		ECUtoVirtualTerminal = 0xE700,
+        Acknowledge = 0xE800,
+        ParameterGroupNumberRequest = 0xEA00,
+        TransportProtocolData = 0xEB00,
+        TransportProtocolCommand = 0xEC00,
+        AddressClaim = 0xEE00,
+        ProprietaryA = 0xEF00
+    };
 
 } // namespace isobus
 

--- a/isobus/include/isobus_virtual_terminal_client.hpp
+++ b/isobus/include/isobus_virtual_terminal_client.hpp
@@ -446,6 +446,14 @@ namespace isobus
 			NumberFlags
 		};
 
+		enum class CurrentObjectPoolUploadState : std::uint8_t
+		{
+			Uninitialized,
+			InProgress,
+			Success,
+			Failed
+		};
+
 		struct ObjectPoolDataStruct
 		{
 			const std::uint8_t *objectPoolDataPointer;
@@ -487,6 +495,12 @@ namespace isobus
 
 		static void process_flags(std::uint32_t flag, void *parent);
 		static void process_rx_message(CANMessage *message, void *parentPointer);
+		static void process_callback(std::uint32_t parameterGroupNumber,
+		                             std::uint32_t dataLength,
+		                             InternalControlFunction *sourceControlFunction,
+		                             ControlFunction *destinationControlFunction,
+		                             bool successful,
+		                             void *parentPointer);
 
 		void worker_thread_function();
 
@@ -527,6 +541,7 @@ namespace isobus
 
 		// Internal state
 		StateMachineState state;
+		CurrentObjectPoolUploadState currentObjectPoolState;
 		std::uint32_t stateMachineTimestamp_ms;
 		std::uint32_t lastWorkingSetMaintenanceTimestamp_ms;
 		std::vector<VTKeyEventCallback> buttonEventCallbacks;

--- a/isobus/include/isobus_virtual_terminal_client.hpp
+++ b/isobus/include/isobus_virtual_terminal_client.hpp
@@ -1,0 +1,337 @@
+//================================================================================================
+/// @file isobus_virtual_terminal_client.hpp
+///
+/// @brief A class to manage a client connection to a ISOBUS virtual terminal display
+/// @author Adrian Del Grosso
+///
+/// @copyright 2022 Adrian Del Grosso
+//================================================================================================
+#ifndef ISOBUS_VIRTUAL_TERMINAL_CLIENT_HPP
+#define ISOBUS_VIRTUAL_TERMINAL_CLIENT_HPP
+
+#include "can_partnered_control_function.hpp"
+#include "can_internal_control_function.hpp"
+
+#include <memory>
+
+namespace isobus
+{
+
+	class VirtualTerminalClient
+	{
+	public:
+		enum class HideShowObjectCommand : std::uint8_t
+		{
+			HideObject = 0,
+			ShowObject = 1
+		};
+
+		enum class EnableDisableObjectCommand : std::uint8_t
+		{
+			DisableObject = 0,
+			EnableObject = 1
+		};
+
+		enum class SelectInputObjectOptions : std::uint8_t
+		{
+			ActivateObjectForDataInput = 0x00,
+			SetFocusToObject = 0xFF
+		};
+
+		enum class VTVersion
+		{
+			Version2OrOlder,
+			Version3,
+			Version4,
+			Version5,
+			Version6,
+			ReservedOrUnknown,
+		};
+
+		enum class LineDirection
+		{
+			TopLeftToBottomRightOfEnclosingVirtualRectangle = 0,
+			BottomLeftToTopRightOfEnclosingVirtualRectangle = 1
+		};
+
+		enum class FontSize
+		{
+			Size6x8 = 0,
+			Size8x8 = 1,
+			Size8x12 = 2,
+			Size12x16 = 3,
+			Size16x16 = 4,
+			Size16x24 = 5,
+			Size24x24 = 6,
+			Size24x32 = 7,
+			Size32x32 = 8,
+			Size48x64 = 9,
+			Size64x64 = 10,
+			Size64x96 = 11,
+			Size96x128 = 12,
+			Size128x128 = 13,
+			Size128x192 = 14
+		};
+
+		enum class FontStyleBits
+		{
+			Bold = 0,
+			CrossedOut = 1,
+			Underlined = 2,
+			Italic = 3,
+			Inverted = 4,
+			Flashing = 5,
+			FlashingHidden = 6,
+			ProportionalFontRendering = 7
+		};
+
+		enum class FontType
+		{
+			ISO8859_1 = 0, // ISO Latin 1
+			ISO8859_15 = 1, // ISO Latin 9
+			ISO8859_2 = 2, // ISO Latin 2
+			Reserved_1 = 3,
+			ISO8859_4 = 4, // ISO Latin 4
+			ISO8859_5 = 5, // Cyrillic
+			Reserved_2 = 6,
+			ISO8859_7 = 7, // Greek
+			ReservedEnd = 239,
+			ProprietaryBegin = 240,
+			ProprietaryEnd = 255
+		};
+
+		enum class FillType
+		{
+			NoFill = 0,
+			FillWithLineColor = 1,
+			FillWithSpecifiedColorInFillColorAttribute = 2,
+			FillWithPatternGivenByFillPatternAttribute = 3
+		};
+
+		enum class MaskType
+		{
+			DataMask = 1,
+			AlarmMask = 2
+		};
+
+		enum class AlarmMaskPriority
+		{
+			High = 0,
+			Medium = 1,
+			Low = 2
+		};
+
+		enum class MaskLockState
+		{
+			UnlockMask = 0,
+			LockMask = 1
+		};
+
+		enum KeyActivationCode
+		{
+			ButtonUnlatchedOrReleased = 0,
+			ButtonPressedOrLatched = 1,
+			ButtonStillHeld = 2,
+			ButtonPressAborted = 3
+		};
+
+		explicit VirtualTerminalClient(std::shared_ptr<PartneredControlFunction> partner, std::shared_ptr<InternalControlFunction> clientSource);
+
+		// Basic Interaction
+		void RegisterVTEventCallback();
+
+		// Command Messages
+		bool send_hide_show_object(std::uint16_t objectID, HideShowObjectCommand command);
+		bool send_enable_disable_object(std::uint16_t objectID, EnableDisableObjectCommand command);
+		bool send_select_input_object(std::uint16_t objectID, SelectInputObjectOptions option);
+		bool send_ESC();
+		bool send_control_audio_signal(std::uint8_t activations, std::uint16_t frequency_hz, std::uint16_t duration_ms, std::uint16_t offTimeDuration_ms);
+		bool send_set_audio_volume(std::uint8_t volume_percent);
+		bool send_change_child_location(std::uint16_t objectID, std::uint16_t parentObjectID, std::uint8_t relativeXPositionChange, std::uint8_t relativeYPositionChange);
+		bool send_change_child_position(std::uint16_t objectID, std::uint16_t parentObjectID, std::uint16_t xPosition, std::uint16_t yPosition);
+		bool send_change_size_command(std::uint16_t objectID, std::uint16_t newWidth, std::uint16_t newHeight);
+		bool send_change_background_colour(std::uint16_t objectID, std::uint8_t color);
+		bool send_change_numeric_value(std::uint16_t objectID, std::uint32_t value);
+		bool send_change_string_value(std::uint16_t objectID, uint16_t stringLength, const char *value);
+		bool send_change_string_value(std::uint16_t objectID, const std::string &value);
+		bool send_change_endpoint(std::uint16_t objectID, std::uint16_t width_px, std::uint16_t height_px, LineDirection direction);
+		bool send_change_font_attributes(std::uint16_t objectID, std::uint8_t color, FontSize size, std::uint8_t type, std::uint8_t styleBitfield);
+		bool send_change_line_attributes(std::uint16_t objectID, std::uint8_t color, std::uint8_t width, std::uint16_t lineArtBitmask);
+		bool send_change_fill_attributes(std::uint16_t objectID, FillType fillType, std::uint8_t color, std::uint16_t fillPatternObjectID);
+		bool send_change_active_mask(std::uint16_t workingSetObjectID, std::uint16_t newActiveMaskObjectID);
+		bool send_change_softkey_mask(MaskType type, std::uint16_t dataOrAlarmMaskObjectID, std::uint16_t newSoftKeyMaskObjectID);
+		bool send_change_attribute(std::uint16_t objectID, std::uint8_t attributeID, std::uint32_t value);
+		bool send_change_priority(std::uint16_t alarmMaskObjectID, AlarmMaskPriority priority);
+		bool send_change_list_item(std::uint16_t objectID, std::uint8_t listIndex, std::uint16_t newObjectID);
+		bool send_lock_unlock_mask(MaskLockState state, std::uint16_t objectID, std::uint16_t timeout_ms);
+		bool send_execute_macro(std::uint16_t objectID);
+		bool send_change_object_label(std::uint16_t objectID, std::uint16_t labelStringObjectID, std::uint8_t fontType, std::uint16_t graphicalDesignatorObjectID);
+		bool send_change_polygon_point(std::uint16_t objectID, std::uint8_t pointIndex, std::uint16_t newXValue, std::uint16_t newYValue);
+		bool send_change_polygon_scale(std::uint16_t objectID, std::uint16_t widthAttribute, std::uint16_t heightAttribute);
+		bool send_select_color_map_or_palette(std::uint16_t objectID);
+		bool send_execute_extended_macro(std::uint16_t objectID);
+		bool send_select_active_working_set(std::uint64_t NAMEofWorkingSetMasterForDesiredWorkingSet);
+
+		// Graphics Context Commands
+		bool send_set_graphics_cursor(std::int16_t xPosition, std::int16_t yPosition);
+		bool send_move_graphics_cursor(std::int16_t xOffset, std::int16_t yOffset);
+		bool send_set_foreground_colour(std::uint8_t color);
+		bool send_set_background_colour(std::uint8_t color);
+		bool send_set_line_attributes_object_id(std::uint16_t objectID);
+		bool send_set_fill_attributes_object_id(std::uint16_t objectID);
+		bool send_set_font_attributes_object_id(std::uint16_t objectID);
+		bool send_erase_rectangle(std::uint16_t width, std::uint16_t height);
+		bool send_draw_point(std::int16_t xOffset, std::int16_t yOffset);
+		bool send_draw_line(std::int16_t xOffset, std::int16_t yOffset);
+		bool send_draw_rectangle(std::uint16_t width, std::uint16_t height);
+		bool send_draw_closed_ellipse(std::uint16_t width, std::uint16_t height);
+		bool send_draw_polygon(std::uint8_t numberOfPoints, std::int16_t *listOfXOffsetsRelativeToCursor, std::int16_t *listOfYOffsetsRelativeToCursor);
+		bool send_draw_text(bool transparent, std::uint8_t textLength, const char *value);
+		bool send_pan_viewport(std::int16_t xAttribute, std::int16_t yAttribute);
+		bool send_zoom_viewport(float zoom);
+		bool send_pan_and_zoom_viewport(std::int16_t xAttribute, std::int16_t yAttribute, float zoom);
+		bool send_change_viewport_size(std::uint16_t width, std::uint16_t height);
+		bool send_draw_vt_object(std::uint16_t objectID);
+		bool send_copy_canvas_to_picture_graphic(std::uint16_t objectID);
+		bool send_copy_viewport_to_picture_graphic(std::uint16_t objectID);
+
+		// VT Querying
+		bool send_get_attribute_value(std::uint16_t objectID, std::uint8_t attributeID);
+
+
+		VTVersion get_connected_vt_version() const;
+
+	private:
+		enum class Function
+		{
+			SoftKeyActivationMessage = 0x00,
+			ButtonActivationMessage = 0x01,
+			PointingEventMessage = 0x02,
+			VTSelectInputObjectMessage = 0x03,
+			VTESCMessage = 0x04,
+			VTChangeNumericValueMessage = 0x05,
+			VTChangeActiveMaskMessage = 0x06,
+			VTChangeSoftKeyMaskMessage = 0x07,
+			VTChangeStringValueMessage = 0x08,
+			VTOnUserLayoutHideShowMessage = 0x09,
+			VTControlAudioSignalTerminationMessage = 0x0A,
+			ObjectPoolTransferMessage = 0x11,
+			EndOfObjectPoolMessage = 0x12,
+			AuxiliaryAssignmentTypeOneCommand = 0x20,
+			AuxiliaryInputTypeOneStatus = 0x21,
+			PreferredAssignmentCommand = 0x22,
+			AuxiliaryInputTypeTwoMaintenanceMessage = 0x23,
+			AuxiliaryAssignmentTypeTwoCommand = 0x24,
+			AuxiliaryInputStatusTypeTwoEnableCommand = 0x25,
+			AuxiliaryInputTypeTwoStatusMessage = 0x26,
+			AuxiliaryCapabilitiesRequest = 0x27,
+			SelectActiveWorkingSet = 0x90,
+			ESCCommand = 0x92,
+			HideShowObjectCommand = 0xA0,
+			EnableDisableObjectCommand = 0xA1,
+			SelectInputObjectCommand = 0xA2,
+			ControlAudioSignalCommand = 0xA3,
+			SetAudioVolumeCommand = 0xA4,
+			ChangeChildLocationCommand = 0xA5,
+			ChangeSizeCommand = 0xA6,
+			ChangeBackgroundColourCommand = 0xA7,
+			ChangeNumericValueCommand = 0xA8,
+			ChangeEndPointCommand = 0xA9,
+			ChangeFontAttributesCommand = 0xAA,
+			ChangeLineAttributesCommand = 0xAB,
+			ChangeFillAttributesCommand = 0xAC,
+			ChangeActiveMaskCommand = 0xAD,
+			ChangeSoftKeyMaskCommand = 0xAE,
+			ChangeAttributeCommand = 0xAF,
+			ChangePriorityCommand = 0xB0,
+			ChangeListItemCommand = 0xB1,
+			DeleteObjectPoolCommand = 0xB2,
+			ChangeStringValueCommand = 0xB3,
+			ChangeChildPositionCommand = 0xB4,
+			ChangeObjectLabelCommand = 0xB5,
+			ChangePolygonPointCommand = 0xB6,
+			ChangePolygonScaleCommand = 0xB7,
+			GraphicsContextCommand = 0xB8,
+			GetAttributeValueMessage = 0xB9,
+			SelectColourMapCommand = 0xBA,
+			IdentifyVTMessage = 0xBB,
+			ExecuteExtendedMacroCommand = 0xBC,
+			LockUnlockMaskCommand = 0xBD,
+			ExecuteMacroCommand = 0xBE,
+			GetMemoryMessage = 0xC0,
+			GetSupportedWidecharsMessage = 0xC1,
+			GetNumberOfSoftKeysMessage = 0xC2,
+			GetTextFontDataMessage = 0xC3,
+			GetWindowMaskDataMessage = 0xC4,
+			GetSupportedObjectsMessage = 0xC5,
+			GetHardwareMessage = 0xC7,
+			StoreVersionCommand = 0xD0,
+			LoadVersionCommand = 0xD1,
+			DeleteVersionCommand = 0xD2,
+			ExtendedGetVersionsMessage = 0xD3,
+			ExtendedStoreVersionCommand = 0xD4,
+			ExtendedLoadVersionCommand = 0xD5,
+			ExtendedDeleteVersionCommand = 0xD6,
+			GetVersionsMessage = 0xDF,
+			GetVersionsResponse = 0xE0,
+			UnsupportedVTFunctionMessage = 0xFD,
+			VTStatusMessage = 0xFE,
+			WorkingSetMaintenanceMessage = 0xFF
+		};
+
+		enum class EventID : std::uint8_t
+		{
+			Reserved = 0,
+			OnActivate = 1,
+			OnDeactivate = 2,
+			OnShow = 3,
+			OnHide = 4,
+			OnEnable = 5,
+			OnDisable = 6,
+			OnChangeActiveMask = 7,
+			OnChangeSoftKeyMask = 8,
+			OnChangeAttribute = 9,
+			OnChangeBackgroundColor = 10,
+			OnChangeFontAttributes = 11,
+			OnChangeLineAttributes = 12,
+			OnChangeFillAttributes = 13,
+			OnChangeChildLocation = 14,
+			OnChangeSize = 15,
+			OnChangeValue = 16,
+			OnChangePriority = 17,
+			OnChangeEndPoint = 18,
+			OnInputFieldSelection = 19, 
+			OnInputFieldDeselection = 20,
+			OnESC = 21,
+			OnEntryOfValue = 22, 
+			OnEntryOfNewValue = 23,
+			OnKeyPress = 24,
+			OnKeyRelease = 25,
+			OnChangeChildPosition = 26, 
+			OnPointingEventPress = 27,
+			OnPointingEventRelease = 28,
+			ReservedBegin = 29,
+			ReservedEnd = 254,
+			UseExtendedMacroReference = 255
+		};
+
+		// Object Pool Managment
+		bool send_delete_object_pool();
+		bool send_working_set_maintenance(bool initializing, VTVersion workingSetVersion);
+
+		std::shared_ptr<PartneredControlFunction> partnerControlFunction;
+		std::shared_ptr<InternalControlFunction> myControlFunction;
+
+		// Status message contents from the VT
+		std::uint16_t activeWorkingSetDataMaskObjectID;
+		std::uint16_t activeWorkingSetSoftkeyMaskObjectID;
+		std::uint8_t activeWorkingSetMasterAddress;
+		std::uint8_t busyCodesBitfield;
+		std::uint8_t currentCommandFunctionCode;
+
+		std::uint8_t connectedVTVersion;
+	};
+
+} // namespace isobus
+
+#endif // ISOBUS_VIRTUAL_TERMINAL_CLIENT_HPP

--- a/isobus/include/isobus_virtual_terminal_client.hpp
+++ b/isobus/include/isobus_virtual_terminal_client.hpp
@@ -318,6 +318,21 @@ namespace isobus
 		// Object Pool Managment
 		bool send_delete_object_pool();
 		bool send_working_set_maintenance(bool initializing, VTVersion workingSetVersion);
+		bool send_get_memory(std::uint32_t requiredMemory);
+		bool send_get_number_of_softkeys();
+		bool send_get_text_font_data();
+		bool send_get_hardware();
+		bool send_get_supported_widechars();
+		bool send_get_window_mask_data();
+		bool send_get_supported_objects();
+		bool send_get_versions();
+		bool send_store_version(std::array<std::uint8_t, 7> versionLabel);
+		bool send_load_version(std::array<std::uint8_t, 7> versionLabel);
+		bool send_delete_version(std::array<std::uint8_t, 7> versionLabel);
+		bool send_extended_get_versions();
+		bool send_extended_store_version(std::array<std::uint8_t, 32> versionLabel);
+		bool send_extended_load_version(std::array<std::uint8_t, 32> versionLabel);
+		bool send_extended_delete_version(std::array<std::uint8_t, 32> versionLabel);
 
 		std::shared_ptr<PartneredControlFunction> partnerControlFunction;
 		std::shared_ptr<InternalControlFunction> myControlFunction;

--- a/isobus/include/isobus_virtual_terminal_client.hpp
+++ b/isobus/include/isobus_virtual_terminal_client.hpp
@@ -152,7 +152,44 @@ namespace isobus
 			UploadObjectPool,
 			SendEndOfObjectPool,
 			WaitForEndOfObjectPoolResponse,
-			Connected
+			Connected,
+			Failed
+		};
+
+		enum class MacroEventID : std::uint8_t
+		{
+			Reserved = 0,
+			OnActivate = 1,
+			OnDeactivate = 2,
+			OnShow = 3,
+			OnHide = 4,
+			OnEnable = 5,
+			OnDisable = 6,
+			OnChangeActiveMask = 7,
+			OnChangeSoftKeyMask = 8,
+			OnChangeAttribute = 9,
+			OnChangeBackgroundColor = 10,
+			OnChangeFontAttributes = 11,
+			OnChangeLineAttributes = 12,
+			OnChangeFillAttributes = 13,
+			OnChangeChildLocation = 14,
+			OnChangeSize = 15,
+			OnChangeValue = 16,
+			OnChangePriority = 17,
+			OnChangeEndPoint = 18,
+			OnInputFieldSelection = 19,
+			OnInputFieldDeselection = 20,
+			OnESC = 21,
+			OnEntryOfValue = 22,
+			OnEntryOfNewValue = 23,
+			OnKeyPress = 24,
+			OnKeyRelease = 25,
+			OnChangeChildPosition = 26,
+			OnPointingEventPress = 27,
+			OnPointingEventRelease = 28,
+			ReservedBegin = 29,
+			ReservedEnd = 254,
+			UseExtendedMacroReference = 255
 		};
 
 		static const std::uint16_t NULL_OBJECT_ID = 0xFFFF;
@@ -160,7 +197,22 @@ namespace isobus
 		explicit VirtualTerminalClient(std::shared_ptr<PartneredControlFunction> partner, std::shared_ptr<InternalControlFunction> clientSource);
 
 		// Basic Interaction
-		void RegisterVTEventCallback();
+		typedef void (*VTKeyEventCallback)(KeyActivationCode keyEvent, std::uint8_t keyNumber, std::uint16_t objectID, std::uint16_t parentObjectID, VirtualTerminalClient *parentPointer);
+		typedef void (*VTPointingEventCallback)(KeyActivationCode keyEvent, std::uint16_t xPosition, std::uint16_t yPosition, VirtualTerminalClient *parentPointer);
+		typedef void (*VTSelectInputObjectCallback)(std::uint16_t objectID, bool objectSelected, bool objectOpenForInput, VirtualTerminalClient *parentPointer);
+
+		// Callbacks for events that happen on the VT
+		void RegisterVTSoftKeyEventCallback(VTKeyEventCallback value);
+		void RemoveVTSoftKeyEventCallback(VTKeyEventCallback value);
+
+		void RegisterVTButtonEventCallback(VTKeyEventCallback value);
+		void RemoveVTButtonEventCallback(VTKeyEventCallback value);
+
+		void RegisterVTPointingEventCallback(VTPointingEventCallback value);
+		void RemoveVTPointingEventCallback(VTPointingEventCallback value);
+
+		void RegisterVTSelectInputObjectEventCallback(VTSelectInputObjectCallback value);
+		void RemoveVTSelectInputObjectEventCallback(VTSelectInputObjectCallback value);
 
 		// Command Messages
 		bool send_hide_show_object(std::uint16_t objectID, HideShowObjectCommand command);
@@ -195,27 +247,27 @@ namespace isobus
 		bool send_select_active_working_set(std::uint64_t NAMEofWorkingSetMasterForDesiredWorkingSet);
 
 		// Graphics Context Commands
-		bool send_set_graphics_cursor(std::int16_t xPosition, std::int16_t yPosition);
-		bool send_move_graphics_cursor(std::int16_t xOffset, std::int16_t yOffset);
-		bool send_set_foreground_colour(std::uint8_t color);
-		bool send_set_background_colour(std::uint8_t color);
-		bool send_set_line_attributes_object_id(std::uint16_t objectID);
-		bool send_set_fill_attributes_object_id(std::uint16_t objectID);
-		bool send_set_font_attributes_object_id(std::uint16_t objectID);
-		bool send_erase_rectangle(std::uint16_t width, std::uint16_t height);
-		bool send_draw_point(std::int16_t xOffset, std::int16_t yOffset);
-		bool send_draw_line(std::int16_t xOffset, std::int16_t yOffset);
-		bool send_draw_rectangle(std::uint16_t width, std::uint16_t height);
-		bool send_draw_closed_ellipse(std::uint16_t width, std::uint16_t height);
-		bool send_draw_polygon(std::uint8_t numberOfPoints, std::int16_t *listOfXOffsetsRelativeToCursor, std::int16_t *listOfYOffsetsRelativeToCursor);
-		bool send_draw_text(bool transparent, std::uint8_t textLength, const char *value);
-		bool send_pan_viewport(std::int16_t xAttribute, std::int16_t yAttribute);
-		bool send_zoom_viewport(float zoom);
-		bool send_pan_and_zoom_viewport(std::int16_t xAttribute, std::int16_t yAttribute, float zoom);
-		bool send_change_viewport_size(std::uint16_t width, std::uint16_t height);
-		bool send_draw_vt_object(std::uint16_t objectID);
-		bool send_copy_canvas_to_picture_graphic(std::uint16_t objectID);
-		bool send_copy_viewport_to_picture_graphic(std::uint16_t objectID);
+		bool send_set_graphics_cursor(std::uint16_t objectID, std::int16_t xPosition, std::int16_t yPosition);
+		bool send_move_graphics_cursor(std::uint16_t objectID, std::int16_t xOffset, std::int16_t yOffset);
+		bool send_set_foreground_colour(std::uint16_t objectID, std::uint8_t color);
+		bool send_set_background_colour(std::uint16_t objectID, std::uint8_t color);
+		bool send_set_line_attributes_object_id(std::uint16_t objectID, std::uint16_t lineAttributeobjectID);
+		bool send_set_fill_attributes_object_id(std::uint16_t objectID, std::uint16_t fillAttributeobjectID);
+		bool send_set_font_attributes_object_id(std::uint16_t objectID, std::uint16_t fontAttributesObjectID);
+		bool send_erase_rectangle(std::uint16_t objectID, std::uint16_t width, std::uint16_t height);
+		bool send_draw_point(std::uint16_t objectID, std::int16_t xOffset, std::int16_t yOffset);
+		bool send_draw_line(std::uint16_t objectID, std::int16_t xOffset, std::int16_t yOffset);
+		bool send_draw_rectangle(std::uint16_t objectID, std::uint16_t width, std::uint16_t height);
+		bool send_draw_closed_ellipse(std::uint16_t objectID, std::uint16_t width, std::uint16_t height);
+		bool send_draw_polygon(std::uint16_t objectID, std::uint8_t numberOfPoints, std::int16_t *listOfXOffsetsRelativeToCursor, std::int16_t *listOfYOffsetsRelativeToCursor);
+		bool send_draw_text(std::uint16_t objectID, bool transparent, std::uint8_t textLength, const char *value);
+		bool send_pan_viewport(std::uint16_t objectID, std::int16_t xAttribute, std::int16_t yAttribute);
+		bool send_zoom_viewport(std::uint16_t objectID, float zoom);
+		bool send_pan_and_zoom_viewport(std::uint16_t objectID, std::int16_t xAttribute, std::int16_t yAttribute, float zoom);
+		bool send_change_viewport_size(std::uint16_t objectID, std::uint16_t width, std::uint16_t height);
+		bool send_draw_vt_object(std::uint16_t graphicsContextObjectID, std::uint16_t VTObjectID);
+		bool send_copy_canvas_to_picture_graphic(std::uint16_t graphicsContextObjectID, std::uint16_t objectID);
+		bool send_copy_viewport_to_picture_graphic(std::uint16_t graphicsContextObjectID, std::uint16_t objectID);
 
 		// VT Querying
 		bool send_get_attribute_value(std::uint16_t objectID, std::uint8_t attributeID);
@@ -232,8 +284,8 @@ namespace isobus
 		// This is probably better for huge pools if you are RAM constrained, or if your
 		// pool is stored on some external device that you need to get data from in pages.
 		// If using callbacks, The object pool and pointer MUST NOT be deleted or leave scope until upload is done.
-		void set_object_pool(const std::uint8_t *pool, std::uint32_t size);
-		void set_object_pool(const std::vector<std::uint8_t> *pool);
+		void set_object_pool(std::uint8_t poolIndex, const std::uint8_t *pool, std::uint32_t size);
+		void set_object_pool(std::uint8_t poolIndex, const std::vector<std::uint8_t> *pool);
 		void register_object_pool_data_chunk_callback(DataChunkCallback value);
 
 		// Periodic Update Function (thread should call this)
@@ -317,40 +369,29 @@ namespace isobus
 			WorkingSetMaintenanceMessage = 0xFF
 		};
 
-		enum class EventID : std::uint8_t
+		enum class GraphicsContextSubCommandID
 		{
-			Reserved = 0,
-			OnActivate = 1,
-			OnDeactivate = 2,
-			OnShow = 3,
-			OnHide = 4,
-			OnEnable = 5,
-			OnDisable = 6,
-			OnChangeActiveMask = 7,
-			OnChangeSoftKeyMask = 8,
-			OnChangeAttribute = 9,
-			OnChangeBackgroundColor = 10,
-			OnChangeFontAttributes = 11,
-			OnChangeLineAttributes = 12,
-			OnChangeFillAttributes = 13,
-			OnChangeChildLocation = 14,
-			OnChangeSize = 15,
-			OnChangeValue = 16,
-			OnChangePriority = 17,
-			OnChangeEndPoint = 18,
-			OnInputFieldSelection = 19, 
-			OnInputFieldDeselection = 20,
-			OnESC = 21,
-			OnEntryOfValue = 22, 
-			OnEntryOfNewValue = 23,
-			OnKeyPress = 24,
-			OnKeyRelease = 25,
-			OnChangeChildPosition = 26, 
-			OnPointingEventPress = 27,
-			OnPointingEventRelease = 28,
-			ReservedBegin = 29,
-			ReservedEnd = 254,
-			UseExtendedMacroReference = 255
+			SetGraphicsCursor = 0x00,
+			MoveGraphicsCursor = 0x01,
+			SetForegroundColor = 0x02,
+			SetBackgroundColor = 0x03,
+			SetLineAttributesObjectID = 0x04,
+			SetFillAttributesObjectID = 0x05,
+			SetFontAttributesObjectOD = 0x06,
+			EraseRectangle = 0x07,
+			DrawPoint = 0x08,
+			DrawLine = 0x09,
+			DrawRectangle = 0x0A,
+			DrawClosedEllipse = 0x0B,
+			DrawPolygon = 0x0C,
+			DrawText = 0x0D,
+			PanViewport = 0x0E,
+			ZoomViewport = 0x0F,
+			PanAndZoomViewport = 0x10,
+			ChangeViewportSize = 0x11,
+			DrawVTObject = 0x12,
+			CopyCanvasToPictureGraphic = 0x13,
+			CopyViewportToPictureGraphic = 0x14
 		};
 
 		// Object Pool Managment
@@ -374,7 +415,14 @@ namespace isobus
 
 		void set_state(StateMachineState value);
 
-		static const std::uint32_t VT_STATUS_TIMEOUT_MS = 750;
+		void process_button_event_callback(KeyActivationCode keyEvent, std::uint8_t keyNumber, std::uint16_t objectID, std::uint16_t parentObjectID, VirtualTerminalClient *parentPointer);
+		void process_softkey_event_callback(KeyActivationCode keyEvent, std::uint8_t keyNumber, std::uint16_t objectID, std::uint16_t parentObjectID, VirtualTerminalClient *parentPointer);
+		void process_pointing_event_callback(KeyActivationCode signal, std::uint16_t xPosition, std::uint16_t yPosition, VirtualTerminalClient *parentPointer);
+		void process_select_input_object_callback(std::uint16_t objectID, bool objectSelected, bool objectOpenForInput, VirtualTerminalClient *parentPointer);
+
+		static void process_rx_message(CANMessage *message, void *parentPointer);
+
+		static const std::uint32_t VT_STATUS_TIMEOUT_MS = 3000;
 
 		std::shared_ptr<PartneredControlFunction> partnerControlFunction;
 		std::shared_ptr<InternalControlFunction> myControlFunction;
@@ -391,6 +439,10 @@ namespace isobus
 		// Internal state
 		StateMachineState state;
 		std::uint32_t stateMachineTimestamp_ms;
+		std::vector<VTKeyEventCallback> buttonEventCallbacks;
+		std::vector<VTKeyEventCallback> softKeyEventCallbacks;
+		std::vector<VTPointingEventCallback> pointingEventCallbacks;
+		std::vector<VTSelectInputObjectCallback> selectInputObjectCallbacks;
 
 		// Object Pool info
 		DataChunkCallback objectPoolDataCallback;

--- a/isobus/include/isobus_virtual_terminal_client.hpp
+++ b/isobus/include/isobus_virtual_terminal_client.hpp
@@ -142,6 +142,7 @@ namespace isobus
 		{
 			Disconnected,
 			WaitForPartnerVTStatusMessage,
+			SendWorkingSetMasterMessage,
 			ReadyForObjectPool,
 			SendGetMemory,
 			WaitForGetMemoryResponse,
@@ -323,6 +324,7 @@ namespace isobus
 		// 2. Get a callback at some inteval to provide data in chunks
 		// This is probably better for huge pools if you are RAM constrained, or if your
 		// pool is stored on some external device that you need to get data from in pages.
+		// This is also the best way to load from IOP files!
 		// If using callbacks, The object pool and pointer MUST NOT be deleted or leave scope until upload is done.
 		// Version must be the same for all pools uploaded to this VT server!!!
 		void set_object_pool(std::uint8_t poolIndex, VTVersion poolSupportedVTVersion, const std::uint8_t *pool, std::uint32_t size);
@@ -452,6 +454,7 @@ namespace isobus
 			std::uint32_t objectPoolSize;
 			VTVersion version; // Must be the same for all pools!
 			bool useDataCallback;
+			bool uploaded;
 		};
 
 		// Object Pool Managment
@@ -472,6 +475,8 @@ namespace isobus
 		bool send_extended_store_version(std::array<std::uint8_t, 32> versionLabel);
 		bool send_extended_load_version(std::array<std::uint8_t, 32> versionLabel);
 		bool send_extended_delete_version(std::array<std::uint8_t, 32> versionLabel);
+		bool send_end_of_object_pool();
+		bool send_working_set_master();
 
 		void set_state(StateMachineState value);
 
@@ -537,6 +542,7 @@ namespace isobus
 		// Object Pool info
 		DataChunkCallback objectPoolDataCallback;
 		std::uint32_t objectPoolSize_bytes;
+		std::uint32_t lastObjectPoolIndex;
 	};
 
 } // namespace isobus

--- a/isobus/include/isobus_virtual_terminal_client.hpp
+++ b/isobus/include/isobus_virtual_terminal_client.hpp
@@ -9,13 +9,13 @@
 #ifndef ISOBUS_VIRTUAL_TERMINAL_CLIENT_HPP
 #define ISOBUS_VIRTUAL_TERMINAL_CLIENT_HPP
 
-#include "can_partnered_control_function.hpp"
 #include "can_internal_control_function.hpp"
+#include "can_partnered_control_function.hpp"
 #include "processing_flags.hpp"
 
 #include <memory>
-#include <vector>
 #include <thread>
+#include <vector>
 
 namespace isobus
 {
@@ -319,7 +319,7 @@ namespace isobus
 
 		// These are the functions for specifying your pool to upload.
 		// You have a few options:
-		// 1. Upload in one blob of contigious memory 
+		// 1. Upload in one blob of contigious memory
 		// This is good for small pools or pools where you have all the data in memory.
 		// 2. Get a callback at some inteval to provide data in chunks
 		// This is probably better for huge pools if you are RAM constrained, or if your
@@ -501,6 +501,11 @@ namespace isobus
 		                             ControlFunction *destinationControlFunction,
 		                             bool successful,
 		                             void *parentPointer);
+		static bool process_internal_object_pool_upload_callback(std::uint32_t callbackIndex,
+		                                                         std::uint32_t bytesOffset,
+		                                                         std::uint32_t numberOfBytesNeeded,
+		                                                         std::uint8_t *chunkBuffer,
+		                                                         void *parentPointer);
 
 		void worker_thread_function();
 

--- a/isobus/src/isobus_virtual_terminal_client.cpp
+++ b/isobus/src/isobus_virtual_terminal_client.cpp
@@ -12,6 +12,8 @@
 #include "can_network_manager.hpp"
 #include "can_warning_logger.hpp"
 
+#include <cstring>
+
 namespace isobus
 {
 
@@ -199,8 +201,8 @@ namespace isobus
 			                                             static_cast<std::uint8_t>(objectID >> 8),
 			                                             color,
 			                                             0xFF,
-																									 0xFF,
-																									 0xFF,
+			                                             0xFF,
+			                                             0xFF,
 			                                             0xFF };
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer,
@@ -212,14 +214,16 @@ namespace isobus
 
 	bool VirtualTerminalClient::send_change_numeric_value(std::uint16_t objectID, std::uint32_t value)
 	{
-		const std::uint8_t buffer[CAN_DATA_LENGTH] = { static_cast<std::uint8_t>(Function::ChangeNumericValueCommand),
-			                                             static_cast<std::uint8_t>(objectID & 0xFF),
-			                                             static_cast<std::uint8_t>(objectID >> 8),
-			                                             0xFF,
-			                                             static_cast<std::uint8_t>(value & 0xFF),
-																									 static_cast<std::uint8_t>((value >> 8) & 0xFF),
-																									 static_cast<std::uint8_t>((value >> 16) & 0xFF),
-			                                             static_cast<std::uint8_t>((value >> 24) & 0xFF), };
+		const std::uint8_t buffer[CAN_DATA_LENGTH] = {
+			static_cast<std::uint8_t>(Function::ChangeNumericValueCommand),
+			static_cast<std::uint8_t>(objectID & 0xFF),
+			static_cast<std::uint8_t>(objectID >> 8),
+			0xFF,
+			static_cast<std::uint8_t>(value & 0xFF),
+			static_cast<std::uint8_t>((value >> 8) & 0xFF),
+			static_cast<std::uint8_t>((value >> 16) & 0xFF),
+			static_cast<std::uint8_t>((value >> 24) & 0xFF),
+		};
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer,
 		                                                      CAN_DATA_LENGTH,
@@ -245,12 +249,12 @@ namespace isobus
 				buffer[5 + i] = value[i];
 			}
 			retVal = CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
-		                                                      buffer,
-		                                                      5 + stringLength,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
-		                                                      CANIdentifier::PriorityLowest7);
-			delete [] buffer;
+			                                                        buffer,
+			                                                        5 + stringLength,
+			                                                        myControlFunction.get(),
+			                                                        partnerControlFunction.get(),
+			                                                        CANIdentifier::PriorityLowest7);
+			delete[] buffer;
 		}
 		return retVal;
 	}
@@ -267,7 +271,7 @@ namespace isobus
 			                                             static_cast<std::uint8_t>(objectID >> 8),
 			                                             static_cast<std::uint8_t>(width_px & 0xFF),
 			                                             static_cast<std::uint8_t>(width_px >> 8),
-																									 static_cast<std::uint8_t>(height_px & 0xFF),
+			                                             static_cast<std::uint8_t>(height_px & 0xFF),
 			                                             static_cast<std::uint8_t>(height_px >> 8),
 			                                             static_cast<std::uint8_t>(direction) };
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
@@ -285,7 +289,7 @@ namespace isobus
 			                                             static_cast<std::uint8_t>(objectID >> 8),
 			                                             color,
 			                                             static_cast<std::uint8_t>(size),
-																									 type,
+			                                             type,
 			                                             styleBitfield,
 			                                             0xFF };
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
@@ -303,7 +307,7 @@ namespace isobus
 			                                             static_cast<std::uint8_t>(objectID >> 8),
 			                                             color,
 			                                             static_cast<std::uint8_t>(width),
-																									 static_cast<std::uint8_t>(lineArtBitmask & 0xFF),
+			                                             static_cast<std::uint8_t>(lineArtBitmask & 0xFF),
 			                                             static_cast<std::uint8_t>(lineArtBitmask >> 8),
 			                                             0xFF };
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
@@ -321,7 +325,7 @@ namespace isobus
 			                                             static_cast<std::uint8_t>(objectID >> 8),
 			                                             static_cast<std::uint8_t>(fillType),
 			                                             color,
-																									 static_cast<std::uint8_t>(fillPatternObjectID & 0xFF),
+			                                             static_cast<std::uint8_t>(fillPatternObjectID & 0xFF),
 			                                             static_cast<std::uint8_t>(fillPatternObjectID >> 8),
 			                                             0xFF };
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
@@ -339,7 +343,7 @@ namespace isobus
 			                                             static_cast<std::uint8_t>(workingSetObjectID >> 8),
 			                                             static_cast<std::uint8_t>(newActiveMaskObjectID & 0xFF),
 			                                             static_cast<std::uint8_t>(newActiveMaskObjectID >> 8),
-																									 0xFF,
+			                                             0xFF,
 			                                             0xFF,
 			                                             0xFF };
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
@@ -375,8 +379,8 @@ namespace isobus
 			                                             static_cast<std::uint8_t>(objectID >> 8),
 			                                             attributeID,
 			                                             static_cast<std::uint8_t>(value & 0xFF),
-																									 static_cast<std::uint8_t>((value >> 8) & 0xFF),
-																									 static_cast<std::uint8_t>((value >> 16) & 0xFF),
+			                                             static_cast<std::uint8_t>((value >> 8) & 0xFF),
+			                                             static_cast<std::uint8_t>((value >> 16) & 0xFF),
 			                                             static_cast<std::uint8_t>((value >> 24) & 0xFF) };
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer,
@@ -393,8 +397,8 @@ namespace isobus
 			                                             static_cast<std::uint8_t>(alarmMaskObjectID >> 8),
 			                                             static_cast<std::uint8_t>(priority),
 			                                             0xFF,
-																									 0xFF,
-																									 0xFF,
+			                                             0xFF,
+			                                             0xFF,
 			                                             0xFF };
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer,
@@ -412,7 +416,7 @@ namespace isobus
 			                                             listIndex,
 			                                             static_cast<std::uint8_t>(newObjectID & 0xFF),
 			                                             static_cast<std::uint8_t>(newObjectID >> 8),
-																									 0xFF,
+			                                             0xFF,
 			                                             0xFF };
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer,
@@ -425,12 +429,12 @@ namespace isobus
 	bool VirtualTerminalClient::send_lock_unlock_mask(MaskLockState state, std::uint16_t objectID, std::uint16_t timeout_ms)
 	{
 		const std::uint8_t buffer[CAN_DATA_LENGTH] = { static_cast<std::uint8_t>(Function::LockUnlockMaskCommand),
-																									 static_cast<std::uint8_t>(state),
+			                                             static_cast<std::uint8_t>(state),
 			                                             static_cast<std::uint8_t>(objectID & 0xFF),
 			                                             static_cast<std::uint8_t>(objectID >> 8),
 			                                             static_cast<std::uint8_t>(timeout_ms & 0xFF),
 			                                             static_cast<std::uint8_t>(timeout_ms >> 8),
-																									 0xFF,
+			                                             0xFF,
 			                                             0xFF };
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer,
@@ -443,12 +447,12 @@ namespace isobus
 	bool VirtualTerminalClient::send_execute_macro(std::uint16_t objectID)
 	{
 		const std::uint8_t buffer[CAN_DATA_LENGTH] = { static_cast<std::uint8_t>(Function::ExecuteMacroCommand),
-																									 static_cast<std::uint8_t>(objectID & 0xFF),
+			                                             static_cast<std::uint8_t>(objectID & 0xFF),
 			                                             static_cast<std::uint8_t>(objectID >> 8),
 			                                             0xFF,
 			                                             0xFF,
 			                                             0xFF,
-																									 0xFF,
+			                                             0xFF,
 			                                             0xFF };
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer,
@@ -461,12 +465,12 @@ namespace isobus
 	bool VirtualTerminalClient::send_change_object_label(std::uint16_t objectID, std::uint16_t labelStringObjectID, std::uint8_t fontType, std::uint16_t graphicalDesignatorObjectID)
 	{
 		const std::uint8_t buffer[CAN_DATA_LENGTH] = { static_cast<std::uint8_t>(Function::ChangeObjectLabelCommand),
-																									 static_cast<std::uint8_t>(objectID & 0xFF),
+			                                             static_cast<std::uint8_t>(objectID & 0xFF),
 			                                             static_cast<std::uint8_t>(objectID >> 8),
 			                                             static_cast<std::uint8_t>(labelStringObjectID & 0xFF),
 			                                             static_cast<std::uint8_t>(labelStringObjectID >> 8),
 			                                             fontType,
-																									 static_cast<std::uint8_t>(graphicalDesignatorObjectID & 0xFF),
+			                                             static_cast<std::uint8_t>(graphicalDesignatorObjectID & 0xFF),
 			                                             static_cast<std::uint8_t>(graphicalDesignatorObjectID >> 8) };
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer,
@@ -479,9 +483,9 @@ namespace isobus
 	bool VirtualTerminalClient::send_change_polygon_point(std::uint16_t objectID, std::uint8_t pointIndex, std::uint16_t newXValue, std::uint16_t newYValue)
 	{
 		const std::uint8_t buffer[CAN_DATA_LENGTH] = { static_cast<std::uint8_t>(Function::ChangePolygonPointCommand),
-																									 static_cast<std::uint8_t>(objectID & 0xFF),
+			                                             static_cast<std::uint8_t>(objectID & 0xFF),
 			                                             static_cast<std::uint8_t>(objectID >> 8),
-																									 pointIndex,
+			                                             pointIndex,
 			                                             static_cast<std::uint8_t>(newXValue & 0xFF),
 			                                             static_cast<std::uint8_t>(newXValue >> 8),
 			                                             static_cast<std::uint8_t>(newYValue & 0xFF),
@@ -497,9 +501,9 @@ namespace isobus
 	bool VirtualTerminalClient::send_change_polygon_scale(std::uint16_t objectID, std::uint16_t widthAttribute, std::uint16_t heightAttribute)
 	{
 		const std::uint8_t buffer[CAN_DATA_LENGTH] = { static_cast<std::uint8_t>(Function::ChangePolygonScaleCommand),
-																									 static_cast<std::uint8_t>(objectID & 0xFF),
+			                                             static_cast<std::uint8_t>(objectID & 0xFF),
 			                                             static_cast<std::uint8_t>(objectID >> 8),
-																									 static_cast<std::uint8_t>(widthAttribute & 0xFF),
+			                                             static_cast<std::uint8_t>(widthAttribute & 0xFF),
 			                                             static_cast<std::uint8_t>(widthAttribute >> 8),
 			                                             static_cast<std::uint8_t>(heightAttribute & 0xFF),
 			                                             static_cast<std::uint8_t>(heightAttribute >> 8),
@@ -515,9 +519,9 @@ namespace isobus
 	bool VirtualTerminalClient::send_select_color_map_or_palette(std::uint16_t objectID)
 	{
 		const std::uint8_t buffer[CAN_DATA_LENGTH] = { static_cast<std::uint8_t>(Function::SelectColourMapCommand),
-																									 0xFF,
+			                                             static_cast<std::uint8_t>(objectID & 0xFF),
+			                                             static_cast<std::uint8_t>(objectID >> 8),
 			                                             0xFF,
-																									 0xFF,
 			                                             0xFF,
 			                                             0xFF,
 			                                             0xFF,
@@ -533,9 +537,9 @@ namespace isobus
 	bool VirtualTerminalClient::send_execute_extended_macro(std::uint16_t objectID)
 	{
 		const std::uint8_t buffer[CAN_DATA_LENGTH] = { static_cast<std::uint8_t>(Function::ExecuteExtendedMacroCommand),
-																									 static_cast<std::uint8_t>(objectID & 0xFF),
+			                                             static_cast<std::uint8_t>(objectID & 0xFF),
 			                                             static_cast<std::uint8_t>(objectID >> 8),
-																									 0xFF,
+			                                             0xFF,
 			                                             0xFF,
 			                                             0xFF,
 			                                             0xFF,
@@ -551,14 +555,14 @@ namespace isobus
 	bool VirtualTerminalClient::send_select_active_working_set(std::uint64_t NAMEofWorkingSetMasterForDesiredWorkingSet)
 	{
 		const std::uint8_t buffer[9] = { static_cast<std::uint8_t>(Function::SelectActiveWorkingSet),
-																									 static_cast<std::uint8_t>(NAMEofWorkingSetMasterForDesiredWorkingSet & 0xFF),
-			                                             static_cast<std::uint8_t>((NAMEofWorkingSetMasterForDesiredWorkingSet >> 8) & 0xFF),
-																									 static_cast<std::uint8_t>((NAMEofWorkingSetMasterForDesiredWorkingSet >> 16) & 0xFF),
-			                                             static_cast<std::uint8_t>((NAMEofWorkingSetMasterForDesiredWorkingSet >> 24) & 0xFF),
-			                                             static_cast<std::uint8_t>((NAMEofWorkingSetMasterForDesiredWorkingSet >> 32) & 0xFF),
-			                                             static_cast<std::uint8_t>((NAMEofWorkingSetMasterForDesiredWorkingSet >> 40) & 0xFF),
-			                                             static_cast<std::uint8_t>((NAMEofWorkingSetMasterForDesiredWorkingSet >> 48) & 0xFF),
-																									 static_cast<std::uint8_t>((NAMEofWorkingSetMasterForDesiredWorkingSet >> 56) & 0xFF) };
+			                               static_cast<std::uint8_t>(NAMEofWorkingSetMasterForDesiredWorkingSet & 0xFF),
+			                               static_cast<std::uint8_t>((NAMEofWorkingSetMasterForDesiredWorkingSet >> 8) & 0xFF),
+			                               static_cast<std::uint8_t>((NAMEofWorkingSetMasterForDesiredWorkingSet >> 16) & 0xFF),
+			                               static_cast<std::uint8_t>((NAMEofWorkingSetMasterForDesiredWorkingSet >> 24) & 0xFF),
+			                               static_cast<std::uint8_t>((NAMEofWorkingSetMasterForDesiredWorkingSet >> 32) & 0xFF),
+			                               static_cast<std::uint8_t>((NAMEofWorkingSetMasterForDesiredWorkingSet >> 40) & 0xFF),
+			                               static_cast<std::uint8_t>((NAMEofWorkingSetMasterForDesiredWorkingSet >> 48) & 0xFF),
+			                               static_cast<std::uint8_t>((NAMEofWorkingSetMasterForDesiredWorkingSet >> 56) & 0xFF) };
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer,
 		                                                      9,
@@ -615,13 +619,13 @@ namespace isobus
 	bool VirtualTerminalClient::send_delete_object_pool()
 	{
 		constexpr std::uint8_t buffer[CAN_DATA_LENGTH] = { static_cast<std::uint8_t>(Function::DeleteObjectPoolCommand),
-																									 0xFF,
-			                                             0xFF,
-			                                             0xFF,
-			                                             0xFF,
-			                                             0xFF,
-																									 0xFF,
-			                                             0xFF };
+			                                                 0xFF,
+			                                                 0xFF,
+			                                                 0xFF,
+			                                                 0xFF,
+			                                                 0xFF,
+			                                                 0xFF,
+			                                                 0xFF };
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer,
 		                                                      CAN_DATA_LENGTH,
@@ -669,12 +673,12 @@ namespace isobus
 		}
 
 		const std::uint8_t buffer[CAN_DATA_LENGTH] = { static_cast<std::uint8_t>(Function::WorkingSetMaintenanceMessage),
-																									 bitmask,
+			                                             bitmask,
 			                                             versionByte,
 			                                             0xFF,
 			                                             0xFF,
 			                                             0xFF,
-																									 0xFF,
+			                                             0xFF,
 			                                             0xFF };
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer,
@@ -682,6 +686,273 @@ namespace isobus
 		                                                      myControlFunction.get(),
 		                                                      partnerControlFunction.get(),
 		                                                      CANIdentifier::PriorityLowest7);
+	}
+
+	bool VirtualTerminalClient::send_get_memory(std::uint32_t requiredMemory)
+	{
+		const std::uint8_t buffer[CAN_DATA_LENGTH] = { static_cast<std::uint8_t>(Function::GetMemoryMessage),
+			                                             0xFF,
+			                                             static_cast<std::uint8_t>(requiredMemory & 0xFF),
+			                                             static_cast<std::uint8_t>((requiredMemory >> 8) & 0xFF),
+			                                             static_cast<std::uint8_t>((requiredMemory >> 16) & 0xFF),
+			                                             static_cast<std::uint8_t>((requiredMemory >> 24) & 0xFF),
+			                                             0xFF,
+			                                             0xFF };
+		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
+		                                                      buffer,
+		                                                      CAN_DATA_LENGTH,
+		                                                      myControlFunction.get(),
+		                                                      partnerControlFunction.get(),
+		                                                      CANIdentifier::PriorityLowest7);
+	}
+
+	bool VirtualTerminalClient::send_get_number_of_softkeys()
+	{
+		constexpr std::uint8_t buffer[CAN_DATA_LENGTH] = { static_cast<std::uint8_t>(Function::GetNumberOfSoftKeysMessage),
+			                                                 0xFF,
+			                                                 0xFF,
+			                                                 0xFF,
+			                                                 0xFF,
+			                                                 0xFF,
+			                                                 0xFF,
+			                                                 0xFF };
+		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
+		                                                      buffer,
+		                                                      CAN_DATA_LENGTH,
+		                                                      myControlFunction.get(),
+		                                                      partnerControlFunction.get(),
+		                                                      CANIdentifier::PriorityLowest7);
+	}
+
+	bool VirtualTerminalClient::send_get_text_font_data()
+	{
+		constexpr std::uint8_t buffer[CAN_DATA_LENGTH] = { static_cast<std::uint8_t>(Function::GetTextFontDataMessage),
+			                                                 0xFF,
+			                                                 0xFF,
+			                                                 0xFF,
+			                                                 0xFF,
+			                                                 0xFF,
+			                                                 0xFF,
+			                                                 0xFF };
+		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
+		                                                      buffer,
+		                                                      CAN_DATA_LENGTH,
+		                                                      myControlFunction.get(),
+		                                                      partnerControlFunction.get(),
+		                                                      CANIdentifier::PriorityLowest7);
+	}
+
+	bool VirtualTerminalClient::send_get_hardware()
+	{
+		constexpr std::uint8_t buffer[CAN_DATA_LENGTH] = { static_cast<std::uint8_t>(Function::GetHardwareMessage),
+			                                                 0xFF,
+			                                                 0xFF,
+			                                                 0xFF,
+			                                                 0xFF,
+			                                                 0xFF,
+			                                                 0xFF,
+			                                                 0xFF };
+		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
+		                                                      buffer,
+		                                                      CAN_DATA_LENGTH,
+		                                                      myControlFunction.get(),
+		                                                      partnerControlFunction.get(),
+		                                                      CANIdentifier::PriorityLowest7);
+	}
+
+	bool VirtualTerminalClient::send_get_supported_widechars()
+	{
+		constexpr std::uint8_t buffer[CAN_DATA_LENGTH] = { static_cast<std::uint8_t>(Function::GetSupportedWidecharsMessage),
+			                                                 0xFF,
+			                                                 0xFF,
+			                                                 0xFF,
+			                                                 0xFF,
+			                                                 0xFF,
+			                                                 0xFF,
+			                                                 0xFF };
+		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
+		                                                      buffer,
+		                                                      CAN_DATA_LENGTH,
+		                                                      myControlFunction.get(),
+		                                                      partnerControlFunction.get(),
+		                                                      CANIdentifier::PriorityLowest7);
+	}
+
+	bool VirtualTerminalClient::send_get_window_mask_data()
+	{
+		constexpr std::uint8_t buffer[CAN_DATA_LENGTH] = { static_cast<std::uint8_t>(Function::GetWindowMaskDataMessage),
+			                                                 0xFF,
+			                                                 0xFF,
+			                                                 0xFF,
+			                                                 0xFF,
+			                                                 0xFF,
+			                                                 0xFF,
+			                                                 0xFF };
+		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
+		                                                      buffer,
+		                                                      CAN_DATA_LENGTH,
+		                                                      myControlFunction.get(),
+		                                                      partnerControlFunction.get(),
+		                                                      CANIdentifier::PriorityLowest7);
+	}
+
+	bool VirtualTerminalClient::send_get_supported_objects()
+	{
+		constexpr std::uint8_t buffer[CAN_DATA_LENGTH] = { static_cast<std::uint8_t>(Function::GetSupportedObjectsMessage),
+			                                                 0xFF,
+			                                                 0xFF,
+			                                                 0xFF,
+			                                                 0xFF,
+			                                                 0xFF,
+			                                                 0xFF,
+			                                                 0xFF };
+		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
+		                                                      buffer,
+		                                                      CAN_DATA_LENGTH,
+		                                                      myControlFunction.get(),
+		                                                      partnerControlFunction.get(),
+		                                                      CANIdentifier::PriorityLowest7);
+	}
+
+	bool VirtualTerminalClient::send_get_versions()
+	{
+		constexpr std::uint8_t buffer[CAN_DATA_LENGTH] = { static_cast<std::uint8_t>(Function::GetVersionsMessage),
+			                                                 0xFF,
+			                                                 0xFF,
+			                                                 0xFF,
+			                                                 0xFF,
+			                                                 0xFF,
+			                                                 0xFF,
+			                                                 0xFF };
+		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
+		                                                      buffer,
+		                                                      CAN_DATA_LENGTH,
+		                                                      myControlFunction.get(),
+		                                                      partnerControlFunction.get(),
+		                                                      CANIdentifier::PriorityLowest7);
+	}
+
+	bool VirtualTerminalClient::send_store_version(std::array<std::uint8_t, 7> versionLabel)
+	{
+		const std::uint8_t buffer[CAN_DATA_LENGTH] = { static_cast<std::uint8_t>(Function::StoreVersionCommand),
+			                                             versionLabel[0],
+			                                             versionLabel[1],
+			                                             versionLabel[2],
+			                                             versionLabel[3],
+			                                             versionLabel[4],
+			                                             versionLabel[5],
+			                                             versionLabel[6] };
+		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
+		                                                      buffer,
+		                                                      CAN_DATA_LENGTH,
+		                                                      myControlFunction.get(),
+		                                                      partnerControlFunction.get(),
+		                                                      CANIdentifier::PriorityLowest7);
+	}
+
+	bool VirtualTerminalClient::send_load_version(std::array<std::uint8_t, 7> versionLabel)
+	{
+		const std::uint8_t buffer[CAN_DATA_LENGTH] = { static_cast<std::uint8_t>(Function::LoadVersionCommand),
+			                                             versionLabel[0],
+			                                             versionLabel[1],
+			                                             versionLabel[2],
+			                                             versionLabel[3],
+			                                             versionLabel[4],
+			                                             versionLabel[5],
+			                                             versionLabel[6] };
+		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
+		                                                      buffer,
+		                                                      CAN_DATA_LENGTH,
+		                                                      myControlFunction.get(),
+		                                                      partnerControlFunction.get(),
+		                                                      CANIdentifier::PriorityLowest7);
+	}
+
+	bool VirtualTerminalClient::send_delete_version(std::array<std::uint8_t, 7> versionLabel)
+	{
+		const std::uint8_t buffer[CAN_DATA_LENGTH] = { static_cast<std::uint8_t>(Function::DeleteVersionCommand),
+			                                             versionLabel[0],
+			                                             versionLabel[1],
+			                                             versionLabel[2],
+			                                             versionLabel[3],
+			                                             versionLabel[4],
+			                                             versionLabel[5],
+			                                             versionLabel[6] };
+		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
+		                                                      buffer,
+		                                                      CAN_DATA_LENGTH,
+		                                                      myControlFunction.get(),
+		                                                      partnerControlFunction.get(),
+		                                                      CANIdentifier::PriorityLowest7);
+	}
+
+	bool VirtualTerminalClient::send_extended_get_versions()
+	{
+		const std::uint8_t buffer[CAN_DATA_LENGTH] = { static_cast<std::uint8_t>(Function::ExtendedDeleteVersionCommand),
+			                                             0xFF,
+			                                             0xFF,
+			                                             0xFF,
+			                                             0xFF,
+			                                             0xFF,
+			                                             0xFF,
+			                                             0xFF };
+		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
+		                                                      buffer,
+		                                                      CAN_DATA_LENGTH,
+		                                                      myControlFunction.get(),
+		                                                      partnerControlFunction.get(),
+		                                                      CANIdentifier::PriorityLowest7);
+	}
+
+	bool VirtualTerminalClient::send_extended_store_version(std::array<std::uint8_t, 32> versionLabel)
+	{
+		bool retVal;
+
+		std::uint8_t *buffer = new std::uint8_t[33];
+		buffer[0] = static_cast<std::uint8_t>(Function::ExtendedStoreVersionCommand);
+		memcpy(&buffer[1], versionLabel.data(), 32);
+		retVal = CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
+		                                                        buffer,
+		                                                        33,
+		                                                        myControlFunction.get(),
+		                                                        partnerControlFunction.get(),
+		                                                        CANIdentifier::PriorityLowest7);
+		delete [] buffer;
+		return retVal;
+	}
+
+	bool VirtualTerminalClient::send_extended_load_version(std::array<std::uint8_t, 32> versionLabel)
+	{
+		bool retVal;
+
+		std::uint8_t *buffer = new std::uint8_t[33];
+		buffer[0] = static_cast<std::uint8_t>(Function::ExtendedLoadVersionCommand);
+		memcpy(&buffer[1], versionLabel.data(), 32);
+		retVal = CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
+		                                                        buffer,
+		                                                        33,
+		                                                        myControlFunction.get(),
+		                                                        partnerControlFunction.get(),
+		                                                        CANIdentifier::PriorityLowest7);
+		delete[] buffer;
+		return retVal;
+	}
+
+	bool VirtualTerminalClient::send_extended_delete_version(std::array<std::uint8_t, 32> versionLabel)
+	{
+		bool retVal;
+
+		std::uint8_t *buffer = new std::uint8_t[33];
+		buffer[0] = static_cast<std::uint8_t>(Function::ExtendedDeleteVersionCommand);
+		memcpy(&buffer[1], versionLabel.data(), 32);
+		retVal = CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
+		                                                        buffer,
+		                                                        33,
+		                                                        myControlFunction.get(),
+		                                                        partnerControlFunction.get(),
+		                                                        CANIdentifier::PriorityLowest7);
+		delete[] buffer;
+		return retVal;
 	}
 
 } // namespace isobus

--- a/isobus/src/isobus_virtual_terminal_client.cpp
+++ b/isobus/src/isobus_virtual_terminal_client.cpp
@@ -1,0 +1,687 @@
+//================================================================================================
+/// @file isobus_virtual_terminal.cpp
+///
+/// @brief Implements the client for a virtual terminal
+/// @author Adrian Del Grosso
+///
+/// @copyright 2022 Adrian Del Grosso
+//================================================================================================
+
+#include "isobus_virtual_terminal_client.hpp"
+#include "can_general_parameter_group_numbers.hpp"
+#include "can_network_manager.hpp"
+#include "can_warning_logger.hpp"
+
+namespace isobus
+{
+
+	VirtualTerminalClient::VirtualTerminalClient(std::shared_ptr<PartneredControlFunction> partner, std::shared_ptr<InternalControlFunction> clientSource) :
+	  partnerControlFunction(partner),
+	  myControlFunction(clientSource)
+	{
+	}
+
+	bool VirtualTerminalClient::send_hide_show_object(std::uint16_t objectID, HideShowObjectCommand command)
+	{
+		const std::uint8_t buffer[CAN_DATA_LENGTH] = { static_cast<std::uint8_t>(Function::HideShowObjectCommand),
+			                                             static_cast<std::uint8_t>(objectID & 0xFF),
+			                                             static_cast<std::uint8_t>(objectID >> 8),
+			                                             static_cast<std::uint8_t>(command),
+			                                             0xFF,
+			                                             0xFF,
+			                                             0xFF,
+			                                             0xFF };
+
+		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
+		                                                      buffer,
+		                                                      CAN_DATA_LENGTH,
+		                                                      myControlFunction.get(),
+		                                                      partnerControlFunction.get(),
+		                                                      CANIdentifier::PriorityLowest7);
+	}
+
+	bool VirtualTerminalClient::send_enable_disable_object(std::uint16_t objectID, EnableDisableObjectCommand command)
+	{
+		const std::uint8_t buffer[CAN_DATA_LENGTH] = { static_cast<std::uint8_t>(Function::EnableDisableObjectCommand),
+			                                             static_cast<std::uint8_t>(objectID & 0xFF),
+			                                             static_cast<std::uint8_t>(objectID >> 8),
+			                                             static_cast<std::uint8_t>(command),
+			                                             0xFF,
+			                                             0xFF,
+			                                             0xFF,
+			                                             0xFF };
+		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
+		                                                      buffer,
+		                                                      CAN_DATA_LENGTH,
+		                                                      myControlFunction.get(),
+		                                                      partnerControlFunction.get(),
+		                                                      CANIdentifier::PriorityLowest7);
+	}
+
+	bool VirtualTerminalClient::send_select_input_object(std::uint16_t objectID, SelectInputObjectOptions option)
+	{
+		const std::uint8_t buffer[CAN_DATA_LENGTH] = { static_cast<std::uint8_t>(Function::SelectInputObjectCommand),
+			                                             static_cast<std::uint8_t>(objectID & 0xFF),
+			                                             static_cast<std::uint8_t>(objectID >> 8),
+			                                             static_cast<std::uint8_t>(option),
+			                                             0xFF,
+			                                             0xFF,
+			                                             0xFF,
+			                                             0xFF };
+		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
+		                                                      buffer,
+		                                                      CAN_DATA_LENGTH,
+		                                                      myControlFunction.get(),
+		                                                      partnerControlFunction.get(),
+		                                                      CANIdentifier::PriorityLowest7);
+	}
+
+	bool VirtualTerminalClient::send_ESC()
+	{
+		const std::uint8_t buffer[CAN_DATA_LENGTH] = { static_cast<std::uint8_t>(Function::ESCCommand),
+			                                             0xFF,
+			                                             0xFF,
+			                                             0xFF,
+			                                             0xFF,
+			                                             0xFF,
+			                                             0xFF,
+			                                             0xFF };
+		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
+		                                                      buffer,
+		                                                      CAN_DATA_LENGTH,
+		                                                      myControlFunction.get(),
+		                                                      partnerControlFunction.get(),
+		                                                      CANIdentifier::PriorityLowest7);
+	}
+
+	bool VirtualTerminalClient::send_control_audio_signal(std::uint8_t activations, std::uint16_t frequency_hz, std::uint16_t duration_ms, std::uint16_t offTimeDuration_ms)
+	{
+		const std::uint8_t buffer[CAN_DATA_LENGTH] = { static_cast<std::uint8_t>(Function::ControlAudioSignalCommand),
+			                                             activations,
+			                                             static_cast<std::uint8_t>(frequency_hz & 0xFF),
+			                                             static_cast<std::uint8_t>(frequency_hz >> 8),
+			                                             static_cast<std::uint8_t>(duration_ms & 0xFF),
+			                                             static_cast<std::uint8_t>(duration_ms >> 8),
+			                                             static_cast<std::uint8_t>(offTimeDuration_ms & 0xFF),
+			                                             static_cast<std::uint8_t>(offTimeDuration_ms >> 8) };
+		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
+		                                                      buffer,
+		                                                      CAN_DATA_LENGTH,
+		                                                      myControlFunction.get(),
+		                                                      partnerControlFunction.get(),
+		                                                      CANIdentifier::PriorityLowest7);
+	}
+
+	bool VirtualTerminalClient::send_set_audio_volume(std::uint8_t volume_percent)
+	{
+		if (volume_percent > 100)
+		{
+			volume_percent = 100;
+		}
+
+		const std::uint8_t buffer[CAN_DATA_LENGTH] = { static_cast<std::uint8_t>(Function::SetAudioVolumeCommand),
+			                                             volume_percent,
+			                                             0xFF,
+			                                             0xFF,
+			                                             0xFF,
+			                                             0xFF,
+			                                             0xFF,
+			                                             0xFF };
+		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
+		                                                      buffer,
+		                                                      CAN_DATA_LENGTH,
+		                                                      myControlFunction.get(),
+		                                                      partnerControlFunction.get(),
+		                                                      CANIdentifier::PriorityLowest7);
+	}
+
+	bool VirtualTerminalClient::send_change_child_location(std::uint16_t objectID, std::uint16_t parentObjectID, std::uint8_t relativeXPositionChange, std::uint8_t relativeYPositionChange)
+	{
+		const std::uint8_t buffer[CAN_DATA_LENGTH] = { static_cast<std::uint8_t>(Function::ChangeChildLocationCommand),
+			                                             static_cast<std::uint8_t>(parentObjectID & 0xFF),
+			                                             static_cast<std::uint8_t>(parentObjectID >> 8),
+			                                             static_cast<std::uint8_t>(objectID & 0xFF),
+			                                             static_cast<std::uint8_t>(objectID >> 8),
+			                                             relativeXPositionChange,
+			                                             relativeYPositionChange,
+			                                             0xFF };
+		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
+		                                                      buffer,
+		                                                      CAN_DATA_LENGTH,
+		                                                      myControlFunction.get(),
+		                                                      partnerControlFunction.get(),
+		                                                      CANIdentifier::PriorityLowest7);
+	}
+
+	bool VirtualTerminalClient::send_change_child_position(std::uint16_t objectID, std::uint16_t parentObjectID, std::uint16_t xPosition, std::uint16_t yPosition)
+	{
+		const std::uint8_t buffer[9] = {
+			static_cast<std::uint8_t>(Function::ChangeChildPositionCommand),
+			static_cast<std::uint8_t>(parentObjectID & 0xFF),
+			static_cast<std::uint8_t>(parentObjectID >> 8),
+			static_cast<std::uint8_t>(objectID & 0xFF),
+			static_cast<std::uint8_t>(objectID >> 8),
+			static_cast<std::uint8_t>(xPosition & 0xFF),
+			static_cast<std::uint8_t>(xPosition >> 8),
+			static_cast<std::uint8_t>(yPosition & 0xFF),
+			static_cast<std::uint8_t>(yPosition >> 8),
+		};
+		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
+		                                                      buffer,
+		                                                      9,
+		                                                      myControlFunction.get(),
+		                                                      partnerControlFunction.get(),
+		                                                      CANIdentifier::PriorityLowest7);
+	}
+
+	bool VirtualTerminalClient::send_change_size_command(std::uint16_t objectID, std::uint16_t newWidth, std::uint16_t newHeight)
+	{
+		const std::uint8_t buffer[CAN_DATA_LENGTH] = { static_cast<std::uint8_t>(Function::ChangeSizeCommand),
+			                                             static_cast<std::uint8_t>(objectID & 0xFF),
+			                                             static_cast<std::uint8_t>(objectID >> 8),
+			                                             static_cast<std::uint8_t>(newWidth & 0xFF),
+			                                             static_cast<std::uint8_t>(newWidth >> 8),
+			                                             static_cast<std::uint8_t>(newHeight & 0xFF),
+			                                             static_cast<std::uint8_t>(newHeight >> 8),
+			                                             0xFF };
+		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
+		                                                      buffer,
+		                                                      CAN_DATA_LENGTH,
+		                                                      myControlFunction.get(),
+		                                                      partnerControlFunction.get(),
+		                                                      CANIdentifier::PriorityLowest7);
+	}
+
+	bool VirtualTerminalClient::send_change_background_colour(std::uint16_t objectID, std::uint8_t color)
+	{
+		const std::uint8_t buffer[CAN_DATA_LENGTH] = { static_cast<std::uint8_t>(Function::ChangeBackgroundColourCommand),
+			                                             static_cast<std::uint8_t>(objectID & 0xFF),
+			                                             static_cast<std::uint8_t>(objectID >> 8),
+			                                             color,
+			                                             0xFF,
+																									 0xFF,
+																									 0xFF,
+			                                             0xFF };
+		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
+		                                                      buffer,
+		                                                      CAN_DATA_LENGTH,
+		                                                      myControlFunction.get(),
+		                                                      partnerControlFunction.get(),
+		                                                      CANIdentifier::PriorityLowest7);
+	}
+
+	bool VirtualTerminalClient::send_change_numeric_value(std::uint16_t objectID, std::uint32_t value)
+	{
+		const std::uint8_t buffer[CAN_DATA_LENGTH] = { static_cast<std::uint8_t>(Function::ChangeNumericValueCommand),
+			                                             static_cast<std::uint8_t>(objectID & 0xFF),
+			                                             static_cast<std::uint8_t>(objectID >> 8),
+			                                             0xFF,
+			                                             static_cast<std::uint8_t>(value & 0xFF),
+																									 static_cast<std::uint8_t>((value >> 8) & 0xFF),
+																									 static_cast<std::uint8_t>((value >> 16) & 0xFF),
+			                                             static_cast<std::uint8_t>((value >> 24) & 0xFF), };
+		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
+		                                                      buffer,
+		                                                      CAN_DATA_LENGTH,
+		                                                      myControlFunction.get(),
+		                                                      partnerControlFunction.get(),
+		                                                      CANIdentifier::PriorityLowest7);
+	}
+
+	bool VirtualTerminalClient::send_change_string_value(std::uint16_t objectID, uint16_t stringLength, const char *value)
+	{
+		bool retVal = false;
+
+		if (nullptr != value)
+		{
+			std::uint8_t *buffer = new std::uint8_t[5 + stringLength];
+			buffer[0] = static_cast<std::uint8_t>(Function::ChangeStringValueCommand);
+			buffer[1] = static_cast<std::uint8_t>(objectID & 0xFF);
+			buffer[2] = static_cast<std::uint8_t>(objectID >> 8);
+			buffer[3] = static_cast<std::uint8_t>(stringLength & 0xFF);
+			buffer[4] = static_cast<std::uint8_t>(stringLength >> 8);
+			for (uint16_t i = 0; i < stringLength; i++)
+			{
+				buffer[5 + i] = value[i];
+			}
+			retVal = CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
+		                                                      buffer,
+		                                                      5 + stringLength,
+		                                                      myControlFunction.get(),
+		                                                      partnerControlFunction.get(),
+		                                                      CANIdentifier::PriorityLowest7);
+			delete [] buffer;
+		}
+		return retVal;
+	}
+
+	bool VirtualTerminalClient::send_change_string_value(std::uint16_t objectID, const std::string &value)
+	{
+		return send_change_string_value(objectID, value.size(), value.c_str());
+	}
+
+	bool VirtualTerminalClient::send_change_endpoint(std::uint16_t objectID, std::uint16_t width_px, std::uint16_t height_px, LineDirection direction)
+	{
+		const std::uint8_t buffer[CAN_DATA_LENGTH] = { static_cast<std::uint8_t>(Function::ChangeEndPointCommand),
+			                                             static_cast<std::uint8_t>(objectID & 0xFF),
+			                                             static_cast<std::uint8_t>(objectID >> 8),
+			                                             static_cast<std::uint8_t>(width_px & 0xFF),
+			                                             static_cast<std::uint8_t>(width_px >> 8),
+																									 static_cast<std::uint8_t>(height_px & 0xFF),
+			                                             static_cast<std::uint8_t>(height_px >> 8),
+			                                             static_cast<std::uint8_t>(direction) };
+		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
+		                                                      buffer,
+		                                                      CAN_DATA_LENGTH,
+		                                                      myControlFunction.get(),
+		                                                      partnerControlFunction.get(),
+		                                                      CANIdentifier::PriorityLowest7);
+	}
+
+	bool VirtualTerminalClient::send_change_font_attributes(std::uint16_t objectID, std::uint8_t color, FontSize size, std::uint8_t type, std::uint8_t styleBitfield)
+	{
+		const std::uint8_t buffer[CAN_DATA_LENGTH] = { static_cast<std::uint8_t>(Function::ChangeFontAttributesCommand),
+			                                             static_cast<std::uint8_t>(objectID & 0xFF),
+			                                             static_cast<std::uint8_t>(objectID >> 8),
+			                                             color,
+			                                             static_cast<std::uint8_t>(size),
+																									 type,
+			                                             styleBitfield,
+			                                             0xFF };
+		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
+		                                                      buffer,
+		                                                      CAN_DATA_LENGTH,
+		                                                      myControlFunction.get(),
+		                                                      partnerControlFunction.get(),
+		                                                      CANIdentifier::PriorityLowest7);
+	}
+
+	bool VirtualTerminalClient::send_change_line_attributes(std::uint16_t objectID, std::uint8_t color, std::uint8_t width, std::uint16_t lineArtBitmask)
+	{
+		const std::uint8_t buffer[CAN_DATA_LENGTH] = { static_cast<std::uint8_t>(Function::ChangeLineAttributesCommand),
+			                                             static_cast<std::uint8_t>(objectID & 0xFF),
+			                                             static_cast<std::uint8_t>(objectID >> 8),
+			                                             color,
+			                                             static_cast<std::uint8_t>(width),
+																									 static_cast<std::uint8_t>(lineArtBitmask & 0xFF),
+			                                             static_cast<std::uint8_t>(lineArtBitmask >> 8),
+			                                             0xFF };
+		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
+		                                                      buffer,
+		                                                      CAN_DATA_LENGTH,
+		                                                      myControlFunction.get(),
+		                                                      partnerControlFunction.get(),
+		                                                      CANIdentifier::PriorityLowest7);
+	}
+
+	bool VirtualTerminalClient::send_change_fill_attributes(std::uint16_t objectID, FillType fillType, std::uint8_t color, std::uint16_t fillPatternObjectID)
+	{
+		const std::uint8_t buffer[CAN_DATA_LENGTH] = { static_cast<std::uint8_t>(Function::ChangeFillAttributesCommand),
+			                                             static_cast<std::uint8_t>(objectID & 0xFF),
+			                                             static_cast<std::uint8_t>(objectID >> 8),
+			                                             static_cast<std::uint8_t>(fillType),
+			                                             color,
+																									 static_cast<std::uint8_t>(fillPatternObjectID & 0xFF),
+			                                             static_cast<std::uint8_t>(fillPatternObjectID >> 8),
+			                                             0xFF };
+		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
+		                                                      buffer,
+		                                                      CAN_DATA_LENGTH,
+		                                                      myControlFunction.get(),
+		                                                      partnerControlFunction.get(),
+		                                                      CANIdentifier::PriorityLowest7);
+	}
+
+	bool VirtualTerminalClient::send_change_active_mask(std::uint16_t workingSetObjectID, std::uint16_t newActiveMaskObjectID)
+	{
+		const std::uint8_t buffer[CAN_DATA_LENGTH] = { static_cast<std::uint8_t>(Function::ChangeActiveMaskCommand),
+			                                             static_cast<std::uint8_t>(workingSetObjectID & 0xFF),
+			                                             static_cast<std::uint8_t>(workingSetObjectID >> 8),
+			                                             static_cast<std::uint8_t>(newActiveMaskObjectID & 0xFF),
+			                                             static_cast<std::uint8_t>(newActiveMaskObjectID >> 8),
+																									 0xFF,
+			                                             0xFF,
+			                                             0xFF };
+		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
+		                                                      buffer,
+		                                                      CAN_DATA_LENGTH,
+		                                                      myControlFunction.get(),
+		                                                      partnerControlFunction.get(),
+		                                                      CANIdentifier::PriorityLowest7);
+	}
+
+	bool VirtualTerminalClient::send_change_softkey_mask(MaskType type, std::uint16_t dataOrAlarmMaskObjectID, std::uint16_t newSoftKeyMaskObjectID)
+	{
+		const std::uint8_t buffer[CAN_DATA_LENGTH] = { static_cast<std::uint8_t>(Function::ChangeSoftKeyMaskCommand),
+			                                             static_cast<std::uint8_t>(type),
+			                                             static_cast<std::uint8_t>(dataOrAlarmMaskObjectID & 0xFF),
+			                                             static_cast<std::uint8_t>(dataOrAlarmMaskObjectID >> 8),
+			                                             static_cast<std::uint8_t>(newSoftKeyMaskObjectID & 0xFF),
+			                                             static_cast<std::uint8_t>(newSoftKeyMaskObjectID >> 8),
+			                                             0xFF,
+			                                             0xFF };
+		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
+		                                                      buffer,
+		                                                      CAN_DATA_LENGTH,
+		                                                      myControlFunction.get(),
+		                                                      partnerControlFunction.get(),
+		                                                      CANIdentifier::PriorityLowest7);
+	}
+
+	bool VirtualTerminalClient::send_change_attribute(std::uint16_t objectID, std::uint8_t attributeID, std::uint32_t value)
+	{
+		const std::uint8_t buffer[CAN_DATA_LENGTH] = { static_cast<std::uint8_t>(Function::ChangeAttributeCommand),
+			                                             static_cast<std::uint8_t>(objectID & 0xFF),
+			                                             static_cast<std::uint8_t>(objectID >> 8),
+			                                             attributeID,
+			                                             static_cast<std::uint8_t>(value & 0xFF),
+																									 static_cast<std::uint8_t>((value >> 8) & 0xFF),
+																									 static_cast<std::uint8_t>((value >> 16) & 0xFF),
+			                                             static_cast<std::uint8_t>((value >> 24) & 0xFF) };
+		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
+		                                                      buffer,
+		                                                      CAN_DATA_LENGTH,
+		                                                      myControlFunction.get(),
+		                                                      partnerControlFunction.get(),
+		                                                      CANIdentifier::PriorityLowest7);
+	}
+
+	bool VirtualTerminalClient::send_change_priority(std::uint16_t alarmMaskObjectID, AlarmMaskPriority priority)
+	{
+		const std::uint8_t buffer[CAN_DATA_LENGTH] = { static_cast<std::uint8_t>(Function::ChangePriorityCommand),
+			                                             static_cast<std::uint8_t>(alarmMaskObjectID & 0xFF),
+			                                             static_cast<std::uint8_t>(alarmMaskObjectID >> 8),
+			                                             static_cast<std::uint8_t>(priority),
+			                                             0xFF,
+																									 0xFF,
+																									 0xFF,
+			                                             0xFF };
+		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
+		                                                      buffer,
+		                                                      CAN_DATA_LENGTH,
+		                                                      myControlFunction.get(),
+		                                                      partnerControlFunction.get(),
+		                                                      CANIdentifier::PriorityLowest7);
+	}
+
+	bool VirtualTerminalClient::send_change_list_item(std::uint16_t objectID, std::uint8_t listIndex, std::uint16_t newObjectID)
+	{
+		const std::uint8_t buffer[CAN_DATA_LENGTH] = { static_cast<std::uint8_t>(Function::ChangeListItemCommand),
+			                                             static_cast<std::uint8_t>(objectID & 0xFF),
+			                                             static_cast<std::uint8_t>(objectID >> 8),
+			                                             listIndex,
+			                                             static_cast<std::uint8_t>(newObjectID & 0xFF),
+			                                             static_cast<std::uint8_t>(newObjectID >> 8),
+																									 0xFF,
+			                                             0xFF };
+		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
+		                                                      buffer,
+		                                                      CAN_DATA_LENGTH,
+		                                                      myControlFunction.get(),
+		                                                      partnerControlFunction.get(),
+		                                                      CANIdentifier::PriorityLowest7);
+	}
+
+	bool VirtualTerminalClient::send_lock_unlock_mask(MaskLockState state, std::uint16_t objectID, std::uint16_t timeout_ms)
+	{
+		const std::uint8_t buffer[CAN_DATA_LENGTH] = { static_cast<std::uint8_t>(Function::LockUnlockMaskCommand),
+																									 static_cast<std::uint8_t>(state),
+			                                             static_cast<std::uint8_t>(objectID & 0xFF),
+			                                             static_cast<std::uint8_t>(objectID >> 8),
+			                                             static_cast<std::uint8_t>(timeout_ms & 0xFF),
+			                                             static_cast<std::uint8_t>(timeout_ms >> 8),
+																									 0xFF,
+			                                             0xFF };
+		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
+		                                                      buffer,
+		                                                      CAN_DATA_LENGTH,
+		                                                      myControlFunction.get(),
+		                                                      partnerControlFunction.get(),
+		                                                      CANIdentifier::PriorityLowest7);
+	}
+
+	bool VirtualTerminalClient::send_execute_macro(std::uint16_t objectID)
+	{
+		const std::uint8_t buffer[CAN_DATA_LENGTH] = { static_cast<std::uint8_t>(Function::ExecuteMacroCommand),
+																									 static_cast<std::uint8_t>(objectID & 0xFF),
+			                                             static_cast<std::uint8_t>(objectID >> 8),
+			                                             0xFF,
+			                                             0xFF,
+			                                             0xFF,
+																									 0xFF,
+			                                             0xFF };
+		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
+		                                                      buffer,
+		                                                      CAN_DATA_LENGTH,
+		                                                      myControlFunction.get(),
+		                                                      partnerControlFunction.get(),
+		                                                      CANIdentifier::PriorityLowest7);
+	}
+
+	bool VirtualTerminalClient::send_change_object_label(std::uint16_t objectID, std::uint16_t labelStringObjectID, std::uint8_t fontType, std::uint16_t graphicalDesignatorObjectID)
+	{
+		const std::uint8_t buffer[CAN_DATA_LENGTH] = { static_cast<std::uint8_t>(Function::ChangeObjectLabelCommand),
+																									 static_cast<std::uint8_t>(objectID & 0xFF),
+			                                             static_cast<std::uint8_t>(objectID >> 8),
+			                                             static_cast<std::uint8_t>(labelStringObjectID & 0xFF),
+			                                             static_cast<std::uint8_t>(labelStringObjectID >> 8),
+			                                             fontType,
+																									 static_cast<std::uint8_t>(graphicalDesignatorObjectID & 0xFF),
+			                                             static_cast<std::uint8_t>(graphicalDesignatorObjectID >> 8) };
+		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
+		                                                      buffer,
+		                                                      CAN_DATA_LENGTH,
+		                                                      myControlFunction.get(),
+		                                                      partnerControlFunction.get(),
+		                                                      CANIdentifier::PriorityLowest7);
+	}
+
+	bool VirtualTerminalClient::send_change_polygon_point(std::uint16_t objectID, std::uint8_t pointIndex, std::uint16_t newXValue, std::uint16_t newYValue)
+	{
+		const std::uint8_t buffer[CAN_DATA_LENGTH] = { static_cast<std::uint8_t>(Function::ChangePolygonPointCommand),
+																									 static_cast<std::uint8_t>(objectID & 0xFF),
+			                                             static_cast<std::uint8_t>(objectID >> 8),
+																									 pointIndex,
+			                                             static_cast<std::uint8_t>(newXValue & 0xFF),
+			                                             static_cast<std::uint8_t>(newXValue >> 8),
+			                                             static_cast<std::uint8_t>(newYValue & 0xFF),
+			                                             static_cast<std::uint8_t>(newYValue >> 8) };
+		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
+		                                                      buffer,
+		                                                      CAN_DATA_LENGTH,
+		                                                      myControlFunction.get(),
+		                                                      partnerControlFunction.get(),
+		                                                      CANIdentifier::PriorityLowest7);
+	}
+
+	bool VirtualTerminalClient::send_change_polygon_scale(std::uint16_t objectID, std::uint16_t widthAttribute, std::uint16_t heightAttribute)
+	{
+		const std::uint8_t buffer[CAN_DATA_LENGTH] = { static_cast<std::uint8_t>(Function::ChangePolygonScaleCommand),
+																									 static_cast<std::uint8_t>(objectID & 0xFF),
+			                                             static_cast<std::uint8_t>(objectID >> 8),
+																									 static_cast<std::uint8_t>(widthAttribute & 0xFF),
+			                                             static_cast<std::uint8_t>(widthAttribute >> 8),
+			                                             static_cast<std::uint8_t>(heightAttribute & 0xFF),
+			                                             static_cast<std::uint8_t>(heightAttribute >> 8),
+			                                             0xFF };
+		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
+		                                                      buffer,
+		                                                      CAN_DATA_LENGTH,
+		                                                      myControlFunction.get(),
+		                                                      partnerControlFunction.get(),
+		                                                      CANIdentifier::PriorityLowest7);
+	}
+
+	bool VirtualTerminalClient::send_select_color_map_or_palette(std::uint16_t objectID)
+	{
+		const std::uint8_t buffer[CAN_DATA_LENGTH] = { static_cast<std::uint8_t>(Function::SelectColourMapCommand),
+																									 0xFF,
+			                                             0xFF,
+																									 0xFF,
+			                                             0xFF,
+			                                             0xFF,
+			                                             0xFF,
+			                                             0xFF };
+		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
+		                                                      buffer,
+		                                                      CAN_DATA_LENGTH,
+		                                                      myControlFunction.get(),
+		                                                      partnerControlFunction.get(),
+		                                                      CANIdentifier::PriorityLowest7);
+	}
+
+	bool VirtualTerminalClient::send_execute_extended_macro(std::uint16_t objectID)
+	{
+		const std::uint8_t buffer[CAN_DATA_LENGTH] = { static_cast<std::uint8_t>(Function::ExecuteExtendedMacroCommand),
+																									 static_cast<std::uint8_t>(objectID & 0xFF),
+			                                             static_cast<std::uint8_t>(objectID >> 8),
+																									 0xFF,
+			                                             0xFF,
+			                                             0xFF,
+			                                             0xFF,
+			                                             0xFF };
+		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
+		                                                      buffer,
+		                                                      CAN_DATA_LENGTH,
+		                                                      myControlFunction.get(),
+		                                                      partnerControlFunction.get(),
+		                                                      CANIdentifier::PriorityLowest7);
+	}
+
+	bool VirtualTerminalClient::send_select_active_working_set(std::uint64_t NAMEofWorkingSetMasterForDesiredWorkingSet)
+	{
+		const std::uint8_t buffer[9] = { static_cast<std::uint8_t>(Function::SelectActiveWorkingSet),
+																									 static_cast<std::uint8_t>(NAMEofWorkingSetMasterForDesiredWorkingSet & 0xFF),
+			                                             static_cast<std::uint8_t>((NAMEofWorkingSetMasterForDesiredWorkingSet >> 8) & 0xFF),
+																									 static_cast<std::uint8_t>((NAMEofWorkingSetMasterForDesiredWorkingSet >> 16) & 0xFF),
+			                                             static_cast<std::uint8_t>((NAMEofWorkingSetMasterForDesiredWorkingSet >> 24) & 0xFF),
+			                                             static_cast<std::uint8_t>((NAMEofWorkingSetMasterForDesiredWorkingSet >> 32) & 0xFF),
+			                                             static_cast<std::uint8_t>((NAMEofWorkingSetMasterForDesiredWorkingSet >> 40) & 0xFF),
+			                                             static_cast<std::uint8_t>((NAMEofWorkingSetMasterForDesiredWorkingSet >> 48) & 0xFF),
+																									 static_cast<std::uint8_t>((NAMEofWorkingSetMasterForDesiredWorkingSet >> 56) & 0xFF) };
+		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
+		                                                      buffer,
+		                                                      9,
+		                                                      myControlFunction.get(),
+		                                                      partnerControlFunction.get(),
+		                                                      CANIdentifier::PriorityLowest7);
+	}
+
+	VirtualTerminalClient::VTVersion VirtualTerminalClient::get_connected_vt_version() const
+	{
+		VTVersion retVal;
+
+		switch (connectedVTVersion)
+		{
+			case 0x03:
+			{
+				retVal = VTVersion::Version3;
+			}
+			break;
+
+			case 0x04:
+			{
+				retVal = VTVersion::Version4;
+			}
+			break;
+
+			case 0x05:
+			{
+				retVal = VTVersion::Version5;
+			}
+			break;
+
+			case 0x06:
+			{
+				retVal = VTVersion::Version6;
+			}
+			break;
+
+			case 0xFF:
+			{
+				retVal = VTVersion::Version2OrOlder;
+			}
+			break;
+
+			default:
+			{
+				retVal = VTVersion::ReservedOrUnknown;
+			}
+			break;
+		}
+		return retVal;
+	}
+
+	bool VirtualTerminalClient::send_delete_object_pool()
+	{
+		constexpr std::uint8_t buffer[CAN_DATA_LENGTH] = { static_cast<std::uint8_t>(Function::DeleteObjectPoolCommand),
+																									 0xFF,
+			                                             0xFF,
+			                                             0xFF,
+			                                             0xFF,
+			                                             0xFF,
+																									 0xFF,
+			                                             0xFF };
+		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
+		                                                      buffer,
+		                                                      CAN_DATA_LENGTH,
+		                                                      myControlFunction.get(),
+		                                                      partnerControlFunction.get(),
+		                                                      CANIdentifier::PriorityLowest7);
+	}
+
+	bool VirtualTerminalClient::send_working_set_maintenance(bool initializing, VTVersion workingSetVersion)
+	{
+		std::uint8_t versionByte;
+		std::uint8_t bitmask = (initializing ? 0x01 : 0x00);
+
+		switch (workingSetVersion)
+		{
+			case VTVersion::Version3:
+			{
+				versionByte = 0x03;
+			}
+			break;
+
+			case VTVersion::Version4:
+			{
+				versionByte = 0x04;
+			}
+			break;
+
+			case VTVersion::Version5:
+			{
+				versionByte = 0x05;
+			}
+			break;
+
+			case VTVersion::Version6:
+			{
+				versionByte = 0x06;
+			}
+			break;
+
+			default:
+			{
+				versionByte = 0xFF;
+			}
+			break;
+		}
+
+		const std::uint8_t buffer[CAN_DATA_LENGTH] = { static_cast<std::uint8_t>(Function::WorkingSetMaintenanceMessage),
+																									 bitmask,
+			                                             versionByte,
+			                                             0xFF,
+			                                             0xFF,
+			                                             0xFF,
+																									 0xFF,
+			                                             0xFF };
+		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
+		                                                      buffer,
+		                                                      CAN_DATA_LENGTH,
+		                                                      myControlFunction.get(),
+		                                                      partnerControlFunction.get(),
+		                                                      CANIdentifier::PriorityLowest7);
+	}
+
+} // namespace isobus

--- a/utility/CMakeLists.txt
+++ b/utility/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SYSTEM_TIMING_INCLUDE_DIR "include")
 # Set source files 
 set(SYSTEM_TIMING_SRC 
   "system_timing.cpp"
+  "processing_flags.cpp"
 )
 
 # Prepend the source directory path to all the source files
@@ -18,6 +19,7 @@ PREPEND(SYSTEM_TIMING_SRC ${SYSTEM_TIMING_SRC_DIR} ${SYSTEM_TIMING_SRC})
 # Set the include files
 set(SYSTEM_TIMING_INCLUDE 
   "system_timing.hpp"
+  "processing_flags.hpp"
 )
 
 # Prepend the include directory path to all the include files

--- a/utility/include/processing_flags.hpp
+++ b/utility/include/processing_flags.hpp
@@ -1,0 +1,35 @@
+//================================================================================================
+/// @file processing_flags.hpp
+///
+/// @brief A class that manages 1 bit flags. Handy as a retry machanism for sending CAN messages.
+/// @author Adrian Del Grosso
+///
+/// @copyright 2022 Adrian Del Grosso
+//================================================================================================
+#ifndef PROCESSING_FLAGS_HPP
+#define PROCESSING_FLAGS_HPP
+
+#include <cstdint>
+
+namespace isobus
+{
+	class ProcessingFlags
+	{
+	public:
+		typedef void (*ProcessFlagsCallback)(std::uint32_t flag, void *parentPointer);
+
+		ProcessingFlags(std::uint32_t numberOfFlags, ProcessFlagsCallback processingCallback, void *parentPointer);
+		~ProcessingFlags();
+
+		void set_flag(std::uint32_t flag);
+		void process_all_flags();
+
+	private:
+		ProcessFlagsCallback callback;
+		const std::uint32_t maxFlag;
+		std::uint8_t *flagBitfield;
+		void *parent;
+	};
+} // namespace isobus
+
+#endif // PROCESSING_FLAGS_HPP

--- a/utility/include/system_timing.hpp
+++ b/utility/include/system_timing.hpp
@@ -1,25 +1,34 @@
+//================================================================================================
+/// @file system_timing.cpp
+///
+/// @brief Utility class for getting system time and handling u32 time rollover
+/// @author Adrian Del Grosso
+///
+/// @copyright 2022 Adrian Del Grosso
+//================================================================================================
+
 #include <cstdint>
 
 namespace isobus
 {
 
-class SystemTiming
-{
-public:
-    static std::uint32_t get_timestamp_ms();
-    static std::uint64_t get_timestamp_us();
+	class SystemTiming
+	{
+	public:
+		static std::uint32_t get_timestamp_ms();
+		static std::uint64_t get_timestamp_us();
 
-    static std::uint32_t get_time_elapsed_ms(std::uint32_t timestamp_ms);
-    static std::uint64_t get_time_elapsed_us(std::uint64_t timestamp_us);
+		static std::uint32_t get_time_elapsed_ms(std::uint32_t timestamp_ms);
+		static std::uint64_t get_time_elapsed_us(std::uint64_t timestamp_us);
 
-    static bool time_expired_ms(std::uint32_t timestamp_ms, std::uint32_t timeout_ms);
-    static bool time_expired_us(std::uint64_t timestamp_us, std::uint64_t timeout_us);
+		static bool time_expired_ms(std::uint32_t timestamp_ms, std::uint32_t timeout_ms);
+		static bool time_expired_us(std::uint64_t timestamp_us, std::uint64_t timeout_us);
 
-private:
-    static std::uint32_t incrementing_difference(std::uint32_t currentValue, std::uint32_t previousValue);
-    static std::uint64_t incrementing_difference(std::uint64_t currentValue, std::uint64_t previousValue);
-    static std::uint64_t s_timestamp_ms;
-    static std::uint64_t s_timestamp_us;
-};
+	private:
+		static std::uint32_t incrementing_difference(std::uint32_t currentValue, std::uint32_t previousValue);
+		static std::uint64_t incrementing_difference(std::uint64_t currentValue, std::uint64_t previousValue);
+		static std::uint64_t s_timestamp_ms;
+		static std::uint64_t s_timestamp_us;
+	};
 
 } // namespace isobus

--- a/utility/src/processing_flags.cpp
+++ b/utility/src/processing_flags.cpp
@@ -1,0 +1,62 @@
+//================================================================================================
+/// @file processing_flags.cpp
+///
+/// @brief A class that manages 1 bit flags. Handy as a retry machanism for sending CAN messages.
+/// @author Adrian Del Grosso
+///
+/// @copyright 2022 Adrian Del Grosso
+//================================================================================================
+
+#include "processing_flags.hpp"
+
+#include <cstring>
+
+namespace isobus
+{
+	ProcessingFlags::ProcessingFlags(std::uint32_t numberOfFlags, ProcessFlagsCallback processingCallback, void *parentPointer) :
+	  callback(processingCallback),
+	  maxFlag(numberOfFlags),
+	  flagBitfield(nullptr),
+	  parent(parentPointer)
+	{
+		const std::uint32_t numberBytes = (numberOfFlags / 8) + 1;
+		flagBitfield = new std::uint8_t[numberBytes];
+		memset(flagBitfield, 0, numberBytes);
+	}
+
+	ProcessingFlags ::~ProcessingFlags()
+	{
+		delete[] flagBitfield;
+		flagBitfield = nullptr;
+	}
+
+	void ProcessingFlags::set_flag(std::uint32_t flag)
+	{
+		if (flag <= maxFlag)
+		{
+			flagBitfield[(flag / 8)] |= (1 << (flag % 8));
+		}
+	}
+
+	void ProcessingFlags::process_all_flags()
+	{
+		const std::uint32_t numberBytes = (maxFlag / 8) + 1;
+
+		for (std::uint32_t i = 0; i < numberBytes; i++)
+		{
+			if (flagBitfield[i])
+			{
+				for (std::uint8_t j = 0; j < 8; j++)
+				{
+					std::uint8_t currentFlag = (flagBitfield[i] & (1 << j));
+
+					if (currentFlag)
+					{
+						flagBitfield[i] &= ~(currentFlag);
+						callback((8 * i) + j, parent);
+					}
+				}
+			}
+		}
+	}
+} // namespace isobus

--- a/utility/src/system_timing.cpp
+++ b/utility/src/system_timing.cpp
@@ -1,3 +1,12 @@
+//================================================================================================
+/// @file system_timing.cpp
+///
+/// @brief Utility class for getting system time and handling u32 time rollover
+/// @author Adrian Del Grosso
+///
+/// @copyright 2022 Adrian Del Grosso
+//================================================================================================
+
 #include "system_timing.hpp"
 
 #include <chrono>


### PR DESCRIPTION
This is the first major ISO11783 feature for this project!
Currently only object pools that are able to be uploaded by transport protocol (<= 1785 bytes) or pools that can be split up into 1785 byte size chunks are supported. ETP support is coming next.
I have tried to include functions all the way up to VT version 6 where it was easily doable, and support event based callbacks from VT events, like button presses or soft key presses. But providing the object pools themselves is up to whomever is using the client class. I would be happy to make an example for this and add it to the repo if someone has some non-copyrighted or MIT licensed object pools that I could commit to the repo.
If you or someone you know is interested in helping me test this VT functionality, please reach out. I am in need of IOP files to test against, and VT servers to upload pools to. If you have the equipment to test this whole data path yourself and provide meaningful feedback in the form of issue reports, that's very helpful! Any help I can get will be welcomed provided that you follow the GitHub community guidelines and any contribution/code of conduct info for this project (I will probably push an update for these soon).