### PR TITLE
TP: BAM Tx improvements

### DIFF
--- a/isobus/include/can_network_configuration.hpp
+++ b/isobus/include/can_network_configuration.hpp
@@ -50,6 +50,8 @@ namespace isobus
 		static std::uint32_t get_minimum_time_between_transport_protocol_bam_frames();
 
 	private:
+		static constexpr std::uint8_t DEFAULT_BAM_PACKET_DELAY_TIME_MS = 50; ///< The default time between BAM frames, as defined by J1939
+
 		static std::uint32_t maxNumberTransportProtocolSessions; ///< The max number of TP sessions allowed
 		static std::uint32_t minimumTimeBetweenTransportProtocolBAMFrames; ///< The configurable time between BAM frames
 	};

--- a/isobus/include/can_network_configuration.hpp
+++ b/isobus/include/can_network_configuration.hpp
@@ -8,7 +8,7 @@
 //================================================================================================
 
 #ifndef CAN_NETWORK_CONFIGURATION_HPP
-#define CAN_NETWORK_CONFIGURAION_HPP
+#define CAN_NETWORK_CONFIGURATION_HPP
 
 #include <cstdint>
 
@@ -37,8 +37,21 @@ namespace isobus
 		/// @returns The max number of concurrent TP sessions
 		static std::uint32_t get_max_number_transport_protcol_sessions();
 
+		/// @brief Sets the minimum time to wait between sending BAM frames
+		/// @details The acceptable range as defined by ISO-11783 is 10 to 200 ms.
+		/// This is a minumum time, so if you set it to some value, like 10 ms, the
+		/// stack will attempt to transmit it as close to that time as it can, but it is
+		/// not possible to 100% ensure it.
+		/// @param[in] value The minimum time to wait between sending BAM frames
+		static void set_minimum_time_between_transport_protocol_bam_frames(std::uint32_t value);
+
+		/// @brief Returns the minimum time to wait between sending BAM frames
+		/// @returns The minimum time to wait between sending BAM frames
+		static std::uint32_t get_minimum_time_between_transport_protocol_bam_frames();
+
 	private:
 		static std::uint32_t maxNumberTransportProtocolSessions; ///< The max number of TP sessions allowed
+		static std::uint32_t minimumTimeBetweenTransportProtocolBAMFrames; ///< The configurable time between BAM frames
 	};
 } // namespace isobus
 

--- a/isobus/include/can_transport_protocol.hpp
+++ b/isobus/include/can_transport_protocol.hpp
@@ -117,7 +117,6 @@ namespace isobus
 		static constexpr std::uint8_t SEQUENCE_NUMBER_DATA_INDEX = 0; ///< The index of the sequence number in a frame
 		static constexpr std::uint8_t MESSAGE_TR_TIMEOUT_MS = 200; ///< The Tr Timeout as defined by the standard
 		static constexpr std::uint8_t PROTOCOL_BYTES_PER_FRAME = 7; ///< The number of payload bytes per frame minus overhead of sequence number
-		static constexpr std::uint8_t DEFAULT_BAM_PACKET_DELAY_TIME_MS = 50; ///< The default time between BAM frames, as defined by J1939
 
 		/// @brief The constructor for the TransportProtocolManager
 		TransportProtocolManager();

--- a/isobus/include/can_transport_protocol.hpp
+++ b/isobus/include/can_transport_protocol.hpp
@@ -228,7 +228,6 @@ namespace isobus
 		void update_state_machine(TransportProtocolSession *session);
 
 		std::vector<TransportProtocolSession *> activeSessions; ///< A list of all active TP sessions
-		std::uint32_t BAMSessionPacketDelayTime_ms;
 	};
 
 } // namespace isobus

--- a/isobus/include/can_transport_protocol.hpp
+++ b/isobus/include/can_transport_protocol.hpp
@@ -42,6 +42,7 @@ namespace isobus
 			RxDataSession, ///< Rx data session is in progress
 			RequestToSend, ///< We are sending the request to send message
 			WaitForClearToSend, ///< We are waiting for a clear to send message
+			BroadcastAnnounce, ///< We are sending the broadcast announce message (BAM)
 			TxDataSession, ///< A Tx data session is in progress
 			WaitForEndOfMessageAcknowledge ///< We are waiting for an end of message acknowledgement
 		};
@@ -116,6 +117,7 @@ namespace isobus
 		static constexpr std::uint8_t SEQUENCE_NUMBER_DATA_INDEX = 0; ///< The index of the sequence number in a frame
 		static constexpr std::uint8_t MESSAGE_TR_TIMEOUT_MS = 200; ///< The Tr Timeout as defined by the standard
 		static constexpr std::uint8_t PROTOCOL_BYTES_PER_FRAME = 7; ///< The number of payload bytes per frame minus overhead of sequence number
+		static constexpr std::uint8_t DEFAULT_BAM_PACKET_DELAY_TIME_MS = 50; ///< The default time between BAM frames, as defined by J1939
 
 		/// @brief The constructor for the TransportProtocolManager
 		TransportProtocolManager();
@@ -183,6 +185,11 @@ namespace isobus
 		/// @param[in] success Denotes if the session was successful
 		void process_session_complete_callback(TransportProtocolSession *session, bool success);
 
+		/// @brief Sends the "broadcast announce" message
+		/// @param[in] session The session for which we're sending the BAM
+		/// @returns true if the BAM was sent, false if sending was not successful
+		bool send_broadcast_announce_message(TransportProtocolSession *session);
+
 		/// @brief Sends the "clear to send" message
 		/// @param[in] session The session for which we're sending the CTS
 		/// @returns true if the CTS was sent, false if sending was not successful
@@ -221,6 +228,7 @@ namespace isobus
 		void update_state_machine(TransportProtocolSession *session);
 
 		std::vector<TransportProtocolSession *> activeSessions; ///< A list of all active TP sessions
+		std::uint32_t BAMSessionPacketDelayTime_ms;
 	};
 
 } // namespace isobus

--- a/isobus/src/can_network_configuration.cpp
+++ b/isobus/src/can_network_configuration.cpp
@@ -12,6 +12,7 @@
 namespace isobus
 {
 	std::uint32_t CANNetworkConfiguration::maxNumberTransportProtocolSessions = 4;
+	std::uint32_t CANNetworkConfiguration::minimumTimeBetweenTransportProtocolBAMFrames = 50;
 
 	CANNetworkConfiguration::CANNetworkConfiguration()
 	{
@@ -29,5 +30,22 @@ namespace isobus
 	std::uint32_t CANNetworkConfiguration::get_max_number_transport_protcol_sessions()
 	{
 		return maxNumberTransportProtocolSessions;
+	}
+
+	void CANNetworkConfiguration::set_minimum_time_between_transport_protocol_bam_frames(std::uint32_t value)
+	{
+		constexpr std::uint32_t MAX_BAM_FRAME_DELAY_MS = 200;
+		constexpr std::uint32_t MIN_BAM_FRAME_DELAY_MS = 10;
+
+		if ((value <= MAX_BAM_FRAME_DELAY_MS) &&
+		    (value >= MIN_BAM_FRAME_DELAY_MS))
+		{
+			minimumTimeBetweenTransportProtocolBAMFrames = value;
+		}
+	}
+
+	std::uint32_t CANNetworkConfiguration::get_minimum_time_between_transport_protocol_bam_frames()
+	{
+		return minimumTimeBetweenTransportProtocolBAMFrames;
 	}
 }

--- a/isobus/src/can_network_configuration.cpp
+++ b/isobus/src/can_network_configuration.cpp
@@ -12,7 +12,7 @@
 namespace isobus
 {
 	std::uint32_t CANNetworkConfiguration::maxNumberTransportProtocolSessions = 4;
-	std::uint32_t CANNetworkConfiguration::minimumTimeBetweenTransportProtocolBAMFrames = 50;
+	std::uint32_t CANNetworkConfiguration::minimumTimeBetweenTransportProtocolBAMFrames = DEFAULT_BAM_PACKET_DELAY_TIME_MS;
 
 	CANNetworkConfiguration::CANNetworkConfiguration()
 	{

--- a/isobus/src/can_transport_protocol.cpp
+++ b/isobus/src/can_transport_protocol.cpp
@@ -47,8 +47,7 @@ namespace isobus
 	{
 	}
 
-	TransportProtocolManager::TransportProtocolManager() :
-	  BAMSessionPacketDelayTime_ms(DEFAULT_BAM_PACKET_DELAY_TIME_MS)
+	TransportProtocolManager::TransportProtocolManager()
 	{
 	}
 
@@ -723,7 +722,7 @@ namespace isobus
 
 				case StateMachineState::TxDataSession:
 				{
-					if ((nullptr != session->sessionMessage.get_destination_control_function()) || (SystemTiming::time_expired_ms(session->timestamp_ms, BAMSessionPacketDelayTime_ms)))
+					if ((nullptr != session->sessionMessage.get_destination_control_function()) || (SystemTiming::time_expired_ms(session->timestamp_ms, CANNetworkConfiguration::get_minimum_time_between_transport_protocol_bam_frames())))
 					{
 						std::uint8_t dataBuffer[CAN_DATA_LENGTH];
 


### PR DESCRIPTION
Closes #21
Solves several issues with transmitting BAM sessions and adds configurable BAM frame delay according to ISO 11783-3. 
With this PR I believe I have validated that basic BAM transmitting is working.
More extensive testing will follow for all BAM message lengths and timing values before I will officially update the state as shown in the README.