### PR TITLE
Fixed receiving TP connection mode messages

### DIFF
--- a/isobus/include/can_transport_protocol.hpp
+++ b/isobus/include/can_transport_protocol.hpp
@@ -84,6 +84,7 @@ namespace isobus
 			std::uint16_t lastPacketNumber; ///< The last processed sequence number for this set of packets
 			std::uint8_t packetCount; ///< The total number of packets to receive or send in this session
 			std::uint8_t processedPacketsThisSession; ///< The total processed packet count for the whole session so far
+			std::uint8_t clearToSendPacketMax; ///< The max packets that can be sent per CTS as indicated by the RTS message
 			const Direction sessionDirection; ///< Represents Tx or Rx session
 		};
 
@@ -181,6 +182,11 @@ namespace isobus
 		/// @param[in] session The session we've just completed
 		/// @param[in] success Denotes if the session was successful
 		void process_session_complete_callback(TransportProtocolSession *session, bool success);
+
+		/// @brief Sends the "clear to send" message
+		/// @param[in] session The session for which we're sending the CTS
+		/// @returns true if the CTS was sent, false if sending was not successful
+		bool send_clear_to_send(TransportProtocolSession *session);
 
 		/// @brief Sends the "request to send" message as part of initiating a transmit
 		/// @param[in] session The session for which we're sending the RTS

--- a/isobus/include/can_transport_protocol.hpp
+++ b/isobus/include/can_transport_protocol.hpp
@@ -129,7 +129,7 @@ namespace isobus
 		void initialize(CANLibBadge<CANNetworkManager>) override;
 
 		/// @brief A generic way for a protocol to process a received message
-		/// @param[in] message A received CAN message 
+		/// @param[in] message A received CAN message
 		void process_message(CANMessage *const message) override;
 
 		/// @brief A generic way for a protocol to process a received message

--- a/isobus/src/can_transport_protocol.cpp
+++ b/isobus/src/can_transport_protocol.cpp
@@ -12,8 +12,8 @@
 
 #include "can_general_parameter_group_numbers.hpp"
 #include "can_network_configuration.hpp"
-#include "system_timing.hpp"
 #include "can_warning_logger.hpp"
+#include "system_timing.hpp"
 
 #include <algorithm>
 
@@ -36,16 +36,15 @@ namespace isobus
 	{
 	}
 
-	bool TransportProtocolManager::TransportProtocolSession::operator==(const TransportProtocolSession& obj)
+	bool TransportProtocolManager::TransportProtocolSession::operator==(const TransportProtocolSession &obj)
 	{
 		return ((sessionMessage.get_source_control_function() == obj.sessionMessage.get_source_control_function()) &&
-			    (sessionMessage.get_destination_control_function() == obj.sessionMessage.get_destination_control_function()) &&
-			    (sessionMessage.get_identifier().get_parameter_group_number() == obj.sessionMessage.get_identifier().get_parameter_group_number()));
+		        (sessionMessage.get_destination_control_function() == obj.sessionMessage.get_destination_control_function()) &&
+		        (sessionMessage.get_identifier().get_parameter_group_number() == obj.sessionMessage.get_identifier().get_parameter_group_number()));
 	}
 
 	TransportProtocolManager::TransportProtocolSession::~TransportProtocolSession()
 	{
-
 	}
 
 	TransportProtocolManager::TransportProtocolManager()
@@ -54,22 +53,22 @@ namespace isobus
 
 	TransportProtocolManager::~TransportProtocolManager()
 	{
-        if (initialized)
-        {
-            CANNetworkManager::CANNetwork.remove_protocol_parameter_group_number_callback(static_cast<std::uint32_t>(CANLibParameterGroupNumber::TransportProtocolCommand), process_message, this);
-            CANNetworkManager::CANNetwork.remove_protocol_parameter_group_number_callback(static_cast<std::uint32_t>(CANLibParameterGroupNumber::TransportProtocolData), process_message, this);
-        }
+		if (initialized)
+		{
+			CANNetworkManager::CANNetwork.remove_protocol_parameter_group_number_callback(static_cast<std::uint32_t>(CANLibParameterGroupNumber::TransportProtocolCommand), process_message, this);
+			CANNetworkManager::CANNetwork.remove_protocol_parameter_group_number_callback(static_cast<std::uint32_t>(CANLibParameterGroupNumber::TransportProtocolData), process_message, this);
+		}
 	}
 
-    void TransportProtocolManager::initialize(CANLibBadge<CANNetworkManager>)
-    {
-        if (!initialized)
-        {
-            initialized = true;
-            CANNetworkManager::CANNetwork.add_protocol_parameter_group_number_callback(static_cast<std::uint32_t>(CANLibParameterGroupNumber::TransportProtocolCommand), process_message, this);
-            CANNetworkManager::CANNetwork.add_protocol_parameter_group_number_callback(static_cast<std::uint32_t>(CANLibParameterGroupNumber::TransportProtocolData), process_message, this);
-        }
-    }
+	void TransportProtocolManager::initialize(CANLibBadge<CANNetworkManager>)
+	{
+		if (!initialized)
+		{
+			initialized = true;
+			CANNetworkManager::CANNetwork.add_protocol_parameter_group_number_callback(static_cast<std::uint32_t>(CANLibParameterGroupNumber::TransportProtocolCommand), process_message, this);
+			CANNetworkManager::CANNetwork.add_protocol_parameter_group_number_callback(static_cast<std::uint32_t>(CANLibParameterGroupNumber::TransportProtocolData), process_message, this);
+		}
+	}
 
 	void TransportProtocolManager::process_message(CANMessage *const message)
 	{
@@ -79,195 +78,195 @@ namespace isobus
 			{
 				case static_cast<std::uint32_t>(CANLibParameterGroupNumber::TransportProtocolCommand):
 				{
-					switch(message->get_data()[0])
+					switch (message->get_data()[0])
 					{
-							case BROADCAST_ANNOUNCE_MESSAGE_MULTIPLEXOR:
+						case BROADCAST_ANNOUNCE_MESSAGE_MULTIPLEXOR:
+						{
+							if (CAN_DATA_LENGTH == message->get_data_length())
 							{
-								if (CAN_DATA_LENGTH == message->get_data_length())
-								{
-									auto data = message->get_data();
-									TransportProtocolSession *session;
-									const std::uint32_t pgn = (static_cast<std::uint32_t>(data[5]) | (static_cast<std::uint32_t>(data[6]) << 8) | (static_cast<std::uint32_t>(data[7]) << 16));
+								auto data = message->get_data();
+								TransportProtocolSession *session;
+								const std::uint32_t pgn = (static_cast<std::uint32_t>(data[5]) | (static_cast<std::uint32_t>(data[6]) << 8) | (static_cast<std::uint32_t>(data[7]) << 16));
 
-									if ((nullptr == message->get_destination_control_function()) &&
-										(activeSessions.size() < CANNetworkConfiguration::get_max_number_transport_protcol_sessions()) &&
-										(!get_session(session, message->get_source_control_function(), message->get_destination_control_function(), pgn)))
-									{
-										TransportProtocolSession *newSession = new TransportProtocolSession(TransportProtocolSession::Direction::Receive, message->get_can_port_index());
-										CANIdentifier tempIdentifierData(CANIdentifier::Type::Extended, pgn, CANIdentifier::CANPriority::PriorityLowest7, BROADCAST_CAN_ADDRESS, message->get_source_control_function()->get_address());
-										newSession->sessionMessage.set_data_size(static_cast<std::uint16_t>(data[1]) | static_cast<std::uint16_t>(data[2] << 8));
-										newSession->sessionMessage.set_source_control_function(message->get_source_control_function());
-										newSession->sessionMessage.set_destination_control_function(nullptr);
-										newSession->packetCount = data[3];
-										newSession->sessionMessage.set_identifier(tempIdentifierData);
-										newSession->state = StateMachineState::RxDataSession;
-										newSession->timestamp_ms = SystemTiming::get_timestamp_ms();
-										activeSessions.push_back(newSession);
-										CANStackLogger::CAN_stack_log("[TP]: New BAM Session. Source: " + std::to_string(static_cast<int>(newSession->sessionMessage.get_source_control_function()->get_address())));
-									}
-									else
-									{
-										// Don't send an abort, they're probably expecting a CTS so it'll timeout
-										// Or maybe if we already had a session they sent a second BAM? Also bad
-										CANStackLogger::CAN_stack_log("[TP]: Can't Create BAM session");
-									}
+								if ((nullptr == message->get_destination_control_function()) &&
+								    (activeSessions.size() < CANNetworkConfiguration::get_max_number_transport_protcol_sessions()) &&
+								    (!get_session(session, message->get_source_control_function(), message->get_destination_control_function(), pgn)))
+								{
+									TransportProtocolSession *newSession = new TransportProtocolSession(TransportProtocolSession::Direction::Receive, message->get_can_port_index());
+									CANIdentifier tempIdentifierData(CANIdentifier::Type::Extended, pgn, CANIdentifier::CANPriority::PriorityLowest7, BROADCAST_CAN_ADDRESS, message->get_source_control_function()->get_address());
+									newSession->sessionMessage.set_data_size(static_cast<std::uint16_t>(data[1]) | static_cast<std::uint16_t>(data[2] << 8));
+									newSession->sessionMessage.set_source_control_function(message->get_source_control_function());
+									newSession->sessionMessage.set_destination_control_function(nullptr);
+									newSession->packetCount = data[3];
+									newSession->sessionMessage.set_identifier(tempIdentifierData);
+									newSession->state = StateMachineState::RxDataSession;
+									newSession->timestamp_ms = SystemTiming::get_timestamp_ms();
+									activeSessions.push_back(newSession);
+									CANStackLogger::CAN_stack_log("[TP]: New BAM Session. Source: " + std::to_string(static_cast<int>(newSession->sessionMessage.get_source_control_function()->get_address())));
 								}
 								else
 								{
-									CANStackLogger::CAN_stack_log("[TP]: Bad BAM Message Length");
+									// Don't send an abort, they're probably expecting a CTS so it'll timeout
+									// Or maybe if we already had a session they sent a second BAM? Also bad
+									CANStackLogger::CAN_stack_log("[TP]: Can't Create BAM session");
 								}
 							}
-							break;
-							
-							case REQUEST_TO_SEND_MULTIPLEXOR:
+							else
 							{
-								if (CAN_DATA_LENGTH == message->get_data_length())
-								{
-									TransportProtocolSession *session;
-									auto data = message->get_data();
-									const std::uint32_t pgn = (static_cast<std::uint32_t>(data[5]) | (static_cast<std::uint32_t>(data[6]) << 8) | (static_cast<std::uint32_t>(data[7]) << 16));
+								CANStackLogger::CAN_stack_log("[TP]: Bad BAM Message Length");
+							}
+						}
+						break;
 
-									if ((nullptr != message->get_destination_control_function()) &&
-										(activeSessions.size() < CANNetworkConfiguration::get_max_number_transport_protcol_sessions()) &&
-										(!get_session(session, message->get_source_control_function(), message->get_destination_control_function(), pgn)))
-									{
-										TransportProtocolSession *newSession = new TransportProtocolSession(TransportProtocolSession::Direction::Receive, message->get_can_port_index());
-										CANIdentifier tempIdentifierData(CANIdentifier::Type::Extended, pgn, CANIdentifier::CANPriority::PriorityLowest7, message->get_destination_control_function()->get_address(), message->get_source_control_function()->get_address());
-										newSession->sessionMessage.set_data_size(static_cast<std::uint16_t>(data[1]) | static_cast<std::uint16_t>(data[2] << 8));
-										newSession->sessionMessage.set_source_control_function(message->get_source_control_function());
-										newSession->sessionMessage.set_destination_control_function(message->get_destination_control_function());
-										newSession->packetCount = data[3];
+						case REQUEST_TO_SEND_MULTIPLEXOR:
+						{
+							if (CAN_DATA_LENGTH == message->get_data_length())
+							{
+								TransportProtocolSession *session;
+								auto data = message->get_data();
+								const std::uint32_t pgn = (static_cast<std::uint32_t>(data[5]) | (static_cast<std::uint32_t>(data[6]) << 8) | (static_cast<std::uint32_t>(data[7]) << 16));
+
+								if ((nullptr != message->get_destination_control_function()) &&
+								    (activeSessions.size() < CANNetworkConfiguration::get_max_number_transport_protcol_sessions()) &&
+								    (!get_session(session, message->get_source_control_function(), message->get_destination_control_function(), pgn)))
+								{
+									TransportProtocolSession *newSession = new TransportProtocolSession(TransportProtocolSession::Direction::Receive, message->get_can_port_index());
+									CANIdentifier tempIdentifierData(CANIdentifier::Type::Extended, pgn, CANIdentifier::CANPriority::PriorityLowest7, message->get_destination_control_function()->get_address(), message->get_source_control_function()->get_address());
+									newSession->sessionMessage.set_data_size(static_cast<std::uint16_t>(data[1]) | static_cast<std::uint16_t>(data[2] << 8));
+									newSession->sessionMessage.set_source_control_function(message->get_source_control_function());
+									newSession->sessionMessage.set_destination_control_function(message->get_destination_control_function());
+									newSession->packetCount = data[3];
 									newSession->clearToSendPacketMax = data[4];
-										newSession->sessionMessage.set_identifier(tempIdentifierData);
+									newSession->sessionMessage.set_identifier(tempIdentifierData);
 									newSession->state = StateMachineState::ClearToSend;
-										newSession->timestamp_ms = SystemTiming::get_timestamp_ms();
-										activeSessions.push_back(newSession);
-									}
-									else if ((get_session(session, message->get_source_control_function(), message->get_destination_control_function(), pgn)) &&
-											(nullptr != message->get_destination_control_function()) &&
-											(ControlFunction::Type::Internal == message->get_destination_control_function()->get_type()))
-									{
-										abort_session(pgn, ConnectionAbortReason::AlreadyInCMSession, reinterpret_cast<InternalControlFunction *>(message->get_destination_control_function()), message->get_source_control_function());
-										CANStackLogger::CAN_stack_log("[TP]: Abort RTS when already in CM session");
-									}
-									else if ((activeSessions.size() >= CANNetworkConfiguration::get_max_number_transport_protcol_sessions()) &&
-											(nullptr != message->get_destination_control_function()) &&
-											(ControlFunction::Type::Internal == message->get_destination_control_function()->get_type()))
-									{
-										abort_session(pgn, ConnectionAbortReason::SystemResourcesNeeded, reinterpret_cast<InternalControlFunction *>(message->get_destination_control_function()), message->get_source_control_function());
-										CANStackLogger::CAN_stack_log("[TP]: Abort No Sessions Available");
-									}
+									newSession->timestamp_ms = SystemTiming::get_timestamp_ms();
+									activeSessions.push_back(newSession);
 								}
-								else
+								else if ((get_session(session, message->get_source_control_function(), message->get_destination_control_function(), pgn)) &&
+								         (nullptr != message->get_destination_control_function()) &&
+								         (ControlFunction::Type::Internal == message->get_destination_control_function()->get_type()))
 								{
-									// Bad RTS message length. Can't really abort? Not sure what the PGN is if length < 8
-									CANStackLogger::CAN_stack_log("[TP]: Bad Message Length");
+									abort_session(pgn, ConnectionAbortReason::AlreadyInCMSession, reinterpret_cast<InternalControlFunction *>(message->get_destination_control_function()), message->get_source_control_function());
+									CANStackLogger::CAN_stack_log("[TP]: Abort RTS when already in CM session");
+								}
+								else if ((activeSessions.size() >= CANNetworkConfiguration::get_max_number_transport_protcol_sessions()) &&
+								         (nullptr != message->get_destination_control_function()) &&
+								         (ControlFunction::Type::Internal == message->get_destination_control_function()->get_type()))
+								{
+									abort_session(pgn, ConnectionAbortReason::SystemResourcesNeeded, reinterpret_cast<InternalControlFunction *>(message->get_destination_control_function()), message->get_source_control_function());
+									CANStackLogger::CAN_stack_log("[TP]: Abort No Sessions Available");
 								}
 							}
-							break;
-
-							case CLEAR_TO_SEND_MULTIPLEXOR:
+							else
 							{
-								// Can't happen when doing a BAM session, make sure the session type is correct
-								if ((CAN_DATA_LENGTH == message->get_data_length()) &&
-									(nullptr != message->get_destination_control_function()) &&
-									(nullptr != message->get_source_control_function()))
-								{
-									TransportProtocolSession *session;
-									auto data = message->get_data();
-									const std::uint32_t pgn = (static_cast<std::uint32_t>(data[5]) | (static_cast<std::uint32_t>(data[6]) << 8) | (static_cast<std::uint32_t>(data[7]) << 16));
-									const std::uint8_t packetsToBeSent = data[1];
+								// Bad RTS message length. Can't really abort? Not sure what the PGN is if length < 8
+								CANStackLogger::CAN_stack_log("[TP]: Bad Message Length");
+							}
+						}
+						break;
 
-									if (get_session(session, message->get_destination_control_function(), message->get_source_control_function(), pgn))
+						case CLEAR_TO_SEND_MULTIPLEXOR:
+						{
+							// Can't happen when doing a BAM session, make sure the session type is correct
+							if ((CAN_DATA_LENGTH == message->get_data_length()) &&
+							    (nullptr != message->get_destination_control_function()) &&
+							    (nullptr != message->get_source_control_function()))
+							{
+								TransportProtocolSession *session;
+								auto data = message->get_data();
+								const std::uint32_t pgn = (static_cast<std::uint32_t>(data[5]) | (static_cast<std::uint32_t>(data[6]) << 8) | (static_cast<std::uint32_t>(data[7]) << 16));
+								const std::uint8_t packetsToBeSent = data[1];
+
+								if (get_session(session, message->get_destination_control_function(), message->get_source_control_function(), pgn))
+								{
+									if (StateMachineState::WaitForClearToSend == session->state)
 									{
-										if (StateMachineState::WaitForClearToSend == session->state)
+										session->packetCount = packetsToBeSent;
+										session->timestamp_ms = SystemTiming::get_timestamp_ms();
+										// If 0 was sent as the packet number, they want us to wait.
+										// Just sit here in this state until we get a non-zero packet count
+										if (0 != packetsToBeSent)
 										{
-											session->packetCount = packetsToBeSent;
-											session->timestamp_ms = SystemTiming::get_timestamp_ms();
-											// If 0 was sent as the packet number, they want us to wait.
-											// Just sit here in this state until we get a non-zero packet count
-											if (0 != packetsToBeSent)
-											{
-												session->lastPacketNumber = 0;
-												session->state = StateMachineState::TxDataSession;
-											}
-										}
-										else
-										{
-											// The session exists, but we're probably already in the TxDataSession state. Need to abort
-											// In the case of Rx'ing a CTS, we're the source in the session
-											abort_session(pgn, ConnectionAbortReason::ClearToSendReceivedWhileTransferInProgress, reinterpret_cast<InternalControlFunction *>(message->get_destination_control_function()), message->get_source_control_function());
-											CANStackLogger::CAN_stack_log("[TP]: Abort CTS while in data session");
+											session->lastPacketNumber = 0;
+											session->state = StateMachineState::TxDataSession;
 										}
 									}
 									else
 									{
-										// We got a CTS but no session exists. Aborting clears up the situation faster than waiting for them to timeout
+										// The session exists, but we're probably already in the TxDataSession state. Need to abort
 										// In the case of Rx'ing a CTS, we're the source in the session
-										abort_session(pgn, ConnectionAbortReason::AnyOtherError, reinterpret_cast<InternalControlFunction *>(message->get_destination_control_function()), message->get_source_control_function());
-										CANStackLogger::CAN_stack_log("[TP]: Abort CTS With no matching session");
+										abort_session(pgn, ConnectionAbortReason::ClearToSendReceivedWhileTransferInProgress, reinterpret_cast<InternalControlFunction *>(message->get_destination_control_function()), message->get_source_control_function());
+										CANStackLogger::CAN_stack_log("[TP]: Abort CTS while in data session");
 									}
 								}
 								else
 								{
-									CANStackLogger::CAN_stack_log("[TP]: Invalid CTS");
+									// We got a CTS but no session exists. Aborting clears up the situation faster than waiting for them to timeout
+									// In the case of Rx'ing a CTS, we're the source in the session
+									abort_session(pgn, ConnectionAbortReason::AnyOtherError, reinterpret_cast<InternalControlFunction *>(message->get_destination_control_function()), message->get_source_control_function());
+									CANStackLogger::CAN_stack_log("[TP]: Abort CTS With no matching session");
 								}
 							}
-							break;
-
-							case END_OF_MESSAGE_ACKNOWLEDGE_MULTIPLEXOR:
+							else
 							{
-								// Can't happen when doing a BAM session, make sure the session type is correct
-								if ((CAN_DATA_LENGTH == message->get_data_length()) &&
-									(nullptr != message->get_destination_control_function()) &&
-									(nullptr != message->get_source_control_function()))
+								CANStackLogger::CAN_stack_log("[TP]: Invalid CTS");
+							}
+						}
+						break;
+
+						case END_OF_MESSAGE_ACKNOWLEDGE_MULTIPLEXOR:
+						{
+							// Can't happen when doing a BAM session, make sure the session type is correct
+							if ((CAN_DATA_LENGTH == message->get_data_length()) &&
+							    (nullptr != message->get_destination_control_function()) &&
+							    (nullptr != message->get_source_control_function()))
+							{
+								TransportProtocolSession *session;
+								auto data = message->get_data();
+								const std::uint32_t pgn = (static_cast<std::uint32_t>(data[5]) | (static_cast<std::uint32_t>(data[6]) << 8) | (static_cast<std::uint32_t>(data[7]) << 16));
+
+								if (get_session(session, message->get_destination_control_function(), message->get_source_control_function(), pgn))
 								{
-									TransportProtocolSession *session;
-									auto data = message->get_data();
-									const std::uint32_t pgn = (static_cast<std::uint32_t>(data[5]) | (static_cast<std::uint32_t>(data[6]) << 8) | (static_cast<std::uint32_t>(data[7]) << 16));
-									
-									if (get_session(session, message->get_destination_control_function(), message->get_source_control_function(), pgn))
+									if (StateMachineState::WaitForEndOfMessageAcknowledge == session->state)
 									{
-										if (StateMachineState::WaitForEndOfMessageAcknowledge == session->state)
-										{
-											// We completed our Tx session!
-											session->state = StateMachineState::None;
-											process_session_complete_callback(session, true);
-											close_session(session);
-										}
-										else
-										{
-											abort_session(pgn, ConnectionAbortReason::AnyOtherError, reinterpret_cast<InternalControlFunction *>(message->get_destination_control_function()), message->get_source_control_function());
-											process_session_complete_callback(session, false);
-											close_session(session);
-											CANStackLogger::CAN_stack_log("[TP]: Abort EOM in wrong session state");
-										}
+										// We completed our Tx session!
+										session->state = StateMachineState::None;
+										process_session_complete_callback(session, true);
+										close_session(session);
 									}
 									else
 									{
 										abort_session(pgn, ConnectionAbortReason::AnyOtherError, reinterpret_cast<InternalControlFunction *>(message->get_destination_control_function()), message->get_source_control_function());
-										CANStackLogger::CAN_stack_log("[TP]: Abort EOM without matching session");
+										process_session_complete_callback(session, false);
+										close_session(session);
+										CANStackLogger::CAN_stack_log("[TP]: Abort EOM in wrong session state");
 									}
 								}
 								else
 								{
-									CANStackLogger::CAN_stack_log("[TP]: Bad EOM received");
+									abort_session(pgn, ConnectionAbortReason::AnyOtherError, reinterpret_cast<InternalControlFunction *>(message->get_destination_control_function()), message->get_source_control_function());
+									CANStackLogger::CAN_stack_log("[TP]: Abort EOM without matching session");
 								}
 							}
-							break;
-
-							case CONNECTION_ABORT_MULTIPLEXOR:
+							else
 							{
-								CANStackLogger::CAN_stack_log("[TP]: Received an abort");
+								CANStackLogger::CAN_stack_log("[TP]: Bad EOM received");
 							}
-							break;
+						}
+						break;
 
-							default:
-							{
-								CANStackLogger::CAN_stack_log("[TP]: Bad Mux in Transport Protocol Command");
-							}
-							break;
-           }
+						case CONNECTION_ABORT_MULTIPLEXOR:
+						{
+							CANStackLogger::CAN_stack_log("[TP]: Received an abort");
+						}
+						break;
+
+						default:
+						{
+							CANStackLogger::CAN_stack_log("[TP]: Bad Mux in Transport Protocol Command");
+						}
+						break;
+					}
 				}
 				break;
 
@@ -281,9 +280,9 @@ namespace isobus
 					}
 
 					if ((CAN_DATA_LENGTH == message->get_data_length()) &&
-						(get_session(tempSession, message->get_source_control_function(), message->get_destination_control_function())) &&
-						(StateMachineState::RxDataSession == tempSession->state) &&
-						(message->get_data()[SEQUENCE_NUMBER_DATA_INDEX] == (tempSession->lastPacketNumber + 1)))
+					    (get_session(tempSession, message->get_source_control_function(), message->get_destination_control_function())) &&
+					    (StateMachineState::RxDataSession == tempSession->state) &&
+					    (message->get_data()[SEQUENCE_NUMBER_DATA_INDEX] == (tempSession->lastPacketNumber + 1)))
 					{
 						for (std::uint8_t i = SEQUENCE_NUMBER_DATA_INDEX; i < CAN_DATA_LENGTH; i++)
 						{
@@ -318,8 +317,8 @@ namespace isobus
 
 				default:
 				{
-                    // This is not a runtime error, should never happen.
-                    // Bad PGN passed to protocol. Check PGN registrations.
+					// This is not a runtime error, should never happen.
+					// Bad PGN passed to protocol. Check PGN registrations.
 					CANStackLogger::CAN_stack_log("[TP]: Received an unexpected PGN");
 				}
 				break;
@@ -327,35 +326,35 @@ namespace isobus
 		}
 	}
 
-    void TransportProtocolManager::process_message(CANMessage *const message, void *parent)
-    {
-        if (nullptr != parent)
-        {
-            reinterpret_cast<TransportProtocolManager *>(parent)->process_message(message);
-        }
-    }
+	void TransportProtocolManager::process_message(CANMessage *const message, void *parent)
+	{
+		if (nullptr != parent)
+		{
+			reinterpret_cast<TransportProtocolManager *>(parent)->process_message(message);
+		}
+	}
 
 	bool TransportProtocolManager::protocol_transmit_message(std::uint32_t parameterGroupNumber,
-		                               const std::uint8_t *dataBuffer,
-		                               std::uint32_t messageLength,
-		                               ControlFunction *source,
-		                               ControlFunction *destination,
-	                                   TransmitCompleteCallback sessionCompleteCallback,
-									   void *parentPointer,
-	                                   DataChunkCallback frameChunkCallback)
+	                                                         const std::uint8_t *dataBuffer,
+	                                                         std::uint32_t messageLength,
+	                                                         ControlFunction *source,
+	                                                         ControlFunction *destination,
+	                                                         TransmitCompleteCallback sessionCompleteCallback,
+	                                                         void *parentPointer,
+	                                                         DataChunkCallback frameChunkCallback)
 	{
 		TransportProtocolSession *session;
 		bool retVal = false;
 
 		if ((messageLength < MAX_PROTOCOL_DATA_LENGTH) &&
-			(messageLength > 8) &&
-		    ((nullptr != dataBuffer) || 
-			(nullptr != frameChunkCallback)) &&
-			(nullptr != source) &&
-			(true == source->get_address_valid()) &&
-			((nullptr == destination) || 
-			 (destination->get_address_valid())) &&
-			 (!get_session(session, source, destination, parameterGroupNumber)))
+		    (messageLength > 8) &&
+		    ((nullptr != dataBuffer) ||
+		     (nullptr != frameChunkCallback)) &&
+		    (nullptr != source) &&
+		    (true == source->get_address_valid()) &&
+		    ((nullptr == destination) ||
+		     (destination->get_address_valid())) &&
+		    (!get_session(session, source, destination, parameterGroupNumber)))
 		{
 			TransportProtocolSession *newSession = new TransportProtocolSession(TransportProtocolSession::Direction::Transmit,
 			                                                                    source->get_can_port());
@@ -423,14 +422,14 @@ namespace isobus
 			data[3] = 0xFF;
 			data[4] = 0xFF;
 			data[5] = static_cast<std::uint8_t>(pgn & 0xFF);
-			data[6] = static_cast<std::uint8_t>((pgn>> 8) & 0xFF);
+			data[6] = static_cast<std::uint8_t>((pgn >> 8) & 0xFF);
 			data[7] = static_cast<std::uint8_t>((pgn >> 16) & 0xFF);
 			retVal = CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::TransportProtocolCommand),
-																data.data(),
-																8,
-																myControlFunction,
-																partnerControlFunction,
-																CANIdentifier::CANPriority::PriorityDefault6);
+			                                                        data.data(),
+			                                                        8,
+			                                                        myControlFunction,
+			                                                        partnerControlFunction,
+			                                                        CANIdentifier::CANPriority::PriorityDefault6);
 		}
 		return retVal;
 	}
@@ -478,7 +477,7 @@ namespace isobus
 		{
 			session->sessionCompleteCallback(session->sessionMessage.get_identifier().get_parameter_group_number(),
 			                                 session->sessionMessage.get_data_length(),
-			                                 reinterpret_cast<InternalControlFunction*>(session->sessionMessage.get_source_control_function()),
+			                                 reinterpret_cast<InternalControlFunction *>(session->sessionMessage.get_source_control_function()),
 			                                 session->sessionMessage.get_destination_control_function(),
 			                                 success,
 			                                 session->parent);
@@ -551,14 +550,14 @@ namespace isobus
 
 		if (nullptr != session)
 		{
-			std::uint8_t dataBuffer[CAN_DATA_LENGTH] = {0};
+			std::uint8_t dataBuffer[CAN_DATA_LENGTH] = { 0 };
 			std::uint32_t messageLength = session->sessionMessage.get_data_length();
 			std::uint32_t pgn = session->sessionMessage.get_identifier().get_parameter_group_number();
-			
+
 			dataBuffer[0] = END_OF_MESSAGE_ACKNOWLEDGE_MULTIPLEXOR;
 			dataBuffer[1] = static_cast<std::uint8_t>(messageLength);
 			dataBuffer[2] = static_cast<std::uint8_t>(messageLength >> 8);
-			dataBuffer[3] = (static_cast<std::uint8_t>((messageLength- 1) / 7) + 1);
+			dataBuffer[3] = (static_cast<std::uint8_t>((messageLength - 1) / 7) + 1);
 			dataBuffer[4] = 0xFF;
 			dataBuffer[5] = static_cast<std::uint8_t>(pgn);
 			dataBuffer[6] = static_cast<std::uint8_t>(pgn >> 8);
@@ -567,12 +566,12 @@ namespace isobus
 			// This message only needs to be sent if we're the recipient. Sanity check the destination is us
 			if (ControlFunction::Type::Internal == session->sessionMessage.get_destination_control_function()->get_type())
 			{
-				retVal = CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::TransportProtocolCommand), 
-				dataBuffer, 
-				CAN_DATA_LENGTH, 
-				reinterpret_cast<InternalControlFunction *>(session->sessionMessage.get_destination_control_function()),
-				session->sessionMessage.get_source_control_function(),
-				CANIdentifier::CANPriority::PriorityDefault6);
+				retVal = CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::TransportProtocolCommand),
+				                                                        dataBuffer,
+				                                                        CAN_DATA_LENGTH,
+				                                                        reinterpret_cast<InternalControlFunction *>(session->sessionMessage.get_destination_control_function()),
+				                                                        session->sessionMessage.get_source_control_function(),
+				                                                        CANIdentifier::CANPriority::PriorityDefault6);
 			}
 		}
 		else
@@ -598,7 +597,7 @@ namespace isobus
 		for (auto i : activeSessions)
 		{
 			if ((i->sessionMessage.get_source_control_function() == source) &&
-				(i->sessionMessage.get_destination_control_function() == destination))
+			    (i->sessionMessage.get_destination_control_function() == destination))
 			{
 				session = i;
 				break;
@@ -613,7 +612,7 @@ namespace isobus
 		session = nullptr;
 
 		if ((get_session(session, source, destination)) &&
-			(session->sessionMessage.get_identifier().get_parameter_group_number() == parameterGroupNumber))
+		    (session->sessionMessage.get_identifier().get_parameter_group_number() == parameterGroupNumber))
 		{
 			retVal = true;
 		}
@@ -671,7 +670,7 @@ namespace isobus
 						for (std::uint8_t i = session->lastPacketNumber; i < session->packetCount; i++)
 						{
 							dataBuffer[0] = (session->processedPacketsThisSession + 1);
-							
+
 							if (nullptr != session->frameChunkCallback)
 							{
 								// Use the callback to get this frame's data
@@ -723,11 +722,11 @@ namespace isobus
 									}
 								}
 							}
-							
+
 							if (CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::TransportProtocolData),
 							                                                   dataBuffer,
 							                                                   CAN_DATA_LENGTH,
-							                                                   reinterpret_cast<InternalControlFunction*>(session->sessionMessage.get_source_control_function()),
+							                                                   reinterpret_cast<InternalControlFunction *>(session->sessionMessage.get_source_control_function()),
 							                                                   session->sessionMessage.get_destination_control_function(),
 							                                                   CANIdentifier::CANPriority::PriorityLowest7))
 							{
@@ -742,8 +741,8 @@ namespace isobus
 							}
 						}
 
-						if ((session->lastPacketNumber == (session->packetCount)) && 
-							(session->sessionMessage.get_data_length() <= (PROTOCOL_BYTES_PER_FRAME * session->processedPacketsThisSession)))
+						if ((session->lastPacketNumber == (session->packetCount)) &&
+						    (session->sessionMessage.get_data_length() <= (PROTOCOL_BYTES_PER_FRAME * session->processedPacketsThisSession)))
 						{
 							set_state(session, StateMachineState::WaitForEndOfMessageAcknowledge);
 							session->timestamp_ms = SystemTiming::get_timestamp_ms();


### PR DESCRIPTION
- CTS message and state were unimplemented
- EOM acknowledgement was being sent too early due to it not taking into account the sequence number overhead in the payload frames.
- Normalized whitespace in the affected files