### PR TITLE
[DP]: Added Software ID and ECU ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The state of the project is as follows...
     - Diagnostic Message 22: Complete :white_check_mark:
     - Product Identification: Complete :white_check_mark:
     - Diagnostic Protocol message Complete :white_check_mark:
+    - Software and ECU Identification Complete :white_check_mark:
     - Control Function Functionalities Message: Not yet supported :x:
         - Submit an issue please if this is a priority for your project!
 ### Planned Features (in no particular order):

--- a/examples/diagnostic_protocol/main.cpp
+++ b/examples/diagnostic_protocol/main.cpp
@@ -73,6 +73,22 @@ int main()
 	isobus::DiagnosticProtocol::DiagnosticTroubleCode testDTC2(567, isobus::DiagnosticProtocol::FailureModeIdentifier::DataErratic, isobus::DiagnosticProtocol::LampStatus::AmberWarningLampSlowFlash);
 	isobus::DiagnosticProtocol::DiagnosticTroubleCode testDTC3(8910, isobus::DiagnosticProtocol::FailureModeIdentifier::BadIntellegentDevice, isobus::DiagnosticProtocol::LampStatus::RedStopLampSolid);
 
+	// Set a product identification string (in case someone requests it)
+	diagnosticProtocol->set_product_identification_code("1234567890ABC");
+	diagnosticProtocol->set_product_identification_brand("Del Grosso Engineering");
+	diagnosticProtocol->set_product_identification_model("ISO 11783 CAN Stack DP Example");
+	
+	// Set a software ID string (This is what tells other ECUs what version your software is)
+	diagnosticProtocol->set_software_id_field(0, "Diagnostic Protocol Example 1.0.0");
+	diagnosticProtocol->set_software_id_field(1, "Another version string x.x.x.x");
+
+	// Set an ECU ID (This is what tells other ECUs more details about your specific physical ECU)
+	diagnosticProtocol->set_ecu_id_field(isobus::DiagnosticProtocol::ECUIdentificationFields::HardwareID, "Hardware ID");
+	diagnosticProtocol->set_ecu_id_field(isobus::DiagnosticProtocol::ECUIdentificationFields::Location, "The Aether");
+	diagnosticProtocol->set_ecu_id_field(isobus::DiagnosticProtocol::ECUIdentificationFields::ManufacturerName, "None");
+	diagnosticProtocol->set_ecu_id_field(isobus::DiagnosticProtocol::ECUIdentificationFields::PartNumber, "1234");
+	diagnosticProtocol->set_ecu_id_field(isobus::DiagnosticProtocol::ECUIdentificationFields::SerialNumber, "1");
+
 	if (nullptr != diagnosticProtocol)
 	{
 		// Set the DTCs active. This should put them in the DM1 message

--- a/isobus/include/can_general_parameter_group_numbers.hpp
+++ b/isobus/include/can_general_parameter_group_numbers.hpp
@@ -30,10 +30,12 @@ namespace isobus
 		ProductIdentification = 0xFC8D,
 		DiagnosticProtocolIdentification = 0xFD32,
 		WorkingSetMaster = 0xFE0D,
+		ECUIdentificationInformation = 0xFDC5,
 		DiagnosticMessage1 = 0xFECA,
 		DiagnosticMessage2 = 0xFECB,
 		DiagnosticMessage3 = 0xFECC,
-		DiagnosticMessage11 = 0xFED3
+		DiagnosticMessage11 = 0xFED3,
+		SoftwareIdentification = 0xFEDA
 	};
 
 } // namespace isobus


### PR DESCRIPTION
Now you can tell the stack ECU and software ID information, and it will respond with that information when it is requested. These messages are extrememly common, and are used by a lot of onboard and offboard (OBD) tools to interrogate a system.