### PR TITLE
ETP: Fix ETP protocol send function return value

### DIFF
--- a/isobus/src/can_extended_transport_protocol.cpp
+++ b/isobus/src/can_extended_transport_protocol.cpp
@@ -388,6 +388,7 @@ namespace isobus
 			set_state(newSession, StateMachineState::RequestToSend);
 			activeSessions.push_back(newSession);
 			CANStackLogger::CAN_stack_log("[ETP]: New ETP Session. Dest: " + std::to_string(static_cast<int>(destination->get_address())));
+			retVal = true;
 		}
 		return retVal;
 	}


### PR DESCRIPTION
Fixed an issue where ETP's send function would always return `false`, when trying to transmit, even though a session was created.