### PR TITLE
[DP]: Fix diagnostic protocol compilation fails on GCC 11.2.1

### DIFF
--- a/isobus/include/isobus_diagnostic_protocol.hpp
+++ b/isobus/include/isobus_diagnostic_protocol.hpp
@@ -27,6 +27,7 @@
 
 #include <list>
 #include <memory>
+#include <string>
 
 namespace isobus
 {


### PR DESCRIPTION
Compilation was failing during testing with GCC 11 on RHEL 9 due to a missing include for string.
Added that string, now there are no errors or warnings on GCC 11.2.1