### PR TITLE
Fix transmit queue processing too slow, fix sending exactly 1785 bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The state of the project is as follows...
 - ISO11783 Transport Protocol (BAM and Connection Mode)
     - TP BAM Rx: Complete :white_check_mark:
     - TP BAM Tx: Implemented, Needs Testing :white_check_mark: :question:
-    - TP CM Tx: Implemented, Needs Testing :white_check_mark: :question:
+    - TP CM Tx: Implemented, Needs Testing :white_check_mark:
     - TP CM Rx: Complete :white_check_mark:
 - ISO11783 Extended Transport Protocol
     - In Development :hourglass:

--- a/isobus/src/can_transport_protocol.cpp
+++ b/isobus/src/can_transport_protocol.cpp
@@ -357,7 +357,7 @@ namespace isobus
 		TransportProtocolSession *session;
 		bool retVal = false;
 
-		if ((messageLength < MAX_PROTOCOL_DATA_LENGTH) &&
+		if ((messageLength <= MAX_PROTOCOL_DATA_LENGTH) &&
 		    (messageLength > CAN_DATA_LENGTH) &&
 		    ((nullptr != dataBuffer) ||
 		     (nullptr != frameChunkCallback)) &&

--- a/socket_can/src/socket_can_interface.cpp
+++ b/socket_can/src/socket_can_interface.cpp
@@ -593,7 +593,7 @@ void CANHardwareInterface::can_thread_function()
 					pCANHardware->receivedMessagesMutex.unlock();
 
 					rxCallbackMutex.lock();
-					for (uint32_t j = 0; j < rxCallbacks.size(); j++)
+					for (std::uint32_t j = 0; j < rxCallbacks.size(); j++)
 					{
 						if (nullptr != rxCallbacks[j].callback)
 						{
@@ -607,7 +607,7 @@ void CANHardwareInterface::can_thread_function()
 			if (get_clear_can_lib_needs_update())
 			{
 				canLibUpdateCallbacksMutex.lock();
-				for (uint32_t j = 0; j < canLibUpdateCallbacks.size(); j++)
+				for (std::uint32_t j = 0; j < canLibUpdateCallbacks.size(); j++)
 				{
 					if (nullptr != canLibUpdateCallbacks[j].callback)
 					{
@@ -624,22 +624,30 @@ void CANHardwareInterface::can_thread_function()
 				isobus::HardwareInterfaceCANFrame packet;
 				bool sendPacket = false;
 
-				if (0 != pCANHardware->messagesToBeTransmitted.size())
+				for (std::uint32_t j = 0; j < pCANHardware->messagesToBeTransmitted.size(); j++)
 				{
-					packet = pCANHardware->messagesToBeTransmitted.front();
-					sendPacket = true;
-				}
-				pCANHardware->messagesToBeTransmittedMutex.unlock();
+					sendPacket = false;
 
-				if (sendPacket)
-				{
-					if (transmit_can_message_from_buffer(packet))
+					if (0 != pCANHardware->messagesToBeTransmitted.size())
 					{
-						pCANHardware->messagesToBeTransmitted.pop_front();
+						packet = pCANHardware->messagesToBeTransmitted.front();
+						sendPacket = true;
 					}
 
-					// Todo, notify CAN lib that we sent, or did not send, each packet
+					if (sendPacket)
+					{
+						if (transmit_can_message_from_buffer(packet))
+						{
+							pCANHardware->messagesToBeTransmitted.pop_front();
+						}
+						else
+						{
+							break;
+						}
+						// Todo, notify CAN lib that we sent, or did not send, each packet
+					}
 				}
+				pCANHardware->messagesToBeTransmittedMutex.unlock();
 			}
 		}
 	}


### PR DESCRIPTION
There was an issue when transmitting out of the CAN message transmit queue where we would only pull the first item out of the queue every iteration.
This was causing us to under-utilize the bus, and take longer to send TP messages than needed.
Fixed an off-by-one error when comparing the maximum protocol payload for TP to the transmit size.
Changed TP CM Tx to complete, as I have now tested all message lengths from 9 to 1785 bytes, and all appeared to succeed.