### PR TITLE
[Core]: Fixed a truncation when constructing some CAN IDs

### DIFF
--- a/isobus/src/can_identifier.cpp
+++ b/isobus/src/can_identifier.cpp
@@ -36,7 +36,7 @@ namespace isobus
 			}
 			else
 			{
-				m_RawIdentifier |= ((pgn << PARAMTER_GROUP_NUMBER_OFFSET) & BROADCAST_PGN_MASK);
+				m_RawIdentifier |= ((pgn & BROADCAST_PGN_MASK) << PARAMTER_GROUP_NUMBER_OFFSET);
 			}
 		}
 		m_RawIdentifier |= static_cast<std::uint32_t>(sourceAddress);


### PR DESCRIPTION
Fixed an issue where broadcast PGNs would be truncated when constructing a CAN ID out of its components.
This was affecting BAM transmits to have the wrong PGN embedded in the payload.