### PR TITLE
ISO 11783 / J1939 Diagnostic protocol

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ add_subdirectory("isobus")
 add_subdirectory("socket_can")
 add_subdirectory("examples/vt_version_3_object_pool")
 add_subdirectory("examples/transport_layer")
+add_subdirectory("examples/diagnostic_protocol")
 
 add_executable(unit_tests test/address_claim_test.cpp test/test_CAN_glue.cpp test/identifier_tests.cpp)
 target_link_libraries(unit_tests gtest_main Isobus SocketCANInterface)

--- a/README.md
+++ b/README.md
@@ -14,18 +14,27 @@ The state of the project is as follows...
 - ISO11783 Extended Transport Protocol
     - Complete :white_check_mark:
 - ISO11783 Virtual Terminal: Implemented, Needs testing :white_check_mark: :question:
-- J1939/ISO11783 Diagnostic Protocol (Diagnostic Message 1 and 2 DM1/DM2)
-    - In Development :hourglass:
-
+- J1939/ISO11783 Diagnostic Protocol
+    - Diagnostic Message 1: Complete :white_check_mark:
+    - Diagnostic Message 2: Complete :white_check_mark:
+    - Diagnostic Message 3: Complete :white_check_mark:
+    - Diagnostic Message 11: Complete :white_check_mark:
+    - Diagnostic Message 22: Complete :white_check_mark:
+    - Product Identification: Complete :white_check_mark:
+    - Diagnostic Protocol message Complete :white_check_mark:
+    - Control Function Functionalities Message: Not yet supported :x:
+        - Submit an issue please if this is a priority for your project!
 ### Planned Features (in no particular order):
+- Tutorial
 - ISO11783 File Server
 - ISO11783 Task Controller (currently planned to be client only)
+- PGN Request interface
 - Common ISO11783-5 Messages (guidance command, machine selected speed, etc.)
-- J1939 DM14
+- J1939 DM13 (Stop/Start Broadcast)
 - NMEA2000 Fast Packet Protocol
 - NMEA2000 ISOBUS messages (GNSS)
 - Meta: Package this library as a debian package
-- Meta: Windows OS support via some common CAN driver layers (P-CAN, for example)
+- Meta: Windows OS support via some common CAN driver layers (PEAK P-CAN, for example)
 
 ### Stretch Goals:
 - AEF's Tractor Implement Management Protocol (maybe)

--- a/examples/diagnostic_protocol/CMakeLists.txt
+++ b/examples/diagnostic_protocol/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.16)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+add_executable(DiagnosticProtocolExampleTarget main.cpp)
+target_link_libraries(DiagnosticProtocolExampleTarget Isobus SocketCANInterface Threads::Threads SystemTiming)

--- a/examples/diagnostic_protocol/main.cpp
+++ b/examples/diagnostic_protocol/main.cpp
@@ -1,0 +1,75 @@
+#include "can_network_manager.hpp"
+#include "socket_can_interface.hpp"
+#include "can_general_parameter_group_numbers.hpp"
+#include "isobus_diagnostic_protocol.hpp"
+
+#include <csignal>
+#include <memory>
+#include <iterator>
+
+static std::shared_ptr<isobus::InternalControlFunction> TestInternalECU = nullptr;
+
+using namespace std;
+
+void signal_handler(int signum)
+{
+	isobus::DiagnosticProtocol::deassign_diagnostic_protocol_to_internal_control_function(TestInternalECU);
+    CANHardwareInterface::stop();
+    exit(signum);
+}
+
+void update_CAN_network()
+{
+	isobus::CANNetworkManager::CANNetwork.update();
+}
+
+void raw_can_glue(isobus::HardwareInterfaceCANFrame &rawFrame, void *parentPointer)
+{
+	isobus::CANNetworkManager::CANNetwork.can_lib_process_rx_message(rawFrame, parentPointer);
+}
+
+void setup()
+{
+    CANHardwareInterface::set_number_of_can_channels(1);
+	CANHardwareInterface::assign_can_channel_frame_handler(0, "can0");
+	CANHardwareInterface::start();
+
+	CANHardwareInterface::add_can_lib_update_callback(update_CAN_network, nullptr);
+	CANHardwareInterface::add_raw_can_message_rx_callback(raw_can_glue, nullptr);
+
+	std::this_thread::sleep_for(std::chrono::milliseconds(250));
+
+	isobus::NAME TestDeviceNAME(0);
+
+	// Make sure you change these for your device!!!!
+	// This is an example device that is using a manufacturer code that is currently unused at time of writing
+	TestDeviceNAME.set_arbitrary_address_capable(true);
+	TestDeviceNAME.set_industry_group(0);
+	TestDeviceNAME.set_device_class(0);
+	TestDeviceNAME.set_function_code(static_cast<std::uint8_t>(isobus::NAME::Function::SteeringControl));
+	TestDeviceNAME.set_identity_number(2);
+	TestDeviceNAME.set_ecu_instance(0);
+	TestDeviceNAME.set_function_instance(0);
+	TestDeviceNAME.set_device_class_instance(0);
+	TestDeviceNAME.set_manufacturer_code(64);
+
+	TestInternalECU = std::make_shared<isobus::InternalControlFunction>(TestDeviceNAME, 0x1C, 0);
+
+	isobus::DiagnosticProtocol::assign_diagnostic_protocol_to_internal_control_function(TestInternalECU);
+
+    std::signal(SIGINT,signal_handler);
+}
+
+int main()
+{
+    setup();
+
+    while (true)
+    {
+		// CAN stack runs in other threads. Do nothing forever.
+        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+    }
+
+    CANHardwareInterface::stop();
+    return 0;
+}

--- a/isobus/CMakeLists.txt
+++ b/isobus/CMakeLists.txt
@@ -29,6 +29,7 @@ set(ISOBUS_SRC
   "can_callbacks.cpp"
   "isobus_virtual_terminal_client.cpp"
   "can_extended_transport_protocol.cpp"
+  "isobus_diagnostic_protocol.cpp"
 )
 
 # Prepend the source directory path to all the source files
@@ -53,6 +54,7 @@ set(ISOBUS_INCLUDE
   "can_callbacks.hpp"
   "isobus_virtual_terminal_client.hpp"
   "can_extended_transport_protocol.hpp"
+  "isobus_diagnostic_protocol.hpp"
 )
 
 # Prepend the include directory path to all the include files

--- a/isobus/include/can_general_parameter_group_numbers.hpp
+++ b/isobus/include/can_general_parameter_group_numbers.hpp
@@ -16,6 +16,7 @@ namespace isobus
 	enum class CANLibParameterGroupNumber
 	{
 		Any = 0x0000,
+		DiagnosticMessage22 = 0xC300,
 		ExtendedTransportProtocolDataTransfer = 0xC700,
 		ExtendedTransportProtocolConnectionManagement = 0xC800,
 		VirtualTerminalToECU = 0xE600,

--- a/isobus/include/can_general_parameter_group_numbers.hpp
+++ b/isobus/include/can_general_parameter_group_numbers.hpp
@@ -26,6 +26,7 @@ namespace isobus
 		TransportProtocolCommand = 0xEC00,
 		AddressClaim = 0xEE00,
 		ProprietaryA = 0xEF00,
+		ProductIdentification = 0xFC8D,
 		DiagnosticProtocolIdentification = 0xFD32,
 		WorkingSetMaster = 0xFE0D,
 		DiagnosticMessage1 = 0xFECA,

--- a/isobus/include/can_general_parameter_group_numbers.hpp
+++ b/isobus/include/can_general_parameter_group_numbers.hpp
@@ -18,7 +18,6 @@ namespace isobus
 		Any = 0x0000,
 		ExtendedTransportProtocolDataTransfer = 0xC700,
 		ExtendedTransportProtocolConnectionManagement = 0xC800,
-		WorkingSetMaster = 0xFE0D,
 		VirtualTerminalToECU = 0xE600,
 		ECUtoVirtualTerminal = 0xE700,
 		Acknowledge = 0xE800,
@@ -26,7 +25,12 @@ namespace isobus
 		TransportProtocolData = 0xEB00,
 		TransportProtocolCommand = 0xEC00,
 		AddressClaim = 0xEE00,
-		ProprietaryA = 0xEF00
+		ProprietaryA = 0xEF00,
+		DiagnosticProtocolIdentification = 0xFD32,
+		WorkingSetMaster = 0xFE0D,
+		DiagnosticMessage1 = 0xFECA,
+		DiagnosticMessage2 = 0xFECB,
+		DiagnosticMessage3 = 0xFECC
 	};
 
 } // namespace isobus

--- a/isobus/include/can_general_parameter_group_numbers.hpp
+++ b/isobus/include/can_general_parameter_group_numbers.hpp
@@ -30,7 +30,8 @@ namespace isobus
 		WorkingSetMaster = 0xFE0D,
 		DiagnosticMessage1 = 0xFECA,
 		DiagnosticMessage2 = 0xFECB,
-		DiagnosticMessage3 = 0xFECC
+		DiagnosticMessage3 = 0xFECC,
+		DiagnosticMessage11 = 0xFED3
 	};
 
 } // namespace isobus

--- a/isobus/include/can_network_manager.hpp
+++ b/isobus/include/can_network_manager.hpp
@@ -77,6 +77,7 @@ namespace isobus
 		/// If you don't specify a destination (or use nullptr) you message will be sent as a broadcast
 		/// if it is valid to do so.
 		/// You can also get a callback on success or failure of the transmit.
+		/// @returns `true` if the message was sent, otherwise `false`
 		bool send_can_message(std::uint32_t parameterGroupNumber,
 		                      const std::uint8_t *dataBuffer,
 		                      std::uint32_t dataLength,
@@ -105,17 +106,20 @@ namespace isobus
 		friend class AddressClaimStateMachine; ///< Allows the network manager to work closely with the address claiming process
 		friend class ExtendedTransportProtocolManager; ///< Allows the network manager to access the ETP manager
 		friend class TransportProtocolManager; ///< Allows the network manager to work closely with the transport protocol manager object
+		friend class DiagnosticProtocol; ///< Allows the diagnostic protocol to access the protected functions on the network manager
 
 		/// @brief Adds a PGN callback for a protocol class
 		/// @param[in] parameterGroupNumber The PGN to register for
 		/// @param[in] callback The callback to call when the PGN is received
 		/// @param[in] parentPointer A generic context variable that helps identify what object the callback was destined for
+		/// @returns `true` if the callback was added, otherwise `false`
 		bool add_protocol_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parentPointer);
 
 		/// @brief Removes a PGN callback for a protocol class
 		/// @param[in] parameterGroupNumber The PGN to register for
 		/// @param[in] callback The callback to call when the PGN is received
 		/// @param[in] parentPointer A generic context variable that helps identify what object the callback was destined for
+		/// @returns `true` if the callback was removed, otherwise `false`
 		bool remove_protocol_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parentPointer);
 
 		/// @brief Sends a CAN message using raw addresses. Used only by the stack.
@@ -126,6 +130,7 @@ namespace isobus
 		/// @param[in] priority The CAN priority of the message being sent
 		/// @param[in] data A pointer to the data buffer to send from
 		/// @param[in] size The size of the messgage to send
+		/// @returns `true` if the message was sent, otherwise `false`
 		bool send_can_message_raw(std::uint32_t portIndex,
 		                          std::uint8_t sourceAddress,
 		                          std::uint8_t destAddress,
@@ -182,6 +187,7 @@ namespace isobus
 		/// @brief Returns a control function based on a CAN address and channel index
 		/// @param[in] CANPort The CAN channel index of the CAN message being processed
 		/// @param[in] CFAddress The CAN address associated with a control function
+		/// @returns A control function matching the address and CAN port passed in
 		ControlFunction *get_control_function(std::uint8_t CANPort, std::uint8_t CFAddress) const;
 
 		/// @brief Matches a CAN message to any matching PGN callback, and calls that callback
@@ -199,6 +205,7 @@ namespace isobus
 		/// @param[in] priority The CAN priority of the message being sent
 		/// @param[in] data A pointer to the data buffer to send from
 		/// @param[in] size The size of the messgage to send
+		/// @returns `true` if the message was sent, otherwise `false`
 		bool send_can_message_raw(std::uint32_t portIndex,
 		                          std::uint8_t sourceAddress,
 		                          std::uint8_t destAddress,

--- a/isobus/include/isobus_diagnostic_protocol.hpp
+++ b/isobus/include/isobus_diagnostic_protocol.hpp
@@ -174,7 +174,7 @@ namespace isobus
 		/// type plate of a product. For vehicles, this number can be the same as the VIN. For stand-alone systems, such as VTs,
 		/// this number can be the same as the ECU ID number. The combination of the product identification code and brand shall
 		/// make the product globally unique.
-		/// @param The ascii product identification code, up to 50 characters long
+		/// @param value The ascii product identification code, up to 50 characters long
 		/// @returns true if the value was set, false if the string is too long
 		bool set_product_identification_code(std::string value);
 
@@ -182,11 +182,13 @@ namespace isobus
 		/// @details The product identification brand specifies the brand of a product. The combination of the product ID code and brand
 		/// shall make the product unique in the world.
 		/// @param value The ascii product brand, up to 50 characters long
+		/// @returns true if the value was set, false if the string is too long
 		bool set_product_identification_brand(std::string value);
 
 		/// @brief Sets the product identification model used in the diagnostic protocol "Product Identification" message (PGN 0xFC8D)
 		/// @details The product identification model specifies a unique product within a brand.
 		/// @param value The ascii model string, up to 50 characters
+		/// @returns true if the value was set, false if the string is too long
 		bool set_product_identification_model(std::string value);
 
 		/// @brief Updates the protocol cyclically
@@ -221,6 +223,7 @@ namespace isobus
 			NegativeAcknowledgeOfActiveDTCClear = 0x13 ///< NACK clearing an active DTC
 		};
 
+		/// @brief The negative acknowledge (NACK) reasons for a DM22 message
 		enum class DM22NegativeAcknowledgeIndicator : std::uint8_t
 		{
 			General = 0x00, ///< General negative acknowledge
@@ -233,12 +236,12 @@ namespace isobus
 		/// @brief A structure to hold data about DM22 responses we need to send
 		struct DM22Data
 		{
-			ControlFunction *destination;
-			std::uint32_t suspectParameterNumber;
-			std::uint8_t failureModeIdentifier;
-			std::uint8_t nackIndicator;
-			bool clearActive;
-			bool nack;
+			ControlFunction *destination; ///< Destination for the DM22 message
+			std::uint32_t suspectParameterNumber; ///< SPN of the DTC for the DM22
+			std::uint8_t failureModeIdentifier; ///< FMI of the DTC for the DM22
+			std::uint8_t nackIndicator; ///< The NACK reason, if applicable
+			bool clearActive; ///< true if the DM22 was for an active DTC, false for previously active
+			bool nack; ///< true if we are sending a NACK instead of PACK. Determines if we use nackIndicator
 		};
 
 		static constexpr std::uint32_t DM_MAX_FREQUENCY_MS = 1000; ///< You are techically allowed to send more than this under limited circumstances, but a hard limit saves 4 RAM bytes per DTC and has BAM benefits
@@ -351,9 +354,9 @@ namespace isobus
 		std::vector<DiagnosticTroubleCode> inactiveDTCList; ///< Keeps track of all the previously active DTCs
 		std::vector<DM22Data> dm22ResponseQueue; ///< Maintaining a list of DM22 responses we need to send to allow for retrying in case of Tx failures
 		ProcessingFlags txFlags; ///< An instance of the processing flags to handle retries of some messages
-		std::string productIdentificationCode;
-		std::string productIdentificationBrand;
-		std::string productIdentificationModel;
+		std::string productIdentificationCode; ///< The product identification code for sending the product identification message
+		std::string productIdentificationBrand; ///< The product identification brand for sending the product identification message
+		std::string productIdentificationModel; ///< The product identification model name for sending the product identification message
 		std::uint32_t lastDM1SentTimestamp; ///< A timestamp in milliseconds of the last time a DM1 was sent
 		bool j1939Mode; ///< Tells the protocol to operate according to J1939 instead of ISO11783
 	};

--- a/isobus/include/isobus_diagnostic_protocol.hpp
+++ b/isobus/include/isobus_diagnostic_protocol.hpp
@@ -245,6 +245,7 @@ namespace isobus
 		};
 
 		static constexpr std::uint32_t DM_MAX_FREQUENCY_MS = 1000; ///< You are techically allowed to send more than this under limited circumstances, but a hard limit saves 4 RAM bytes per DTC and has BAM benefits
+		static constexpr std::uint16_t MAX_PAYLOAD_SIZE_BYTES = 1785;
 		static constexpr std::uint8_t DM_PAYLOAD_BYTES_PER_DTC = 4; ///< The number of payload bytes per DTC that gets encoded into the messages
 		static constexpr std::uint8_t PRODUCT_IDENTIFICATION_MAX_STRING_LENGTH = 50; ///< The max string length allowed in the fields of product ID, as defined in ISO 11783-12
 

--- a/isobus/include/isobus_diagnostic_protocol.hpp
+++ b/isobus/include/isobus_diagnostic_protocol.hpp
@@ -252,6 +252,12 @@ namespace isobus
 		/// @returns true if te message was sent, otherwise false
 		bool send_diagnostic_message_3_ack(ControlFunction *destination);
 
+		/// @brief Sends an ACK (pgn E800) for clearing active DTCs via DM11
+		/// @todo Replace manual ACK with a PGN request protocol to simplify ACK/NACK
+		/// @param destination The destination control function for the ACK
+		/// @returns true if te message was sent, otherwise false
+		bool send_diagnostic_message_11_ack(ControlFunction *destination);
+
 		/// @brief Sends a message that identifies which diagnostic protocols are supported
 		/// @returns true if the message was sent, otherwise false
 		bool send_diagnostic_protocol_identification();

--- a/isobus/include/isobus_diagnostic_protocol.hpp
+++ b/isobus/include/isobus_diagnostic_protocol.hpp
@@ -21,8 +21,8 @@
 #include "can_protocol.hpp"
 #include "processing_flags.hpp"
 
-#include <memory>
 #include <list>
+#include <memory>
 
 namespace isobus
 {
@@ -126,6 +126,11 @@ namespace isobus
 		/// @returns `true` If the protocol instance was deleted OK according to the passed in ICF
 		static bool deassign_diagnostic_protocol_to_internal_control_function(std::shared_ptr<InternalControlFunction> internalControlFunction);
 
+		/// @brief Retuns the diagnostic protocol assigned to an internal control function, if any
+		/// @param internalControlFunction The internal control function to search against
+		/// @returns The protocol object associated to the passed in ICF, or `nullptr` if none found that match the passed in ICF
+		static DiagnosticProtocol *get_diagnostic_protocol_by_internal_control_function(std::shared_ptr<InternalControlFunction> internalControlFunction);
+
 		/// @brief The protocol's initializer function
 		void initialize(CANLibBadge<CANNetworkManager>) override;
 
@@ -170,6 +175,26 @@ namespace isobus
 
 		/// @brief The destructor for this protocol
 		~DiagnosticProtocol();
+
+		/// @brief The network manager calls this to see if the protocol can accept a non-raw CAN message for processing
+		/// @note In this protocol, we do not accept messages from the network manager for transmission
+		/// @param[in] parameterGroupNumber The PGN of the message
+		/// @param[in] data The data to be sent
+		/// @param[in] messageLength The length of the data to be sent
+		/// @param[in] source The source control function
+		/// @param[in] destination The destination control function
+		/// @param[in] transmitCompleteCallback A callback for when the protocol completes its work
+		/// @param[in] parentPointer A generic context object for the tx complete and chunk callbacks
+		/// @param[in] frameChunkCallback A callback to get some data to send
+		/// @returns true if the message was accepted by the protocol for processing
+		bool protocol_transmit_message(std::uint32_t parameterGroupNumber,
+		                               const std::uint8_t *data,
+		                               std::uint32_t messageLength,
+		                               ControlFunction *source,
+		                               ControlFunction *destination,
+		                               TransmitCompleteCallback transmitCompleteCallback,
+		                               void *parentPointer,
+		                               DataChunkCallback frameChunkCallback) override;
 
 		/// @brief Sends a DM1 encoded CAN message
 		/// @returns true if the message was sent, otherwise false

--- a/isobus/include/isobus_diagnostic_protocol.hpp
+++ b/isobus/include/isobus_diagnostic_protocol.hpp
@@ -246,16 +246,22 @@ namespace isobus
 		/// @returns true if the message was sent, otherwise false
 		bool send_diagnostic_message_2();
 
+		/// @brief Sends an ACK (pgn E800) for DM2
+		/// @todo Replace manual ACK with a PGN request protocol to simplify ACK/NACK
+		/// @param destination The destination control function for the ACK
+		/// @returns true if the message was sent, otherwise false
+		bool send_diagnostic_message_2_ack(ControlFunction *destination);
+
 		/// @brief Sends an ACK (pgn E800) for clearing inactive DTCs via DM3
 		/// @todo Replace manual ACK with a PGN request protocol to simplify ACK/NACK
 		/// @param destination The destination control function for the ACK
-		/// @returns true if te message was sent, otherwise false
+		/// @returns true if the message was sent, otherwise false
 		bool send_diagnostic_message_3_ack(ControlFunction *destination);
 
 		/// @brief Sends an ACK (pgn E800) for clearing active DTCs via DM11
 		/// @todo Replace manual ACK with a PGN request protocol to simplify ACK/NACK
 		/// @param destination The destination control function for the ACK
-		/// @returns true if te message was sent, otherwise false
+		/// @returns true if the message was sent, otherwise false
 		bool send_diagnostic_message_11_ack(ControlFunction *destination);
 
 		/// @brief Sends a message that identifies which diagnostic protocols are supported
@@ -283,7 +289,6 @@ namespace isobus
 		std::vector<DiagnosticTroubleCode> inactiveDTCList; ///< Keeps track of all the previously active DTCs
 		ProcessingFlags txFlags; ///< An instance of the processing flags to handle retries of some messages
 		std::uint32_t lastDM1SentTimestamp; ///< A timestamp in milliseconds of the last time a DM1 was sent
-		std::uint32_t lastDM2SentTimestamp; ///< A timestamp in milliseconds of the last time a DM2 was sent
 		bool j1939Mode; ///< Tells the protocol to operate according to J1939 instead of ISO11783
 	};
 }

--- a/isobus/include/isobus_diagnostic_protocol.hpp
+++ b/isobus/include/isobus_diagnostic_protocol.hpp
@@ -1,0 +1,199 @@
+//================================================================================================
+/// @file isobus_diagnostic_protocol.hpp
+///
+/// @brief A protocol that handles the ISO-11783 Active DTC Protocol.
+/// @details The ISO-11783 definition of DM1 is based on the J1939 definition with some tweaks.
+/// This protocol reports active diagnostic trouble codes as defined by
+/// SAE J1939-73. The message this protocol sends is sent via BAM, which has some
+/// implications to your application, as only 1 BAM can be active at a time. This message
+/// is sent at 1 Hz. Unlike in J1939, the message is discontinued when no DTCs are active to
+/// minimize bus load. Also, ISO-11783 does not utilize or support lamp status.
+/// You can revert to the standard J1939 behavior though if you want.
+/// @author Adrian Del Grosso
+///
+/// @copyright 2022 Adrian Del Grosso
+//================================================================================================
+
+#ifndef ISOBUS_DIAGNOSTIC_PROTOCOL_HPP
+#define ISOBUS_DIAGNOSTIC_PROTOCOL_HPP
+
+#include "can_internal_control_function.hpp"
+#include "can_protocol.hpp"
+#include "processing_flags.hpp"
+
+#include <memory>
+
+namespace isobus
+{
+	//================================================================================================
+	/// @class DiagnosticProtocol
+	/// @brief Manages the DM1, DM2, and DM3 messages for ISO11783 or J1939
+	//================================================================================================
+	class DiagnosticProtocol : public CANLibProtocol
+	{
+	public:
+		/// @brief The DTC lamp status as defined in J1939-73. Not used when in ISO11783 mode
+		enum class LampStatus
+		{
+			None,
+			MalfunctionIndicatorLampSolid, ///< A lamp used to relay only emissions-related trouble code information
+			MalfuctionIndicatorLampSlowFlash, ///< A lamp used to relay only emissions-related trouble code information
+			MalfunctionIndicatorLampFastFlash, ///< A lamp used to relay only emissions-related trouble code information
+			RedStopLampSolid, ///< This lamp is used to relay trouble code information that is of a severe-enough condition that it warrants stopping the vehicle
+			RedStopLampSlowFlash, ///< This lamp is used to relay trouble code information that is of a severe-enough condition that it warrants stopping the vehicle
+			RedStopLampFastFlash, ///< This lamp is used to relay trouble code information that is of a severe-enough condition that it warrants stopping the vehicle
+			AmberWarningLampSolid, ///< This lamp is used to relay trouble code information that is reporting a problem with the vehicle system but the vehicle need not be immediately stopped.
+			AmberWarningLampSlowFlash, ///< This lamp is used to relay trouble code information that is reporting a problem with the vehicle system but the vehicle need not be immediately stopped.
+			AmberWarningLampFastFlash ///< This lamp is used to relay trouble code information that is reporting a problem with the vehicle system but the vehicle need not be immediately stopped.
+		};
+
+		/// @brief FMI as defined in ISO11783-12 Annex E
+		enum class FailureModeIdentifier
+		{
+			DataValidAboveNormalMostSevere = 0, ///< Condition is above normal as determined by the predefined most severe level limits for that particular measure of the condition
+			DataValidBelowNormalMostSevere = 1, ///< Condition is below normal as determined by the predefined most severe level limits for that particular measure of the condition
+			DataErratic = 2, ///< Erratic or intermittent data include all measurements that change at a rate not considered possible in real - world conditions
+			VoltageAboveNormal = 3, ///< A voltage signal, data or otherwise, is above the predefined limits that bound the range
+			VoltageBelowNormal = 4, ///< A voltage signal, data or otherwise, is below the predefined limits that bound the range
+			CurrentBelowNormal = 5, ///< A current signal, data or otherwise, is below the predefined limits that bound the range
+			CurrentAboveNormal = 6, ///< A current signal, data or otherwise, is above the predefined limits that bound the range
+			MechanicalSystemNotResponding = 7, ///< Any fault that is detected as the result of an improper mechanical adjustment, an improper response or action of a mechanical system
+			AbnormalFrequency = 8, ///< Any frequency or PWM signal that is outside the predefined limits which bound the signal range for frequency or duty cycle
+			AbnotmalUpdateRate = 9, ///< Any failure that is detected when receipt of data through the data network is not at the update rate expected or required
+			AbnormalRateOfChange = 10, ///< Any data, exclusive of FMI 2, that are considered valid but which are changing at a rate that is outside the predefined limits that bound the rate of change for the system
+			RootCauseNotKnown = 11, ///< It has been detected that a failure has occurred in a particular subsystem but the exact nature of the fault is not known
+			BadIntellegentDevice = 12, ///< Internal diagnostic procedures have determined that the failure is one which requires the replacement of the ECU
+			OutOfCalibration = 13, ///< A failure that can be identified as the result of improper calibration
+			SpecialInstructions = 14, ///< Used when the on-board system can isolate the failure to a small number of choices but not to a single point of failure. See 11783-12 Annex E
+			DataValidAboveNormalLeastSevere = 15, ///< Condition is above what would be considered normal as determined by the predefined least severe level limits for that particular measure of the condition
+			DataValidAboveNormalModeratelySevere = 16, ///< Condition is above what would be considered normal as determined by the predefined moderately severe level limits for that particular measure of the condition
+			DataValidBelowNormalLeastSevere = 17, ///< Condition is below what would be considered normal as determined by the predefined least severe level limits for that particular measure of the condition
+			DataValidBelowNormalModeratelySevere = 18, ///< Condition is below what would be considered normal as determined by the predefined moderately severe level limits for that particular measure of the condition
+			ReceivedNetworkDataInError = 19, ///< Any failure that is detected when the data received through the network are found replaced by the “error indicator” value 0xFE
+			ConditionExists = 31 ///< The condition that is identified by the SPN exists when no applicable FMI exists (any other error)
+		};
+
+		enum class TransmitFlags
+		{
+			DM1 = 0,
+			DM2,
+			DiagnosticProtocolID,
+
+			NumberOfFlags
+		};
+
+		//================================================================================================
+		/// @class DiagnosticTroubleCode
+		/// @brief A storage class for describing a complete DTC
+		//================================================================================================
+		class DiagnosticTroubleCode
+		{
+		public:
+			/// @brief Constructor for a DTC, sets default values at construction time
+			DiagnosticTroubleCode();
+
+			/// @brief Constructor for a DTC, sets all values explicitly
+			/// @param[in] spn The suspect parameter number
+			/// @param[in] fmi The failure mode indicator
+			/// @param[in] lamp The J1939 lamp status. Set to `None` if you don't care about J1939
+			DiagnosticTroubleCode(std::uint32_t spn, FailureModeIdentifier fmi, LampStatus lamp);
+
+			/// @brief A useful way to compare DTC objects to each other for equality
+			/// @returns `true` if the objects were equal
+			bool operator==(const DiagnosticTroubleCode &obj);
+
+			///  @brief Returns the occurance count, which will be kept track of by the protocol
+			std::uint8_t get_occurrance_count() const;
+
+			std::uint32_t suspectParameterNumber; ///< This 19-bit number is used to identify the item for which diagnostics are being reported
+			std::uint8_t failureModeIdentifier; ///< The FMI defines the type of failure detected in the sub-system identified by an SPN
+			LampStatus lampState; ///< The J1939 lamp state for this DTC
+		private:
+			friend class DiagnosticProtocol;
+			std::uint8_t occuranceCount; ///< Number of times the DTC has been active (0 to 126 with 127 being not available)
+		};
+
+		/// @brief The constructor for this protocol
+		explicit DiagnosticProtocol();
+
+		/// @brief The destructor for this protocol
+		~DiagnosticProtocol();
+
+		/// @brief Sets the internal control function that this protocol will use to send messages
+		/// @details This is required for the protocol to function!
+		/// @param[in] internalControlFunction The internal control function to use for sending messages
+		void set_internal_control_function(std::shared_ptr<InternalControlFunction> internalControlFunction);
+
+		/// @brief Enables the protocol to run in J1939 mode instead of ISO11783 mode
+		/// @details See ISO11783-12 and J1939-73 for a complete explanation of the differences
+		/// @param[in] value The desired mode. `true` for J1939 mode, `false` for ISO11783 mode
+		void set_j1939_mode(bool value);
+
+		/// @brief Returns `true` if the protocol is in J1939 mode instead of ISO11783 mode, `false` if using ISO11783 mode
+		/// @returns `true` if the protocol is in J1939 mode instead of ISO11783 mode, `false` if using ISO11783 mode
+		bool get_j1939_mode() const;
+
+		/// @brief Clears the list of active DTCs and makes them all inactive
+		void clear_active_diagnostic_trouble_codes();
+
+		/// @brief Clears the list of inactive DTCs and clears occurance counts
+		void clear_inactive_diagnostic_trouble_codes();
+
+		/// @brief Adds a DTC to the active list, or removes one from the active list
+		/// @details When you call this function with a DTC and `true`, it will be added to the DM1 message.
+		/// When you call it with a DTC and `false` it will be moved to the inactive list.
+		/// If you get `false` as a return value, either the DTC was already in the target state or the data was not valid
+		/// @param[in] dtc A diagnostic trouble code whose state should be altered
+		/// @param[in] active Sets if the DTC is currently active or not
+		/// @returns True if the DTC was added/removed from the list, false if DTC was not valid or target state is invalid
+		bool set_diagnostic_trouble_code_active(const DiagnosticTroubleCode &dtc, bool active);
+
+		/// @brief Returns if a DTC is active
+		/// @param[in] dtc A diagnostic trouble code whose state should be altered
+		/// @returns `true` if the DTC was in the active list
+		bool get_diagnostic_trouble_code_active(const DiagnosticTroubleCode &dtc) const;
+
+		/// @brief Updates the protocol cyclically
+		void update(CANLibBadge<CANNetworkManager>) override;
+
+	private:
+		static constexpr std::uint32_t DM_MAX_FREQUENCY_MS = 1000; ///< You are techically allowed to send more than this under limited circumstances, but a hard limit saves 4 RAM bytes per DTC and has BAM benefits
+		static constexpr std::uint8_t DM_PAYLOAD_BYTES_PER_DTC = 4; ///< The number of payload bytes per DTC that gets encoded into the messages
+
+		/// @brief Sends a DM1 encoded CAN message
+		/// @returns true if the message was sent, otherwise false
+		bool send_diagnostic_message_1();
+
+		/// @brief Sends a DM2 encoded CAN message
+		/// @returns true if the message was sent, otherwise false
+		bool send_diagnostic_message_2();
+
+		/// @brief Sends a message that identifies which diagnostic protocols are supported
+		/// @returns true if the message was sent, otherwise false
+		bool send_diagnostic_protocol_identification();
+
+		/// @brief A generic way for a protocol to process a received message
+		/// @param[in] message A received CAN message
+		void process_message(CANMessage *const message) override;
+
+		/// @brief A generic way for a protocol to process a received message
+		/// @param[in] message A received CAN message
+		/// @param[in] parent Provides the context to the actual TP manager object
+		static void process_message(CANMessage *const message, void *parent);
+
+		/// @brief A generic callback for a the class to process flags from the `ProcessingFlags`
+		/// @param[in] flag The flag to process
+		/// @param[in] parentPointer A generic context pointer to reference a specific instance of this protocol in the callback
+		static void process_flags(std::uint32_t flag, void *parentPointer);
+
+		std::shared_ptr<InternalControlFunction> myControlFunction; ///< The internal control function that this protocol will send from
+		std::vector<DiagnosticTroubleCode> activeDTCList; ///< Keeps track of all the active DTCs
+		std::vector<DiagnosticTroubleCode> inactiveDTCList; ///< Keeps track of all the previously active DTCs
+		ProcessingFlags txFlags; ///< An instance of the processing flags to handle retries of some messages
+		std::uint32_t lastDM1SentTimestamp; ///< A timestamp in milliseconds of the last time a DM1 was sent
+		std::uint32_t lastDM2SentTimestamp; ///< A timestamp in milliseconds of the last time a DM2 was sent
+		bool j1939Mode; ///< Tells the protocol to operate according to J1939 instead of ISO11783
+	};
+}
+
+#endif // ISOBUS_DIAGNOSTIC_PROTOCOL_HPP

--- a/isobus/src/isobus_diagnostic_protocol.cpp
+++ b/isobus/src/isobus_diagnostic_protocol.cpp
@@ -82,9 +82,9 @@ namespace isobus
 	{
 		bool retVal = true;
 
-		for (auto protocol : diagnosticProtocolList)
+		for (auto protocolLocation : diagnosticProtocolList)
 		{
-			if (protocol->myControlFunction == internalControlFunction)
+			if (protocolLocation->myControlFunction == internalControlFunction)
 			{
 				retVal = false;
 				break;
@@ -93,7 +93,8 @@ namespace isobus
 
 		if (retVal)
 		{
-		
+			DiagnosticProtocol *newProtocol = new DiagnosticProtocol(internalControlFunction);
+			diagnosticProtocolList.push_back(newProtocol);
 		}
 		return retVal;
 	}
@@ -102,12 +103,27 @@ namespace isobus
 	{
 		bool retVal = false;
 
+		for (auto protocolLocation = diagnosticProtocolList.begin(); protocolLocation != diagnosticProtocolList.end(); protocolLocation++)
+		{
+			if ((*protocolLocation)->myControlFunction == internalControlFunction)
+			{
+				retVal = true;
+				delete *protocolLocation;
+				diagnosticProtocolList.erase(protocolLocation);
+				break;
+			}
+		}
+		return retVal;
+	}
+
+	DiagnosticProtocol *DiagnosticProtocol::get_diagnostic_protocol_by_internal_control_function(std::shared_ptr<InternalControlFunction> internalControlFunction)
+	{
+		DiagnosticProtocol *retVal = nullptr;
 		for (auto protocol : diagnosticProtocolList)
 		{
 			if (protocol->myControlFunction == internalControlFunction)
 			{
-				retVal = true;
-				delete protocol;
+				retVal = protocol;
 				break;
 			}
 		}
@@ -153,7 +169,7 @@ namespace isobus
 			// First check to see if it's already active
 			auto activeLocation = std::find(activeDTCList.begin(), activeDTCList.end(), dtc);
 
-			if (activeDTCList.end() != activeLocation)
+			if (activeDTCList.end() == activeLocation)
 			{
 				// Not already active. This is valid
 				auto inactiveLocation = std::find(inactiveDTCList.begin(), inactiveDTCList.end(), dtc);
@@ -239,6 +255,18 @@ namespace isobus
 			}
 		}
 		txFlags.process_all_flags();
+	}
+
+	bool DiagnosticProtocol::protocol_transmit_message(std::uint32_t ,
+	                               const std::uint8_t *,
+	                               std::uint32_t ,
+	                               ControlFunction *,
+	                               ControlFunction *,
+	                               TransmitCompleteCallback ,
+	                               void *,
+	                               DataChunkCallback)
+	{
+		return false;
 	}
 
 	bool DiagnosticProtocol::send_diagnostic_message_1()

--- a/isobus/src/isobus_diagnostic_protocol.cpp
+++ b/isobus/src/isobus_diagnostic_protocol.cpp
@@ -203,7 +203,7 @@ namespace isobus
 			/// First check to see if it's already in the inactive list
 			auto inactiveLocation = std::find(inactiveDTCList.begin(), inactiveDTCList.end(), dtc);
 
-			if (inactiveDTCList.end() != inactiveLocation)
+			if (inactiveDTCList.end() == inactiveLocation)
 			{
 				auto activeLocation = std::find(activeDTCList.begin(), activeDTCList.end(), dtc);
 

--- a/isobus/src/isobus_diagnostic_protocol.cpp
+++ b/isobus/src/isobus_diagnostic_protocol.cpp
@@ -1,0 +1,373 @@
+//================================================================================================
+/// @file isobus_diagnostic_protocol.cpp
+///
+/// @brief A protocol that handles the ISO-11783 Active DTC Protocol.
+/// @details The ISO-11783 definition of DM1 is based on the J1939 definition with some tweaks.
+/// This protocol reports active diagnostic trouble codes as defined by
+/// SAE J1939-73. The message this protocol sends is sent via BAM, which has some
+/// implications to your application, as only 1 BAM can be active at a time. This message
+/// is sent at 1 Hz. Unlike in J1939, the message is discontinued when no DTCs are active to
+/// minimize bus load. Also, ISO-11783 does not utilize or support lamp status.
+/// You can revert to the standard J1939 behavior though if you want.
+/// @author Adrian Del Grosso
+///
+/// @copyright 2022 Adrian Del Grosso
+//================================================================================================
+
+#include "isobus_diagnostic_protocol.hpp"
+
+#include "can_general_parameter_group_numbers.hpp"
+#include "can_network_manager.hpp"
+#include "system_timing.hpp"
+
+#include <algorithm>
+
+namespace isobus
+{
+	DiagnosticProtocol::DiagnosticTroubleCode::DiagnosticTroubleCode() :
+	  suspectParameterNumber(0xFFFFFFFF),
+	  failureModeIdentifier(static_cast<std::uint8_t>(FailureModeIdentifier::ConditionExists)),
+	  lampState(LampStatus::None)
+	{
+	}
+
+	DiagnosticProtocol::DiagnosticTroubleCode::DiagnosticTroubleCode(std::uint32_t spn, FailureModeIdentifier fmi, LampStatus lamp) :
+	  suspectParameterNumber(spn),
+	  failureModeIdentifier(static_cast<std::uint8_t>(fmi)),
+	  lampState(lamp)
+	{
+	}
+
+	bool DiagnosticProtocol::DiagnosticTroubleCode::operator==(const DiagnosticTroubleCode &obj)
+	{
+		return ((suspectParameterNumber == obj.suspectParameterNumber) &&
+		        (failureModeIdentifier == obj.failureModeIdentifier) &&
+		        (lampState == obj.lampState));
+	}
+
+	std::uint8_t DiagnosticProtocol::DiagnosticTroubleCode::get_occurrance_count() const
+	{
+		return occuranceCount;
+	}
+
+	DiagnosticProtocol::DiagnosticProtocol() :
+	  myControlFunction(nullptr),
+	  txFlags(static_cast<std::uint32_t>(TransmitFlags::NumberOfFlags), process_flags, this),
+	  lastDM1SentTimestamp(0),
+	  lastDM2SentTimestamp(0),
+	  j1939Mode(false)
+	{
+	}
+
+	DiagnosticProtocol::~DiagnosticProtocol()
+	{
+	}
+
+	void DiagnosticProtocol::set_internal_control_function(std::shared_ptr<InternalControlFunction> internalControlFunction)
+	{
+		myControlFunction = internalControlFunction;
+	}
+
+	void DiagnosticProtocol::set_j1939_mode(bool value)
+	{
+		j1939Mode = value;
+	}
+
+	bool DiagnosticProtocol::get_j1939_mode() const
+	{
+		return j1939Mode;
+	}
+
+	void DiagnosticProtocol::clear_active_diagnostic_trouble_codes()
+	{
+		inactiveDTCList.insert(std::end(inactiveDTCList), std::begin(activeDTCList), std::end(activeDTCList));
+		activeDTCList.clear();
+	}
+
+	void DiagnosticProtocol::clear_inactive_diagnostic_trouble_codes()
+	{
+		inactiveDTCList.clear();
+	}
+
+	bool DiagnosticProtocol::set_diagnostic_trouble_code_active(const DiagnosticTroubleCode &dtc, bool active)
+	{
+		bool retVal = false;
+
+		if (active)
+		{
+			// First check to see if it's already active
+			auto activeLocation = std::find(activeDTCList.begin(), activeDTCList.end(), dtc);
+
+			if (activeDTCList.end() != activeLocation)
+			{
+				// Not already active. This is valid
+				auto inactiveLocation = std::find(inactiveDTCList.begin(), inactiveDTCList.end(), dtc);
+
+				if (inactiveDTCList.end() != inactiveLocation)
+				{
+					inactiveLocation->occuranceCount++;
+					activeDTCList.insert(inactiveDTCList.end(), std::make_move_iterator(inactiveLocation), std::make_move_iterator(activeDTCList.end()));
+					inactiveDTCList.erase(inactiveLocation);
+				}
+				else
+				{
+					activeDTCList.push_back(dtc);
+					activeDTCList[activeDTCList.size() - 1].occuranceCount = 1;
+
+					if (SystemTiming::get_time_elapsed_ms(lastDM1SentTimestamp) > DM_MAX_FREQUENCY_MS)
+					{
+						txFlags.set_flag(static_cast<std::uint32_t>(TransmitFlags::DM1));
+					}
+				}
+			}
+			else
+			{
+				// Already active!
+				retVal = false;
+			}
+		}
+		else
+		{
+			/// First check to see if it's already in the inactive list
+			auto inactiveLocation = std::find(inactiveDTCList.begin(), inactiveDTCList.end(), dtc);
+
+			if (inactiveDTCList.end() != inactiveLocation)
+			{
+				auto activeLocation = std::find(activeDTCList.begin(), activeDTCList.end(), dtc);
+
+				if (activeDTCList.end() != activeLocation)
+				{
+					inactiveDTCList.insert(activeDTCList.end(), std::make_move_iterator(activeLocation), std::make_move_iterator(inactiveDTCList.end()));
+					activeDTCList.erase(activeLocation);
+
+					if (SystemTiming::get_time_elapsed_ms(lastDM2SentTimestamp) > DM_MAX_FREQUENCY_MS)
+					{
+						txFlags.set_flag(static_cast<std::uint32_t>(TransmitFlags::DM2));
+					}
+				}
+			}
+			else
+			{
+				// Already inactive!
+				retVal = false;
+			}
+		}
+		return retVal;
+	}
+
+	void DiagnosticProtocol::update(CANLibBadge<CANNetworkManager>)
+	{
+		if (j1939Mode)
+		{
+			if (SystemTiming::time_expired_ms(lastDM1SentTimestamp, DM_MAX_FREQUENCY_MS))
+			{
+				txFlags.set_flag(static_cast<std::uint32_t>(TransmitFlags::DM1));
+			}
+
+			if (SystemTiming::time_expired_ms(lastDM2SentTimestamp, DM_MAX_FREQUENCY_MS))
+			{
+				txFlags.set_flag(static_cast<std::uint32_t>(TransmitFlags::DM2));
+			}
+		}
+		else
+		{
+			if ((0 != activeDTCList.size()) &&
+				(SystemTiming::time_expired_ms(lastDM1SentTimestamp, DM_MAX_FREQUENCY_MS)))
+			{
+				txFlags.set_flag(static_cast<std::uint32_t>(TransmitFlags::DM1));			
+			}
+
+			if ((0 != inactiveDTCList.size()) &&
+			    (SystemTiming::time_expired_ms(lastDM2SentTimestamp, DM_MAX_FREQUENCY_MS)))
+			{
+				txFlags.set_flag(static_cast<std::uint32_t>(TransmitFlags::DM2));
+			}
+		}
+		txFlags.process_all_flags();
+	}
+
+	bool DiagnosticProtocol::send_diagnostic_message_1()
+	{
+		bool retVal = false;
+
+		if (nullptr != myControlFunction)
+		{
+			std::uint16_t payloadSize = (activeDTCList.size() * DM_PAYLOAD_BYTES_PER_DTC) + 2; // 2 Bytes (0 and 1) are reserved
+			std::vector<std::uint8_t> buffer;
+
+			buffer.resize(payloadSize);
+			buffer[0] = 0xFF;
+			buffer[1] = 0xFF;
+
+			if (0 == activeDTCList.size())
+			{
+				buffer[2] = 0xFF;
+				buffer[3] = 0xFF;
+				buffer[4] = 0xFF;
+				buffer[5] = 0xFF;
+				retVal = CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::DiagnosticMessage1),
+				                                                        buffer.data(),
+				                                                        (DM_PAYLOAD_BYTES_PER_DTC + 2),
+				                                                        myControlFunction.get());
+			}
+			else
+			{
+				for (std::uint16_t i = 0; i < activeDTCList.size(); i++)
+				{
+					buffer[2 + (DM_PAYLOAD_BYTES_PER_DTC * i)] = static_cast<std::uint8_t>(activeDTCList[i].suspectParameterNumber & 0xFF);
+					buffer[3 + (DM_PAYLOAD_BYTES_PER_DTC * i)] = static_cast<std::uint8_t>((activeDTCList[i].suspectParameterNumber >> 8) & 0xFF);
+					buffer[4 + (DM_PAYLOAD_BYTES_PER_DTC * i)] = ((static_cast<std::uint8_t>((activeDTCList[i].suspectParameterNumber >> 16) & 0xFF) << 5) | static_cast<std::uint8_t>(activeDTCList[i].failureModeIdentifier & 0x1F));
+					buffer[5 + (DM_PAYLOAD_BYTES_PER_DTC * i)] = (activeDTCList[i].occuranceCount & 0x7F);
+				}
+				retVal = CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::DiagnosticMessage1),
+				                                                        buffer.data(),
+				                                                        payloadSize,
+				                                                        myControlFunction.get());
+			}
+		}
+		return retVal;
+	}
+
+	bool DiagnosticProtocol::send_diagnostic_message_2()
+	{
+		bool retVal = false;
+
+		if (nullptr != myControlFunction)
+		{
+			std::uint16_t payloadSize = (inactiveDTCList.size() * DM_PAYLOAD_BYTES_PER_DTC) + 2; // 2 Bytes (0 and 1) are reserved
+			std::vector<std::uint8_t> buffer;
+
+			buffer.resize(payloadSize);
+			buffer[0] = 0xFF;
+			buffer[1] = 0xFF;
+
+			if (0 == inactiveDTCList.size())
+			{
+				buffer[2] = 0xFF;
+				buffer[3] = 0xFF;
+				buffer[4] = 0xFF;
+				buffer[5] = 0xFF;
+				retVal = CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::DiagnosticMessage2),
+				                                                        buffer.data(),
+				                                                        (DM_PAYLOAD_BYTES_PER_DTC + 2),
+				                                                        myControlFunction.get());
+			}
+			else
+			{
+				for (std::uint16_t i = 0; i < inactiveDTCList.size(); i++)
+				{
+					buffer[2 + (DM_PAYLOAD_BYTES_PER_DTC * i)] = static_cast<std::uint8_t>(inactiveDTCList[i].suspectParameterNumber & 0xFF);
+					buffer[3 + (DM_PAYLOAD_BYTES_PER_DTC * i)] = static_cast<std::uint8_t>((inactiveDTCList[i].suspectParameterNumber >> 8) & 0xFF);
+					buffer[4 + (DM_PAYLOAD_BYTES_PER_DTC * i)] = ((static_cast<std::uint8_t>((inactiveDTCList[i].suspectParameterNumber >> 16) & 0xFF) << 5) | static_cast<std::uint8_t>(inactiveDTCList[i].failureModeIdentifier & 0x1F));
+					buffer[5 + (DM_PAYLOAD_BYTES_PER_DTC * i)] = (inactiveDTCList[i].occuranceCount & 0x7F);
+				}
+				retVal = CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::DiagnosticMessage2),
+				                                                        buffer.data(),
+				                                                        payloadSize,
+				                                                        myControlFunction.get());
+			}
+		}
+		return retVal;
+	}
+
+	bool DiagnosticProtocol::send_diagnostic_protocol_identification()
+	{
+		bool retVal = false;
+
+		if (nullptr != myControlFunction)
+		{
+			/// Bit 1 = J1939-73, Bit 2 = ISO 14230, Bit 3 = ISO 15765-3, else Reserved
+			constexpr std::uint8_t SUPPORTED_DIAGNOSTIC_PROTOCOLS_BITFIELD = 0x01;
+			std::array<std::uint8_t, CAN_DATA_LENGTH> buffer;
+
+			buffer.fill(0xFF); // Reserved bytes
+			buffer[0] = SUPPORTED_DIAGNOSTIC_PROTOCOLS_BITFIELD;
+			retVal = CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::DiagnosticProtocolIdentification),
+			                                                        buffer.data(),
+			                                                        CAN_DATA_LENGTH,
+			                                                        myControlFunction.get());
+		}
+		return retVal;
+	}
+
+	void DiagnosticProtocol::process_message(CANMessage *const message)
+	{
+		if (nullptr != message)
+		{
+			switch (message->get_identifier().get_parameter_group_number())
+			{
+				case static_cast<std::uint32_t>(CANLibParameterGroupNumber::DiagnosticMessage3):
+				{
+					clear_inactive_diagnostic_trouble_codes();
+					/// @todo ACK
+				}
+				break;
+
+				default:
+				{
+				}
+				break;
+			}
+		}
+	}
+
+	void DiagnosticProtocol::process_message(CANMessage *const message, void *parent)
+	{
+		if (nullptr != parent)
+		{
+			reinterpret_cast<DiagnosticProtocol *>(parent)->process_message(message);
+		}
+	}
+
+	void DiagnosticProtocol::process_flags(std::uint32_t flag, void *parentPointer)
+	{
+		if (nullptr != parentPointer)
+		{
+			DiagnosticProtocol *parent = reinterpret_cast<DiagnosticProtocol *>(parentPointer);
+			bool transmitSuccessful = false;
+
+			switch (flag)
+			{
+				case static_cast<std::uint32_t>(TransmitFlags::DM1):
+				{
+					transmitSuccessful = parent->send_diagnostic_message_1();
+
+					if (transmitSuccessful)
+					{
+						parent->lastDM1SentTimestamp = SystemTiming::get_timestamp_ms();
+					}
+				}
+				break;
+
+				case static_cast<std::uint32_t>(TransmitFlags::DM2):
+				{
+					transmitSuccessful = parent->send_diagnostic_message_2();
+
+					if (transmitSuccessful)
+					{
+						parent->lastDM2SentTimestamp = SystemTiming::get_timestamp_ms();
+					}
+				}
+				break;
+
+				case static_cast<std::uint32_t>(TransmitFlags::DiagnosticProtocolID):
+				{
+					transmitSuccessful = parent->send_diagnostic_protocol_identification();
+				}
+				break;
+
+				default:
+				{
+				
+				}
+				break;
+			}
+
+			if (false == transmitSuccessful)
+			{
+				parent->txFlags.set_flag(flag);
+			}
+		}
+	}
+
+} // namespace isobus

--- a/isobus/src/isobus_diagnostic_protocol.cpp
+++ b/isobus/src/isobus_diagnostic_protocol.cpp
@@ -177,7 +177,7 @@ namespace isobus
 				if (inactiveDTCList.end() != inactiveLocation)
 				{
 					inactiveLocation->occuranceCount++;
-					activeDTCList.insert(inactiveDTCList.end(), std::make_move_iterator(inactiveLocation), std::make_move_iterator(activeDTCList.end()));
+					activeDTCList.push_back(*inactiveLocation);
 					inactiveDTCList.erase(inactiveLocation);
 				}
 				else
@@ -209,7 +209,7 @@ namespace isobus
 
 				if (activeDTCList.end() != activeLocation)
 				{
-					inactiveDTCList.insert(activeDTCList.end(), std::make_move_iterator(activeLocation), std::make_move_iterator(inactiveDTCList.end()));
+					inactiveDTCList.push_back(*activeLocation);
 					activeDTCList.erase(activeLocation);
 
 					if (SystemTiming::get_time_elapsed_ms(lastDM2SentTimestamp) > DM_MAX_FREQUENCY_MS)
@@ -263,6 +263,244 @@ namespace isobus
 		txFlags.process_all_flags();
 	}
 
+	std::uint8_t DiagnosticProtocol::convert_flash_state_to_byte(FlashState flash)
+	{
+		std::uint8_t retVal = 0;
+
+		switch (flash)
+		{
+			case FlashState::Slow:
+			{
+				retVal = 0x00;
+			}
+			break;
+
+			case FlashState::Fast:
+			{
+				retVal = 0x01;
+			}
+			break;
+
+			case FlashState::Solid:
+			default:
+			{
+				retVal = 0x03;
+			}
+			break;
+		}
+		return retVal;
+	}
+
+	void DiagnosticProtocol::get_active_list_lamp_state_and_flash_state(Lamps targetLamp, FlashState &flash, bool &lampOn)
+	{
+		flash = FlashState::Solid;
+		lampOn = false;
+
+		for (auto dtc : activeDTCList)
+		{
+			switch (targetLamp)
+			{
+				case Lamps::AmberWarningLamp:
+				{
+					if (dtc.lampState == LampStatus::AmberWarningLampSolid)
+					{
+						lampOn = true;
+					}
+					else if (dtc.lampState == LampStatus::AmberWarningLampSlowFlash)
+					{
+						lampOn = true;
+						if (flash != FlashState::Fast)
+						{
+							flash = FlashState::Slow;
+						}
+					}
+					else if (dtc.lampState == LampStatus::AmberWarningLampFastFlash)
+					{
+						lampOn = true;
+						flash = FlashState::Fast;
+					}
+				}
+				break;
+
+				case Lamps::MalfunctionIndicatorLamp:
+				{
+					if (dtc.lampState == LampStatus::MalfunctionIndicatorLampSolid)
+					{
+						lampOn = true;
+					}
+					else if (dtc.lampState == LampStatus::MalfuctionIndicatorLampSlowFlash)
+					{
+						lampOn = true;
+						if (flash != FlashState::Fast)
+						{
+							flash = FlashState::Slow;
+						}
+					}
+					else if (dtc.lampState == LampStatus::MalfunctionIndicatorLampFastFlash)
+					{
+						lampOn = true;
+						flash = FlashState::Fast;
+					}
+				}
+				break;
+
+				case Lamps::ProtectLamp:
+				{
+					if (dtc.lampState == LampStatus::EngineProtectLampSolid)
+					{
+						lampOn = true;
+					}
+					else if (dtc.lampState == LampStatus::EngineProtectLampSlowFlash)
+					{
+						lampOn = true;
+						if (flash != FlashState::Fast)
+						{
+							flash = FlashState::Slow;
+						}
+					}
+					else if (dtc.lampState == LampStatus::EngineProtectLampFastFlash)
+					{
+						lampOn = true;
+						flash = FlashState::Fast;
+					}
+				}
+				break;
+
+				case Lamps::RedStopLamp:
+				{
+					if (dtc.lampState == LampStatus::RedStopLampSolid)
+					{
+						lampOn = true;
+					}
+					else if (dtc.lampState == LampStatus::RedStopLampSlowFlash)
+					{
+						lampOn = true;
+						if (flash != FlashState::Fast)
+						{
+							flash = FlashState::Slow;
+						}
+					}
+					else if (dtc.lampState == LampStatus::RedStopLampFastFlash)
+					{
+						lampOn = true;
+						flash = FlashState::Fast;
+					}
+				}
+				break;
+
+				default:
+				{
+				}
+				break;
+			}
+		}
+	}
+
+	void DiagnosticProtocol::get_inactive_list_lamp_state_and_flash_state(Lamps targetLamp, FlashState &flash, bool &lampOn)
+	{
+		flash = FlashState::Solid;
+		lampOn = false;
+
+		for (auto dtc : inactiveDTCList)
+		{
+			switch (targetLamp)
+			{
+				case Lamps::AmberWarningLamp:
+				{
+					if (dtc.lampState == LampStatus::AmberWarningLampSolid)
+					{
+						lampOn = true;
+					}
+					else if (dtc.lampState == LampStatus::AmberWarningLampSlowFlash)
+					{
+						lampOn = true;
+						if (flash != FlashState::Fast)
+						{
+							flash = FlashState::Slow;
+						}
+					}
+					else if (dtc.lampState == LampStatus::AmberWarningLampFastFlash)
+					{
+						lampOn = true;
+						flash = FlashState::Fast;
+					}
+				}
+				break;
+
+				case Lamps::MalfunctionIndicatorLamp:
+				{
+					if (dtc.lampState == LampStatus::MalfunctionIndicatorLampSolid)
+					{
+						lampOn = true;
+					}
+					else if (dtc.lampState == LampStatus::MalfuctionIndicatorLampSlowFlash)
+					{
+						lampOn = true;
+						if (flash != FlashState::Fast)
+						{
+							flash = FlashState::Slow;
+						}
+					}
+					else if (dtc.lampState == LampStatus::MalfunctionIndicatorLampFastFlash)
+					{
+						lampOn = true;
+						flash = FlashState::Fast;
+					}
+				}
+				break;
+
+				case Lamps::ProtectLamp:
+				{
+					if (dtc.lampState == LampStatus::EngineProtectLampSolid)
+					{
+						lampOn = true;
+					}
+					else if (dtc.lampState == LampStatus::EngineProtectLampSlowFlash)
+					{
+						lampOn = true;
+						if (flash != FlashState::Fast)
+						{
+							flash = FlashState::Slow;
+						}
+					}
+					else if (dtc.lampState == LampStatus::EngineProtectLampFastFlash)
+					{
+						lampOn = true;
+						flash = FlashState::Fast;
+					}
+				}
+				break;
+
+				case Lamps::RedStopLamp:
+				{
+					if (dtc.lampState == LampStatus::RedStopLampSolid)
+					{
+						lampOn = true;
+					}
+					else if (dtc.lampState == LampStatus::RedStopLampSlowFlash)
+					{
+						lampOn = true;
+						if (flash != FlashState::Fast)
+						{
+							flash = FlashState::Slow;
+						}
+					}
+					else if (dtc.lampState == LampStatus::RedStopLampFastFlash)
+					{
+						lampOn = true;
+						flash = FlashState::Fast;
+					}
+				}
+				break;
+
+				default:
+				{
+				}
+				break;
+			}
+		}
+	}
+
 	bool DiagnosticProtocol::protocol_transmit_message(std::uint32_t,
 	                                                   const std::uint8_t *,
 	                                                   std::uint32_t,
@@ -285,18 +523,53 @@ namespace isobus
 			std::vector<std::uint8_t> buffer;
 
 			buffer.resize(payloadSize);
-			buffer[0] = 0xFF;
-			buffer[1] = 0xFF;
+
+			if (get_j1939_mode())
+			{
+				bool tempLampState = false;
+				FlashState tempLampFlashState = FlashState::Solid;
+				get_active_list_lamp_state_and_flash_state(Lamps::ProtectLamp, tempLampFlashState, tempLampState);
+
+				/// Encode Protect state and flash
+				buffer[0] = tempLampState;
+				buffer[1] = convert_flash_state_to_byte(tempLampFlashState);
+
+				get_active_list_lamp_state_and_flash_state(Lamps::AmberWarningLamp, tempLampFlashState, tempLampState);
+
+				/// Encode amber warning lamp state and flash
+				buffer[0] |= (tempLampState << 2);
+				buffer[1] |= (convert_flash_state_to_byte(tempLampFlashState) << 2);
+
+				get_active_list_lamp_state_and_flash_state(Lamps::RedStopLamp, tempLampFlashState, tempLampState);
+
+				/// Encode red stop lamp state and flash
+				buffer[0] |= (tempLampState << 4);
+				buffer[1] |= (convert_flash_state_to_byte(tempLampFlashState) << 4);
+
+				get_active_list_lamp_state_and_flash_state(Lamps::MalfunctionIndicatorLamp, tempLampFlashState, tempLampState);
+
+				/// Encode malfunction indicator lamp state and flash
+				buffer[0] |= (tempLampState << 6);
+				buffer[1] |= (convert_flash_state_to_byte(tempLampFlashState) << 6);
+			}
+			else
+			{
+				// ISO 11783 does not use lamp state or lamp flash bytes
+				buffer[0] = 0xFF;
+				buffer[1] = 0xFF;
+			}
 
 			if (0 == activeDTCList.size())
 			{
-				buffer[2] = 0xFF;
-				buffer[3] = 0xFF;
-				buffer[4] = 0xFF;
-				buffer[5] = 0xFF;
+				buffer[2] = 0x00;
+				buffer[3] = 0x00;
+				buffer[4] = 0x00;
+				buffer[5] = 0x00;
+				buffer[6] = 0xFF;
+				buffer[7] = 0xFF;
 				retVal = CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::DiagnosticMessage1),
 				                                                        buffer.data(),
-				                                                        (DM_PAYLOAD_BYTES_PER_DTC + 2),
+				                                                        CAN_DATA_LENGTH,
 				                                                        myControlFunction.get());
 			}
 			else
@@ -323,22 +596,57 @@ namespace isobus
 
 		if (nullptr != myControlFunction)
 		{
-			std::uint16_t payloadSize = (inactiveDTCList.size() * DM_PAYLOAD_BYTES_PER_DTC) + 2; // 2 Bytes (0 and 1) are reserved
+			std::uint16_t payloadSize = (inactiveDTCList.size() * DM_PAYLOAD_BYTES_PER_DTC) + 2; // 2 Bytes (0 and 1) are reserved or used for lamp + flash
 			std::vector<std::uint8_t> buffer;
 
 			buffer.resize(payloadSize);
-			buffer[0] = 0xFF;
-			buffer[1] = 0xFF;
+
+			if (get_j1939_mode())
+			{
+				bool tempLampState = false;
+				FlashState tempLampFlashState = FlashState::Solid;
+				get_inactive_list_lamp_state_and_flash_state(Lamps::ProtectLamp, tempLampFlashState, tempLampState);
+
+				/// Encode Protect state and flash
+				buffer[0] = tempLampState;
+				buffer[1] = convert_flash_state_to_byte(tempLampFlashState);
+
+				get_inactive_list_lamp_state_and_flash_state(Lamps::AmberWarningLamp, tempLampFlashState, tempLampState);
+
+				/// Encode amber warning lamp state and flash
+				buffer[0] |= (tempLampState << 2);
+				buffer[1] |= (convert_flash_state_to_byte(tempLampFlashState) << 2);
+
+				get_inactive_list_lamp_state_and_flash_state(Lamps::RedStopLamp, tempLampFlashState, tempLampState);
+
+				/// Encode red stop lamp state and flash
+				buffer[0] |= (tempLampState << 4);
+				buffer[1] |= (convert_flash_state_to_byte(tempLampFlashState) << 4);
+
+				get_inactive_list_lamp_state_and_flash_state(Lamps::MalfunctionIndicatorLamp, tempLampFlashState, tempLampState);
+
+				/// Encode malfunction indicator lamp state and flash
+				buffer[0] |= (tempLampState << 6);
+				buffer[1] |= (convert_flash_state_to_byte(tempLampFlashState) << 6);
+			}
+			else
+			{
+				// ISO 11783 does not use lamp state or lamp flash bytes
+				buffer[0] = 0xFF;
+				buffer[1] = 0xFF;
+			}
 
 			if (0 == inactiveDTCList.size())
 			{
-				buffer[2] = 0xFF;
-				buffer[3] = 0xFF;
-				buffer[4] = 0xFF;
-				buffer[5] = 0xFF;
+				buffer[2] = 0x00;
+				buffer[3] = 0x00;
+				buffer[4] = 0x00;
+				buffer[5] = 0x00;
+				buffer[6] = 0xFF;
+				buffer[7] = 0xFF;
 				retVal = CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::DiagnosticMessage2),
 				                                                        buffer.data(),
-				                                                        (DM_PAYLOAD_BYTES_PER_DTC + 2),
+				                                                        CAN_DATA_LENGTH,
 				                                                        myControlFunction.get());
 			}
 			else
@@ -355,6 +663,34 @@ namespace isobus
 				                                                        payloadSize,
 				                                                        myControlFunction.get());
 			}
+		}
+		return retVal;
+	}
+
+	bool DiagnosticProtocol::send_diagnostic_message_3_ack(ControlFunction *destination)
+	{
+		std::array<std::uint8_t, CAN_DATA_LENGTH> buffer;
+		bool retVal = false;
+
+		// "A positive or negative acknowledgement is not required in response to a global request."
+		if (nullptr != destination)
+		{
+			constexpr std::uint32_t DM3PGN = static_cast<std::uint32_t>(CANLibParameterGroupNumber::DiagnosticMessage3);
+
+			buffer[0] = 0x00; // Positive acknowledgement
+			buffer[1] = 0xFF; // Group function value
+			buffer[2] = 0xFF; // Reserved
+			buffer[3] = 0xFF; // Reserved
+			buffer[4] = destination->get_address(); // Address acknowledged
+			buffer[5] = (DM3PGN & 0xFF); // PGN LSB
+			buffer[6] = ((DM3PGN >> 8) & 0xFF); // PGN middle byte
+			buffer[7] = ((DM3PGN >> 16) & 0xFF); // PGN MSB
+
+			retVal = CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::Acknowledge),
+			                                                        buffer.data(),
+			                                                        CAN_DATA_LENGTH,
+			                                                        myControlFunction.get(),
+			                                                        nullptr);
 		}
 		return retVal;
 	}
@@ -385,10 +721,21 @@ namespace isobus
 		{
 			switch (message->get_identifier().get_parameter_group_number())
 			{
-				case static_cast<std::uint32_t>(CANLibParameterGroupNumber::DiagnosticMessage3):
+				case static_cast<std::uint32_t>(CANLibParameterGroupNumber::ParameterGroupNumberRequest):
 				{
-					clear_inactive_diagnostic_trouble_codes();
-					/// @todo ACK
+					if (3 == message->get_data_length()) /// PGN requests DLC is 3
+					{
+						std::vector<std::uint8_t> messageData = message->get_data();
+						std::uint32_t requestedPGN =  static_cast<std::uint32_t>(messageData.at(0));
+						requestedPGN |= (static_cast<std::uint32_t>(messageData.at(1)) << 8);
+						requestedPGN |= (static_cast<std::uint32_t>(messageData.at(2)) << 16);
+
+						if (static_cast<std::uint32_t>(CANLibParameterGroupNumber::DiagnosticMessage3) == requestedPGN)
+						{
+							clear_inactive_diagnostic_trouble_codes();
+							send_diagnostic_message_3_ack(message->get_source_control_function());
+						}
+					}
 				}
 				break;
 

--- a/isobus/src/isobus_diagnostic_protocol.cpp
+++ b/isobus/src/isobus_diagnostic_protocol.cpp
@@ -826,6 +826,12 @@ namespace isobus
 							}
 							break;
 
+							case static_cast<std::uint32_t>(CANLibParameterGroupNumber::DiagnosticProtocolIdentification):
+							{
+								txFlags.set_flag(static_cast<std::uint32_t>(TransmitFlags::DiagnosticProtocolID));
+							}
+							break;
+
 							default:
 							{
 								// This PGN request is not handled by the diagnostic protocol

--- a/isobus/src/isobus_diagnostic_protocol.cpp
+++ b/isobus/src/isobus_diagnostic_protocol.cpp
@@ -188,6 +188,7 @@ namespace isobus
 					if (SystemTiming::get_time_elapsed_ms(lastDM1SentTimestamp) > DM_MAX_FREQUENCY_MS)
 					{
 						txFlags.set_flag(static_cast<std::uint32_t>(TransmitFlags::DM1));
+						lastDM1SentTimestamp = SystemTiming::get_timestamp_ms();
 					}
 				}
 			}
@@ -214,6 +215,7 @@ namespace isobus
 					if (SystemTiming::get_time_elapsed_ms(lastDM2SentTimestamp) > DM_MAX_FREQUENCY_MS)
 					{
 						txFlags.set_flag(static_cast<std::uint32_t>(TransmitFlags::DM2));
+						lastDM2SentTimestamp = SystemTiming::get_timestamp_ms();
 					}
 				}
 			}
@@ -233,38 +235,42 @@ namespace isobus
 			if (SystemTiming::time_expired_ms(lastDM1SentTimestamp, DM_MAX_FREQUENCY_MS))
 			{
 				txFlags.set_flag(static_cast<std::uint32_t>(TransmitFlags::DM1));
+				lastDM1SentTimestamp = SystemTiming::get_timestamp_ms();
 			}
 
 			if (SystemTiming::time_expired_ms(lastDM2SentTimestamp, DM_MAX_FREQUENCY_MS))
 			{
 				txFlags.set_flag(static_cast<std::uint32_t>(TransmitFlags::DM2));
+				lastDM2SentTimestamp = SystemTiming::get_timestamp_ms();
 			}
 		}
 		else
 		{
 			if ((0 != activeDTCList.size()) &&
-				(SystemTiming::time_expired_ms(lastDM1SentTimestamp, DM_MAX_FREQUENCY_MS)))
+			    (SystemTiming::time_expired_ms(lastDM1SentTimestamp, DM_MAX_FREQUENCY_MS)))
 			{
-				txFlags.set_flag(static_cast<std::uint32_t>(TransmitFlags::DM1));			
+				txFlags.set_flag(static_cast<std::uint32_t>(TransmitFlags::DM1));
+				lastDM1SentTimestamp = SystemTiming::get_timestamp_ms();
 			}
 
 			if ((0 != inactiveDTCList.size()) &&
 			    (SystemTiming::time_expired_ms(lastDM2SentTimestamp, DM_MAX_FREQUENCY_MS)))
 			{
 				txFlags.set_flag(static_cast<std::uint32_t>(TransmitFlags::DM2));
+				lastDM2SentTimestamp = SystemTiming::get_timestamp_ms();
 			}
 		}
 		txFlags.process_all_flags();
 	}
 
-	bool DiagnosticProtocol::protocol_transmit_message(std::uint32_t ,
-	                               const std::uint8_t *,
-	                               std::uint32_t ,
-	                               ControlFunction *,
-	                               ControlFunction *,
-	                               TransmitCompleteCallback ,
-	                               void *,
-	                               DataChunkCallback)
+	bool DiagnosticProtocol::protocol_transmit_message(std::uint32_t,
+	                                                   const std::uint8_t *,
+	                                                   std::uint32_t,
+	                                                   ControlFunction *,
+	                                                   ControlFunction *,
+	                                                   TransmitCompleteCallback,
+	                                                   void *,
+	                                                   DataChunkCallback)
 	{
 		return false;
 	}
@@ -441,7 +447,6 @@ namespace isobus
 
 				default:
 				{
-				
 				}
 				break;
 			}


### PR DESCRIPTION
Added the following ISO 11783 and J1939 diagnostic protocol components:
* Diagnostic Message 1 (DM1) - Active diagnostic trouble codes, supports either J1939 mode or ISO 11783 mode (default)!
* Diagnostic Message 2 (DM2) - Previously active diagnostic trouble codes
* Diagnostic Message 3 (DM3), -  Reset of previously active diagnostic trouble codes
* Diagnostic Message 11 (DM11) - Reset for active diagnostic trouble codes
* Diagnostic Message 22 (DM22) - Individual clear/reset of active and previously active diagnostic trouble code
* ISO 11783 Product Identification message
* ISO 11783 Diagnostic protocol "supported protocols" message (SAE J1939-73 support is advertised by the stack)

Added a diagnostic protocol example program to show how to use it (if you want to use it).
Updated README
