### PR TITLE
[PR]: Add PGN Request Protocol

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ add_subdirectory("socket_can")
 add_subdirectory("examples/vt_version_3_object_pool")
 add_subdirectory("examples/transport_layer")
 add_subdirectory("examples/diagnostic_protocol")
+add_subdirectory("examples/pgn_requests")
 
 add_executable(unit_tests test/address_claim_test.cpp test/test_CAN_glue.cpp test/identifier_tests.cpp)
 target_link_libraries(unit_tests gtest_main Isobus SocketCANInterface)

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ The state of the project is as follows...
     - Software and ECU Identification Complete :white_check_mark:
     - Control Function Functionalities Message: Not yet supported :x:
         - Submit an issue please if this is a priority for your project!
+- PGN Requests and Requests for Repetition Rate: Complete :white_check_mark:
+- Tutorial [in review](https://github.com/ad3154/ISO11783-CAN-Stack/pull/35)
 ### Planned Features (in no particular order):
-- Tutorial
 - ISO11783 File Server
 - ISO11783 Task Controller (currently planned to be client only)
-- PGN Request interface
 - Common ISO11783-5 Messages (guidance command, machine selected speed, etc.)
 - J1939 DM13 (Stop/Start Broadcast)
 - NMEA2000 Fast Packet Protocol

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ sudo apt install doxygen graphviz
 ```
 Then, generate the docs:
 ```
-doxygen
+doxygen doxyfile
 ```
 
 The documentation will appear in the docs/html folder. Open `index.html` in a web browser to start browsing the docs.

--- a/examples/pgn_requests/CMakeLists.txt
+++ b/examples/pgn_requests/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.16)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+add_executable(PGNRequestExampleTarget main.cpp)
+target_link_libraries(PGNRequestExampleTarget Isobus SocketCANInterface Threads::Threads SystemTiming)

--- a/examples/pgn_requests/README.md
+++ b/examples/pgn_requests/README.md
@@ -1,0 +1,177 @@
+# PGN Request Handling Example
+
+This example shows how you can use the CAN stack to simplify working with PGN requests (PGN 0xEA00) and PGN requests for repetition rate (PGN 0xCC00).
+
+The example sets up an internal control function (ICF) to transmit as, tells the stack that it wants to accept PGN requests for that ICF, sets up handling of the PROPA PGN (0xEF00), and sends a requst of its own to the broadcast address.
+
+For this example to work properly, you must have a valid, functional ISO 11783 CAN network connected as "can0".
+
+## The Basics
+
+This example will assume you have already learned the basics of the stack and ISOBUS communication, and won't go over the basic setup of your internal control function. If you need to brush up on those topics, check out the [transport layer example](https://github.com/ad3154/ISO11783-CAN-Stack/tree/main/examples/transport_layer) first, or visit our [tutorial website](https://delgrossoengineering.com/isobus-tutorial/index.html).
+
+## PGN Requests
+
+The Request message type, identified by the PGN 0xEA00 (59904) provides the ability to request information globally or from a specific destination.
+
+Basically if someone requests a PGN from you using this request PGN, they are politely asking you to either send them a message with that PGN, or perform some action. You have a choice to either respond with the data they want, send the Acknowledgement PGN (this is called ACK or NACK depending on if the acknowledgement is positive or negative), or do nothing.
+
+See ISO 11783-3 for a full description, but here are some general things to keep in mind regarding this message.
+
+* If the request or applicable PGN is sent to the global address, then the response is sent to the global address. The stack will currently always send ACK/NACK responses to the broadcast address, but you can send any reponse you want from your application in response to these requests. Using the CAN stack's ACK/NACK functionality is completely optional.
+* A NACK is not desired as a response to a global request. The CAN stack _will not send them_ in response to a global request.
+* A NACK is required if the PGN is not supported. _It is highly recommended you assign an instance of the PGN request protocol to every internal control function you make if you wish to be in compliance with this rule._ As long as you tell the stack to handle these requests, it will NACK any unhandled request.
+
+### Configuring PGN Request Handling
+
+PGN requests and requests for repetition rate are optional features that the CAN stack can handle for you, similar to how the Diagnostic Protocol is an optional feature. If you want to enable this functionality for one of your internal control functions, all you need to do is tell the CAN stack to assign the PGN request protocol to that internal control function. Like this:
+
+```
+isobus::ParameterGroupNumberRequestProtocol::assign_pgn_request_protocol_to_internal_control_function(<your internal control function goes here>);
+```
+
+This will create an instance of the protocol, and the stack will begin handling requests. By default, it will NACK all requests until you explicitly handle a PGN. Then, requests that match that PGN will be forwarded to your application via a callback.
+
+You can also pass in a callback that handles ALL PGNs sent to that internal control function if you want by using the meta PGN called `isobus::CANLibParameterGroupNumber::Any`.
+
+### Receiving a PGN Request
+
+The CAN stack can provide your application with a callback whenever it receives a PGN request destined for one of your application's internal control functions. This will allow you to transmit the requested data in your application. Or, you can tell the CAN stack from within your callback to ACK or NACK the request on your behalf. You can even take absolutely no action if you want to.
+
+Here's an example callback that is meant to handle PROPA PGN (0xEF00) requests, and tells the CAN stack to send a positive acknowledgement back to the requestor.
+```
+bool example_proprietary_a_pgn_request_handler(std::uint32_t parameterGroupNumber,
+                                               isobus::ControlFunction *,
+                                               bool &acknowledge,
+                                               isobus::AcknowledgementType &acknowledgeType,
+                                               void *)
+{
+	bool retVal;
+
+	// This function will be called whenever PGN EF00 is requested.
+	// Add whatever logic you want execute to on reciept of a PROPA request.
+	// One normal thing to do would be to send a CAN message with that PGN.
+
+	// In this example though, we'll simply acknowledge the request.
+	if (static_cast<std::uint32_t>(isobus::CANLibParameterGroupNumber::ProprietaryA) == parameterGroupNumber)
+	{
+        // These tell the CAN stack we want it to ACK the request on our behalf.
+		acknowledge = true;
+		acknowledgeType = isobus::AcknowledgementType::Positive;
+		retVal = true;
+	}
+	else
+	{
+		// If any other PGN is passed-in, or we don't want to handle this callback for some reason return false.
+		// Returning false will tell the stack to keep looking for another callback (if any exist) to handle this PGN.
+        // Note that the CAN stack will not call this callback with a PGN that you weren't expecting unless you
+        // mis-register the callback with the wrong PGN.
+		retVal = false;
+	}
+	return retVal;
+}
+```
+
+In order for this callback to be called at the appropriate times, you must register it with the CAN stack, like this:
+
+```
+// Get a pointer to the protocol instance
+isobus::ParameterGroupNumberRequestProtocol *pgnRequestProtocol = isobus::ParameterGroupNumberRequestProtocol::get_pgn_request_protocol_by_internal_control_function(<your internal control function>);
+
+
+pgnRequestProtocol->register_pgn_request_callback(static_cast<std::uint32_t>(isobus::CANLibParameterGroupNumber::ProprietaryA), example_proprietary_a_pgn_request_handler, nullptr);
+```
+
+Here you can see we're asking the CAN stack for the protocol instance we created earlier, and we're telling the stack to call our callback whenever it receives a PGN request for PROPA.
+
+### Sending a PGN Request
+
+Sending a PGN request is extremely simple. The CAN stack will take care of message encoding for you. All you need to do is call the function `isobus::ParameterGroupNumberRequestProtocol::request_parameter_group_number`.
+
+Here's what that looks like in the example:
+
+```
+
+isobus::ParameterGroupNumberRequestProtocol::request_parameter_group_number(static_cast<std::uint32_t>(isobus::CANLibParameterGroupNumber::ProprietaryA), TestInternalECU.get(), nullptr);
+
+```
+
+The three parameters are:
+
+* The PGN to request
+* The internal control function to send from
+* The destination control function to send to, or `nullptr` if you want to send it to the broadcast address
+
+This function will return `true` if the request was sent.
+
+## Requests for Repetition Rate
+
+This message, identified by PGN 0xCC00 (52224) allows the system to adapt the bus bandwidth to the needs of the user of the message. Essentially, it's a way for a control function to ask another control function politely to send it a specific PGN at a desired rate. This includes a default rate that can be requested with a value of 0x0000. If it is possible for the source of the message with the requested PGN to deliver the message with the desired repetition rate, it should honour the request.
+
+Some important notes about this message:
+
+* Control functions are not required to monitor the bus for this message.
+* If another control function cannot or does not want to use the requested repetition rate, which is necessary for systems with fixed timing control loops, it may ignore this message. As such _the CAN stack will not NACK unhandled requests for this PGN, as it is not required._
+* If no response for repetition rate has been received, the requester shall assume that the request was not accepted. It is up to your application for how you want to deal with this.
+
+### Configuring Requests for Repetition Rate Handling
+
+Configuring the handling of this message is the same as configuring handling of PGN requests. If you've assigned the PGN request protocol an internal control function, requests for repetition rate will also be handled.
+
+### Receiving Requests for Repetition Rate
+
+The CAN stack can provide your application with a callback whenever it receives a request for repetition rate destined for one of your application's internal control functions. This will allow you to transmit the requested data in your application.
+
+Here's an example callback that is meant to handle PROPA PGN (0xEF00) requests for repetition rate:
+
+```
+bool example_proprietary_a_request_for_repetition_rate_handler(std::uint32_t parameterGroupNumber,
+                                                               isobus::ControlFunction *requestingControlFunction,
+                                                               std::uint32_t repetitionRate,
+                                                               void *)
+{
+	bool retVal;
+
+	if (static_cast<std::uint32_t>(isobus::CANLibParameterGroupNumber::ProprietaryA) == parameterGroupNumber)
+	{
+		retVal = true;
+
+		// Put whatever logic you want to in here so that you can begin to handle the request.
+		// The CAN stack provides this easy way to receive requests for repetition rate, but
+		// your application must handle the actual processing and sending of those messages at the requested rate
+		// since the stack has no idea what your application actually does with most PGNs.
+
+		// In this example, I'll handle it by saving the repetition rate in a global variable and have 
+		// main() service it at the desired rate.
+		repetitionRateRequestor = requestingControlFunction;
+		propARepetitionRate_ms = repetitionRate;
+	}
+	else
+	{
+		// If any other PGN is requested, since this callback doesn't handle it, return false.
+		// Returning false will tell the stack to keep looking for another callback (if any exist) to handle this PGN
+		retVal = false;
+	}
+	return retVal;
+}
+```
+
+In order for this callback to be called at the appropriate times, you must register it with the CAN stack, like this:
+
+```
+// Get a pointer to the protocol instance
+isobus::ParameterGroupNumberRequestProtocol *pgnRequestProtocol = isobus::ParameterGroupNumberRequestProtocol::get_pgn_request_protocol_by_internal_control_function(<your internal control function>);
+
+// Now we'll set up a callback to handle requests for repetition rate for the PROPA PGN
+pgnRequestProtocol->register_request_for_repetition_rate_callback(static_cast<std::uint32_t>(isobus::CANLibParameterGroupNumber::ProprietaryA), example_proprietary_a_request_for_repetition_rate_handler, nullptr);
+```
+
+Here you can see we're asking the CAN stack for the protocol instance we created earlier, and we're telling the stack to call our callback whenever it receives a request for repetition rate specifically for the PROPA PGN.
+
+### Sending a Request for Repetition Rate
+
+Sending a request for repetition rate is as simple as it was for a PGN request. The CAN stack will take care of message encoding for you. All you need to do is call the function `isobus::ParameterGroupNumberRequestProtocol::request_repetition_rate`.
+
+The use of this was omitted in the example, as it does not make sense to request a repetition rate from the broadcast address, and I do not know what devices you might have on your bus, so I suggest you check out the doxygen for this function so you are familliar with its parameters and usage.
+
+That's all for this example! You should now be able to easily deal with PGN requests and requests for repetition rate in your application.

--- a/examples/pgn_requests/main.cpp
+++ b/examples/pgn_requests/main.cpp
@@ -1,0 +1,178 @@
+#include "can_general_parameter_group_numbers.hpp"
+#include "can_network_configuration.hpp"
+#include "can_network_manager.hpp"
+#include "socket_can_interface.hpp"
+#include "can_parameter_group_number_request_protocol.hpp"
+
+#include <csignal>
+#include <iostream>
+#include <memory>
+
+static std::shared_ptr<isobus::InternalControlFunction> TestInternalECU = nullptr;
+static std::uint32_t propARepetitionRate_ms = 0xFFFFFFFF;
+static isobus::ControlFunction *repetitionRateRequestor = nullptr;
+
+using namespace std;
+
+void cleanup()
+{
+	CANHardwareInterface::stop();
+}
+
+void signal_handler(int signum)
+{
+	cleanup();
+	exit(signum);
+}
+
+void update_CAN_network()
+{
+	isobus::CANNetworkManager::CANNetwork.update();
+}
+
+void raw_can_glue(isobus::HardwareInterfaceCANFrame &rawFrame, void *parentPointer)
+{
+	isobus::CANNetworkManager::CANNetwork.can_lib_process_rx_message(rawFrame, parentPointer);
+}
+
+bool example_proprietary_a_pgn_request_handler(std::uint32_t parameterGroupNumber,
+                                               isobus::ControlFunction *,
+                                               bool &acknowledge,
+                                               isobus::AcknowledgementType &acknowledgeType,
+                                               void *)
+{
+	bool retVal;
+
+	// This function will be called whenever PGN EF00 is requested.
+	// Add whatever logic you want execute to on reciept of a PROPA request.
+	// One normal thing to do would be to send a CAN message with that PGN.
+
+	// In this example though, we'll simply acknowledge the request.
+	if (static_cast<std::uint32_t>(isobus::CANLibParameterGroupNumber::ProprietaryA) == parameterGroupNumber)
+	{
+		acknowledge = true;
+		acknowledgeType = isobus::AcknowledgementType::Positive;
+		retVal = true;
+	}
+	else
+	{
+		// If any other PGN is requested, since this callback doesn't handle it, return false.
+		// Returning false will tell the stack to keep looking for another callback (if any exist) to handle this PGN
+		retVal = false;
+	}
+	return retVal;
+}
+
+bool example_proprietary_a_request_for_repetition_rate_handler(std::uint32_t parameterGroupNumber,
+                                                               isobus::ControlFunction *requestingControlFunction,
+                                                               std::uint32_t repetitionRate,
+                                                               void *)
+{
+	bool retVal;
+
+	if (static_cast<std::uint32_t>(isobus::CANLibParameterGroupNumber::ProprietaryA) == parameterGroupNumber)
+	{
+		retVal = true;
+
+		// Put whatever logic you want to in here so that you can begin to handle the request.
+		// The CAN stack provides this easy way to receive requests for repetition rate, but
+		// your application must handle the actual processing and sending of those messages at the requested rate
+		// since the stack has no idea what your application actually does with most PGNs.
+
+		// In this example, I'll handle it by saving the repetition rate in a global variable and have 
+		// main() service it at the desired rate.
+		repetitionRateRequestor = requestingControlFunction;
+		propARepetitionRate_ms = repetitionRate;
+	}
+	else
+	{
+		// If any other PGN is requested, since this callback doesn't handle it, return false.
+		// Returning false will tell the stack to keep looking for another callback (if any exist) to handle this PGN
+		retVal = false;
+	}
+	return retVal;
+}
+
+void setup()
+{
+	CANHardwareInterface::set_number_of_can_channels(1);
+	CANHardwareInterface::assign_can_channel_frame_handler(0, "can0");
+	CANHardwareInterface::start();
+
+	CANHardwareInterface::add_can_lib_update_callback(update_CAN_network, nullptr);
+	CANHardwareInterface::add_raw_can_message_rx_callback(raw_can_glue, nullptr);
+
+	std::this_thread::sleep_for(std::chrono::milliseconds(250));
+
+	isobus::NAME TestDeviceNAME(0);
+
+	// Make sure you change these for your device!!!!
+	// This is an example device that is using a manufacturer code that is currently unused at time of writing
+	TestDeviceNAME.set_arbitrary_address_capable(true);
+	TestDeviceNAME.set_industry_group(1);
+	TestDeviceNAME.set_device_class(0);
+	TestDeviceNAME.set_function_code(static_cast<std::uint8_t>(isobus::NAME::Function::SteeringControl));
+	TestDeviceNAME.set_identity_number(2);
+	TestDeviceNAME.set_ecu_instance(0);
+	TestDeviceNAME.set_function_instance(0);
+	TestDeviceNAME.set_device_class_instance(0);
+	TestDeviceNAME.set_manufacturer_code(64);
+
+	TestInternalECU = std::make_shared<isobus::InternalControlFunction>(TestDeviceNAME, 0x1C, 0);
+	std::signal(SIGINT, signal_handler);
+
+	// Wait to make sure address claiming is done. The time is arbitrary.
+	std::this_thread::sleep_for(std::chrono::milliseconds(1250));
+}
+
+int main()
+{
+	setup();
+
+	// Tell the CAN stack that we want to respond to PGN requests that are sent to our internal control function
+	isobus::ParameterGroupNumberRequestProtocol::assign_pgn_request_protocol_to_internal_control_function(TestInternalECU);
+
+	// Get a pointer to the protocol instance we just assigned
+	isobus::ParameterGroupNumberRequestProtocol *pgnRequestProtocol = isobus::ParameterGroupNumberRequestProtocol::get_pgn_request_protocol_by_internal_control_function(TestInternalECU);
+
+	// Register a callback to handle PROPA PGN Requests
+	if (nullptr != pgnRequestProtocol)
+	{
+		pgnRequestProtocol->register_pgn_request_callback(static_cast<std::uint32_t>(isobus::CANLibParameterGroupNumber::ProprietaryA), example_proprietary_a_pgn_request_handler, nullptr);
+
+		// Now, if you send a PGN request for EF00 to our internal control function, the stack will acknowledge it. Other requests will be NACK'ed (negative acknowledged)
+		// NOTE the device you send from MUST have address claimed.
+
+		// Now we'll set up a callback to handle requests for repetition rate for the PROPA PGN
+		pgnRequestProtocol->register_request_for_repetition_rate_callback(static_cast<std::uint32_t>(isobus::CANLibParameterGroupNumber::ProprietaryA), example_proprietary_a_request_for_repetition_rate_handler, nullptr);
+
+		// Now we'll get a callback when someone requests a repetition rate for PROPA.
+		// The application (not the stack) must handle these requests, as the CAN stack does not know what data to send when responding.
+		// It's entirely application defined!
+		// So we'll handle that below in the `while(true)` loop as an example.
+		// You do not need to handle every PGN. Only ones you care about. ISOBUS allows you to ignore any and all requests for repetition rate if you want with no reponse needed.
+
+		// This is how you would request a PGN from someone else. In this example, we request it from the broadcast address.
+		// Generally you'd want to replace nullptr with your partner control function as its a little nicer than just asking everyone on the bus for a PGN
+		isobus::ParameterGroupNumberRequestProtocol::request_parameter_group_number(static_cast<std::uint32_t>(isobus::CANLibParameterGroupNumber::ProprietaryA), TestInternalECU.get(), nullptr);
+	}
+
+	while (true)
+	{
+		if (0xFFFFFFFF != propARepetitionRate_ms)
+		{
+			// If someone has requested a repetition rate for PROPA, service it here (in the application layer)
+			std::uint8_t buffer[isobus::CAN_DATA_LENGTH] = { 0 };
+			isobus::CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(isobus::CANLibParameterGroupNumber::ProprietaryA), buffer, isobus::CAN_DATA_LENGTH, TestInternalECU.get(), repetitionRateRequestor);
+			std::this_thread::sleep_for(std::chrono::milliseconds(propARepetitionRate_ms));
+		}
+		else
+		{
+			std::this_thread::sleep_for(std::chrono::milliseconds(5)); // Do nothing. Wait time is arbitrary.
+		}
+	}
+
+	cleanup();
+
+	return 0;
+}

--- a/isobus/CMakeLists.txt
+++ b/isobus/CMakeLists.txt
@@ -30,6 +30,7 @@ set(ISOBUS_SRC
   "isobus_virtual_terminal_client.cpp"
   "can_extended_transport_protocol.cpp"
   "isobus_diagnostic_protocol.cpp"
+  "can_parameter_group_number_request_protocol.cpp"
 )
 
 # Prepend the source directory path to all the source files
@@ -55,6 +56,7 @@ set(ISOBUS_INCLUDE
   "isobus_virtual_terminal_client.hpp"
   "can_extended_transport_protocol.hpp"
   "isobus_diagnostic_protocol.hpp"
+  "can_parameter_group_number_request_protocol.hpp"
 )
 
 # Prepend the include directory path to all the include files

--- a/isobus/include/can_callbacks.hpp
+++ b/isobus/include/can_callbacks.hpp
@@ -31,10 +31,11 @@ namespace isobus
 	                                         ControlFunction *destinationControlFunction,
 	                                         bool successful,
 	                                         void *parentPointer);
+	/// @brief A callback for handling a PGN request
 	typedef bool (*PGNRequestCallback)(std::uint32_t parameterGroupNumber,
 	                                   const ControlFunction *requestingControlFunction,
 	                                   bool &acknowledge);
-
+	/// @brief A callback for handling a request for repetition rate for a specific PGN
 	typedef bool (*PGNRequestForRepetitionRateCallback)(std::uint32_t parameterGroupNumber,
 	                                                    const ControlFunction *requestingControlFunction,
 	                                                    std::uint32_t repetitionRate);

--- a/isobus/include/can_callbacks.hpp
+++ b/isobus/include/can_callbacks.hpp
@@ -14,8 +14,19 @@
 
 namespace isobus
 {
+	// Forward declare some classes
 	class InternalControlFunction;
 	class ControlFunction;
+
+	/// @brief The types of acknowldegement that can be sent in the Ack PGN
+	enum class AcknowledgementType : std::uint8_t
+	{
+		Positive = 0, ///< "ACK" Indicates that the request was completed
+		Negative = 1, ///< "NACK" Indicates the request was not completed or we do not support the PGN
+		AccessDenied = 2, ///< Signals to the requestor that their CF is not allowed to request this PGN
+		CannotRespond = 3 ///< Signals to the requestor that we are unable to accept the request for some reason
+	};
+
 	/// @brief A callback for control functions to get CAN messages
 	typedef void (*CANLibCallback)(CANMessage *message, void *parentPointer);
 	/// @brief A callback to get chunks of data for transfer by a protocol
@@ -33,12 +44,15 @@ namespace isobus
 	                                         void *parentPointer);
 	/// @brief A callback for handling a PGN request
 	typedef bool (*PGNRequestCallback)(std::uint32_t parameterGroupNumber,
-	                                   const ControlFunction *requestingControlFunction,
-	                                   bool &acknowledge);
+	                                   ControlFunction *requestingControlFunction,
+	                                   bool &acknowledge,
+	                                   AcknowledgementType &acknowledgeType,
+	                                   void *parentPointer);
 	/// @brief A callback for handling a request for repetition rate for a specific PGN
 	typedef bool (*PGNRequestForRepetitionRateCallback)(std::uint32_t parameterGroupNumber,
-	                                                    const ControlFunction *requestingControlFunction,
-	                                                    std::uint32_t repetitionRate);
+	                                                    ControlFunction *requestingControlFunction,
+	                                                    std::uint32_t repetitionRate,
+	                                                    void *parentPointer);
 
 	//================================================================================================
 	/// @class ParameterGroupNumberCallbackData

--- a/isobus/include/can_callbacks.hpp
+++ b/isobus/include/can_callbacks.hpp
@@ -31,6 +31,13 @@ namespace isobus
 	                                         ControlFunction *destinationControlFunction,
 	                                         bool successful,
 	                                         void *parentPointer);
+	typedef bool (*PGNRequestCallback)(std::uint32_t parameterGroupNumber,
+	                                   const ControlFunction *requestingControlFunction,
+	                                   bool &acknowledge);
+
+	typedef bool (*PGNRequestForRepetitionRateCallback)(std::uint32_t parameterGroupNumber,
+	                                                    const ControlFunction *requestingControlFunction,
+	                                                    std::uint32_t repetitionRate);
 
 	//================================================================================================
 	/// @class ParameterGroupNumberCallbackData

--- a/isobus/include/can_general_parameter_group_numbers.hpp
+++ b/isobus/include/can_general_parameter_group_numbers.hpp
@@ -19,6 +19,7 @@ namespace isobus
 		DiagnosticMessage22 = 0xC300,
 		ExtendedTransportProtocolDataTransfer = 0xC700,
 		ExtendedTransportProtocolConnectionManagement = 0xC800,
+		RequestForRepititionRate = 0xCC00,
 		VirtualTerminalToECU = 0xE600,
 		ECUtoVirtualTerminal = 0xE700,
 		Acknowledge = 0xE800,

--- a/isobus/include/can_general_parameter_group_numbers.hpp
+++ b/isobus/include/can_general_parameter_group_numbers.hpp
@@ -19,7 +19,7 @@ namespace isobus
 		DiagnosticMessage22 = 0xC300,
 		ExtendedTransportProtocolDataTransfer = 0xC700,
 		ExtendedTransportProtocolConnectionManagement = 0xC800,
-		RequestForRepititionRate = 0xCC00,
+		RequestForRepetitionRate = 0xCC00,
 		VirtualTerminalToECU = 0xE600,
 		ECUtoVirtualTerminal = 0xE700,
 		Acknowledge = 0xE800,

--- a/isobus/include/can_network_manager.hpp
+++ b/isobus/include/can_network_manager.hpp
@@ -107,6 +107,7 @@ namespace isobus
 		friend class ExtendedTransportProtocolManager; ///< Allows the network manager to access the ETP manager
 		friend class TransportProtocolManager; ///< Allows the network manager to work closely with the transport protocol manager object
 		friend class DiagnosticProtocol; ///< Allows the diagnostic protocol to access the protected functions on the network manager
+		friend class ParameterGroupNumberRequestProtocol; ///< Allows the PGN request protocol to access the network manager protected functions
 
 		/// @brief Adds a PGN callback for a protocol class
 		/// @param[in] parameterGroupNumber The PGN to register for

--- a/isobus/include/can_parameter_group_number_request_protocol.hpp
+++ b/isobus/include/can_parameter_group_number_request_protocol.hpp
@@ -8,7 +8,6 @@
 ///
 /// @copyright 2022 Adrian Del Grosso
 //================================================================================================
-
 #ifndef CAN_PARAMETER_GROUP_NUMBER_REQUEST_PROTOCOL_HPP
 #define CAN_PARAMETER_GROUP_NUMBER_REQUEST_PROTOCOL_HPP
 
@@ -17,6 +16,8 @@
 #include "can_managed_message.hpp"
 #include "can_network_manager.hpp"
 #include "can_protocol.hpp"
+
+#include <memory>
 
 namespace isobus
 {
@@ -31,52 +32,87 @@ namespace isobus
 	class ParameterGroupNumberRequestProtocol : public CANLibProtocol
 	{
 	public:
-		ParameterGroupNumberRequestProtocol();
-
-		~ParameterGroupNumberRequestProtocol();
-
 		/// @brief The protocol's initializer function
 		void initialize(CANLibBadge<CANNetworkManager>) override;
 
+		/// @brief Used to tell the CAN stack that PGN requests should be handled for the specified internal control function
+		/// @details This will allocate an instance of this protocol
+		/// @returns `true` If the protocol instance was created OK with the passed in ICF
+		static bool assign_pgn_request_protocol_to_internal_control_function(std::shared_ptr<InternalControlFunction> internalControlFunction);
+
+		/// @brief Used to tell the CAN stack that PGN requests should no longer be handled for the specified internal control function
+		/// @details This will delete an instance of this protocol
+		/// @returns `true` If the protocol instance was deleted OK according to the passed in ICF
+		static bool deassign_pgn_request_protocol_to_internal_control_function(std::shared_ptr<InternalControlFunction> internalControlFunction);
+
 		/// @brief Sends a PGN request to the specified control function
-		/// @param pgn The PGN to request
-		/// @param destination The control function to request `pgn` from
+		/// @param[in] pgn The PGN to request
+		/// @param[in] source The internal control function to send from
+		/// @param[in] destination The control function to request `pgn` from
 		/// @returns `true` if the request was successfully sent
-		bool request_parameter_group_number(std::uint32_t pgn, InternalControlFunction *source, ControlFunction *destination);
+		static bool request_parameter_group_number(std::uint32_t pgn, InternalControlFunction *source, ControlFunction *destination);
 
 		/// @brief Sends a PGN request for repitition rate
 		/// @details Use this if you want the requestee to send you the specified PGN at some fixed interval
-		/// @param pgn The PGN to request
-		/// @param destination The control function to send the request to
+		/// @param[in] pgn The PGN to request
+		/// @param[in] repetitionRate_ms The repetition rate to request in milliseconds
+		/// @param[in] source The internal control function to send from
+		/// @param[in] destination The control function to send the request to
 		/// @returns `true` if the request was sent
-		bool request_repetition_rate(std::uint32_t pgn, std::uint16_t repetitionRate_ms, InternalControlFunction *source, ControlFunction *destination);
+		static bool request_repetition_rate(std::uint32_t pgn, std::uint16_t repetitionRate_ms, InternalControlFunction *source, ControlFunction *destination);
 
 		/// @brief Registers for a callback on receipt of a PGN request
+		/// @param[in] pgn The PGN you want to handle in the callback
+		/// @param[in] callback The callback function to register
+		/// @returns true if the callback was registered, false if the callback is nullptr or is already registered for the same PGN
 		bool register_pgn_request_callback(std::uint32_t pgn, PGNRequestCallback callback);
 
+		/// @brief Registers for a callback on receipt of a request for repetition rate
+		/// @param[in] pgn The PGN you want to handle in the callback
+		/// @param[in] callback The callback function to register
+		/// @returns true if the callback was registered, false if the callback is nullptr or is already registered for the same PGN
 		bool register_request_for_repetition_rate_callback(std::uint32_t pgn, PGNRequestCallback callback);
 
-		static constexpr std::uint8_t PGN_REQUEST_LENGTH = 3;
+		/// @brief Updates the protocol cyclically
+		void update(CANLibBadge<CANNetworkManager>) override;
+
+		static constexpr std::uint8_t PGN_REQUEST_LENGTH = 3; ///< The CAN data length of a PGN request
 
 	private:
+		/// @brief A storage class for holding PGN callbacks and their associated PGN
 		class PGNRequestCallbackInfo
 		{
 		public:
+			/// @brief Constructor for PGNRequestCallbackInfo
+			/// @param[in] callback A PGNRequestCallback
+			/// @param[in] parameterGroupNumber The PGN associcated with the callback
 			PGNRequestCallbackInfo(PGNRequestCallback callback, std::uint32_t parameterGroupNumber);
 
+			/// @brief A utility function for determining if the data in the object is equal to another object
+			/// @details The objects are the same if the pgn and callbackFunction both match
+			/// @param[in] obj The object to compare against
+			/// @returns true if the objects have identical data
 			bool operator==(const PGNRequestCallbackInfo &obj);
 
-			PGNRequestCallback callbackFunction;
-			std::uint32_t pgn;
+			PGNRequestCallback callbackFunction; ///< The actual callback
+			std::uint32_t pgn; ///< The PGN associated with the callback
 		};
 
+		/// @brief The types of acknowldegement that can be sent in the Ack PGN
 		enum class AcknowledgementType : std::uint8_t
 		{
-			Positive = 0,
-			Negative = 1,
-			AccessDenied = 2,
-			CannotRespond = 3
+			Positive = 0, ///< "ACK" Indicates that the request was completed
+			Negative = 1, ///< "NACK" Indicates the request was not completed or we do not support the PGN
+			AccessDenied = 2, ///< Signals to the requestor that their CF is not allowed to request this PGN
+			CannotRespond = 3 ///< Signals to the requestor that we are unable to accept the request for some reason
 		};
+
+		/// @brief Constructor for the PGN request protocol
+		/// @param[in] internalControlFunction The internal control function assigned to the protocol instance
+		ParameterGroupNumberRequestProtocol(std::shared_ptr<InternalControlFunction> internalControlFunction);
+
+		/// @brief Destructor for the PGN request protocol
+		~ParameterGroupNumberRequestProtocol();
 
 		/// @brief A generic way for a protocol to process a received message
 		/// @param[in] message A received CAN message
@@ -87,11 +123,40 @@ namespace isobus
 		/// @param[in] parent Provides the context to the actual TP manager object
 		static void process_message(CANMessage *const message, void *parent);
 
+		/// @brief The network manager calls this to see if the protocol can accept a non-raw CAN message for processing
+		/// @note In this protocol, we do not accept messages from the network manager for transmission
+		/// @param[in] parameterGroupNumber The PGN of the message
+		/// @param[in] data The data to be sent
+		/// @param[in] messageLength The length of the data to be sent
+		/// @param[in] source The source control function
+		/// @param[in] destination The destination control function
+		/// @param[in] transmitCompleteCallback A callback for when the protocol completes its work
+		/// @param[in] parentPointer A generic context object for the tx complete and chunk callbacks
+		/// @param[in] frameChunkCallback A callback to get some data to send
+		/// @returns true if the message was accepted by the protocol for processing
+		bool protocol_transmit_message(std::uint32_t parameterGroupNumber,
+		                               const std::uint8_t *data,
+		                               std::uint32_t messageLength,
+		                               ControlFunction *source,
+		                               ControlFunction *destination,
+		                               TransmitCompleteCallback transmitCompleteCallback,
+		                               void *parentPointer,
+		                               DataChunkCallback frameChunkCallback) override;
+
+		/// @brief Sends a message using the acknowledgement PGN
+		/// @param[in] type The type of acknowledgement to send (Ack, vs Nack, etc)
+		/// @param[in] parameterGroupNumber The PGN to acknowledge
+		/// @param[in] source The source control function to send from
+		/// @param[in] destination The destination control function to send the acknowledgement to
+		/// @returns true if the message was sent, false otherwise
 		bool send_acknowledgement(AcknowledgementType type, std::uint32_t parameterGroupNumber, InternalControlFunction *source, ControlFunction *destination);
 
-		std::vector<PGNRequestCallbackInfo> pgnRequestCallbacks;
-		std::vector<PGNRequestCallbackInfo> repetitionRateCallbacks;
-		std::mutex pgnRequestMutex;
+		static std::list<ParameterGroupNumberRequestProtocol *> pgnRequestProtocolList; ///< List of all PGN request protocol instances (one per ICF)
+
+		std::shared_ptr<InternalControlFunction> myControlFunction; ///< The internal control function that this protocol will send from
+		std::vector<PGNRequestCallbackInfo> pgnRequestCallbacks; ///< A list of all registered PGN callbacks and the PGN associated with each callback
+		std::vector<PGNRequestCallbackInfo> repetitionRateCallbacks; ///< A list of all registered request for repetition rate callbacks and the PGN associated with the callback
+		std::mutex pgnRequestMutex; ///< A mutex to protect the callback lists
 	};
 }
 

--- a/isobus/include/can_parameter_group_number_request_protocol.hpp
+++ b/isobus/include/can_parameter_group_number_request_protocol.hpp
@@ -1,0 +1,98 @@
+//================================================================================================
+/// @file can_parameter_group_number_request_protocol.hpp
+///
+/// @brief A protocol that handles PGN requests
+/// @details The purpose of this protocol is to simplify and standardize how PGN requests
+/// are made and responded to.
+/// @author Adrian Del Grosso
+///
+/// @copyright 2022 Adrian Del Grosso
+//================================================================================================
+
+#ifndef CAN_PARAMETER_GROUP_NUMBER_REQUEST_PROTOCOL_HPP
+#define CAN_PARAMETER_GROUP_NUMBER_REQUEST_PROTOCOL_HPP
+
+#include "can_badge.hpp"
+#include "can_control_function.hpp"
+#include "can_managed_message.hpp"
+#include "can_network_manager.hpp"
+#include "can_protocol.hpp"
+
+namespace isobus
+{
+	//================================================================================================
+	/// @class ParameterGroupNumberRequestProtocol
+	///
+	/// @brief A protocol that handles PGN requests
+	/// @details The purpose of this protocol is to simplify and standardize how PGN requests
+	/// are made and responded to. It provides a way to easily send a PGN request or a request for
+	/// repitition rate, as well as methods to receive PGN requests.
+	//================================================================================================
+	class ParameterGroupNumberRequestProtocol : public CANLibProtocol
+	{
+	public:
+		ParameterGroupNumberRequestProtocol();
+
+		~ParameterGroupNumberRequestProtocol();
+
+		/// @brief The protocol's initializer function
+		void initialize(CANLibBadge<CANNetworkManager>) override;
+
+		/// @brief Sends a PGN request to the specified control function
+		/// @param pgn The PGN to request
+		/// @param destination The control function to request `pgn` from
+		/// @returns `true` if the request was successfully sent
+		bool request_parameter_group_number(std::uint32_t pgn, InternalControlFunction *source, ControlFunction *destination);
+
+		/// @brief Sends a PGN request for repitition rate
+		/// @details Use this if you want the requestee to send you the specified PGN at some fixed interval
+		/// @param pgn The PGN to request
+		/// @param destination The control function to send the request to
+		/// @returns `true` if the request was sent
+		bool request_repetition_rate(std::uint32_t pgn, std::uint16_t repetitionRate_ms, InternalControlFunction *source, ControlFunction *destination);
+
+		/// @brief Registers for a callback on receipt of a PGN request
+		bool register_pgn_request_callback(std::uint32_t pgn, PGNRequestCallback callback);
+
+		bool register_request_for_repetition_rate_callback(std::uint32_t pgn, PGNRequestCallback callback);
+
+		static constexpr std::uint8_t PGN_REQUEST_LENGTH = 3;
+
+	private:
+		class PGNRequestCallbackInfo
+		{
+		public:
+			PGNRequestCallbackInfo(PGNRequestCallback callback, std::uint32_t parameterGroupNumber);
+
+			bool operator==(const PGNRequestCallbackInfo &obj);
+
+			PGNRequestCallback callbackFunction;
+			std::uint32_t pgn;
+		};
+
+		enum class AcknowledgementType : std::uint8_t
+		{
+			Positive = 0,
+			Negative = 1,
+			AccessDenied = 2,
+			CannotRespond = 3
+		};
+
+		/// @brief A generic way for a protocol to process a received message
+		/// @param[in] message A received CAN message
+		void process_message(CANMessage *const message) override;
+
+		/// @brief A generic way for a protocol to process a received message
+		/// @param[in] message A received CAN message
+		/// @param[in] parent Provides the context to the actual TP manager object
+		static void process_message(CANMessage *const message, void *parent);
+
+		bool send_acknowledgement(AcknowledgementType type, std::uint32_t parameterGroupNumber, InternalControlFunction *source, ControlFunction *destination);
+
+		std::vector<PGNRequestCallbackInfo> pgnRequestCallbacks;
+		std::vector<PGNRequestCallbackInfo> repetitionRateCallbacks;
+		std::mutex pgnRequestMutex;
+	};
+}
+
+#endif // CAN_PARAMETER_GROUP_NUMBER_REQUEST_PROTOCOL_HPP

--- a/isobus/src/can_parameter_group_number_request_protocol.cpp
+++ b/isobus/src/can_parameter_group_number_request_protocol.cpp
@@ -216,7 +216,10 @@ namespace isobus
 
 	void ParameterGroupNumberRequestProtocol::process_message(CANMessage *const message)
 	{
-		if (nullptr != message)
+		if ((nullptr != message) &&
+		    (((nullptr == message->get_destination_control_function()) &&
+		      (BROADCAST_CAN_ADDRESS == message->get_identifier().get_destination_address())) ||
+		     (message->get_destination_control_function() == myControlFunction.get())))
 		{
 			switch (message->get_identifier().get_parameter_group_number())
 			{

--- a/isobus/src/can_parameter_group_number_request_protocol.cpp
+++ b/isobus/src/can_parameter_group_number_request_protocol.cpp
@@ -1,0 +1,243 @@
+#include "can_parameter_group_number_request_protocol.hpp"
+#include "can_general_parameter_group_numbers.hpp"
+#include "can_warning_logger.hpp"
+
+#include <algorithm>
+
+namespace isobus
+{
+	ParameterGroupNumberRequestProtocol::ParameterGroupNumberRequestProtocol()
+	{
+	
+	}
+
+	ParameterGroupNumberRequestProtocol ::~ParameterGroupNumberRequestProtocol()
+	{
+		if (initialized)
+		{
+			CANNetworkManager::CANNetwork.remove_protocol_parameter_group_number_callback(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ParameterGroupNumberRequest), process_message, this);
+			CANNetworkManager::CANNetwork.remove_protocol_parameter_group_number_callback(static_cast<std::uint32_t>(CANLibParameterGroupNumber::RequestForRepititionRate), process_message, this);
+		}
+	}
+
+	void ParameterGroupNumberRequestProtocol::initialize(CANLibBadge<CANNetworkManager>)
+	{
+		if (!initialized)
+		{
+			initialized = true;
+			CANNetworkManager::CANNetwork.add_protocol_parameter_group_number_callback(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ParameterGroupNumberRequest), process_message, this);
+			CANNetworkManager::CANNetwork.add_protocol_parameter_group_number_callback(static_cast<std::uint32_t>(CANLibParameterGroupNumber::RequestForRepititionRate), process_message, this);
+		}
+	}
+
+	bool ParameterGroupNumberRequestProtocol::request_parameter_group_number(std::uint32_t pgn, InternalControlFunction *source, ControlFunction *destination)
+	{
+		std::array<std::uint8_t, PGN_REQUEST_LENGTH> buffer;
+		
+		buffer[0] = static_cast<std::uint8_t>(pgn & 0xFF);
+		buffer[1] = static_cast<std::uint8_t>((pgn >> 8) & 0xFF);
+		buffer[2] = static_cast<std::uint8_t>((pgn >> 16) & 0xFF);
+
+		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ParameterGroupNumberRequest),
+		                                                      buffer.data(),
+		                                                      PGN_REQUEST_LENGTH,
+		                                                      source,
+		                                                      destination);
+	}
+
+	bool ParameterGroupNumberRequestProtocol::request_repetition_rate(std::uint32_t pgn, std::uint16_t repetitionRate_ms, InternalControlFunction *source, ControlFunction *destination)
+	{
+		std::array<std::uint8_t, CAN_DATA_LENGTH> buffer;
+
+		buffer[0] = static_cast<std::uint8_t>(pgn & 0xFF);
+		buffer[1] = static_cast<std::uint8_t>((pgn >> 8) & 0xFF);
+		buffer[2] = static_cast<std::uint8_t>((pgn >> 16) & 0xFF);
+		buffer[3] = static_cast<std::uint8_t>(repetitionRate_ms & 0xFF);
+		buffer[4] = static_cast<std::uint8_t>((repetitionRate_ms >> 8) & 0xFF);
+		buffer[5] = 0xFF;
+		buffer[6] = 0xFF;
+		buffer[7] = 0xFF;
+
+		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::RequestForRepititionRate),
+		                                                      buffer.data(),
+		                                                      CAN_DATA_LENGTH,
+		                                                      source,
+		                                                      destination);
+	}
+
+	bool ParameterGroupNumberRequestProtocol::register_pgn_request_callback(std::uint32_t pgn, PGNRequestCallback callback)
+	{
+		PGNRequestCallbackInfo pgnCallback(callback, pgn);
+		bool retVal = false;
+		const std::lock_guard<std::mutex> lock(pgnRequestMutex);
+
+		if ((nullptr != callback) && (pgnRequestCallbacks.end() == std::find(pgnRequestCallbacks.begin(), pgnRequestCallbacks.end(), pgnCallback)))
+		{
+			pgnRequestCallbacks.push_back(pgnCallback);
+			retVal = true;
+		}
+		return retVal;
+	}
+
+	bool ParameterGroupNumberRequestProtocol::register_request_for_repetition_rate_callback(std::uint32_t pgn, PGNRequestCallback callback)
+	{
+		PGNRequestCallbackInfo repetitionRateCallback(callback, pgn);
+		bool retVal = false;
+		const std::lock_guard<std::mutex> lock(pgnRequestMutex);
+
+		if ((nullptr != callback) && (repetitionRateCallbacks.end() == std::find(repetitionRateCallbacks.begin(), repetitionRateCallbacks.end(), repetitionRateCallback)))
+		{
+			repetitionRateCallbacks.push_back(repetitionRateCallback);
+			retVal = true;
+		}
+		return retVal;
+	}
+
+	ParameterGroupNumberRequestProtocol::PGNRequestCallbackInfo::PGNRequestCallbackInfo(PGNRequestCallback callback, std::uint32_t parameterGroupNumber) :
+	  callbackFunction(callback),
+	  pgn(parameterGroupNumber)
+	{
+		
+	}
+
+	bool ParameterGroupNumberRequestProtocol::PGNRequestCallbackInfo::operator==(const PGNRequestCallbackInfo &obj)
+	{
+		return ((obj.callbackFunction == this->callbackFunction) && (obj.pgn == this->pgn));
+	}
+
+	void ParameterGroupNumberRequestProtocol::process_message(CANMessage *const message)
+	{
+		if (nullptr != message)
+		{
+			switch (message->get_identifier().get_parameter_group_number())
+			{
+				case static_cast<std::uint32_t>(CANLibParameterGroupNumber::RequestForRepititionRate):
+				{
+					// Can't send this request to global, and must be 8 bytes. Ignore illegal message formats
+					if ((CAN_DATA_LENGTH == message->get_data_length()) && (nullptr != message->get_destination_control_function()))
+					{
+						auto data = message->get_data();
+						std::uint32_t requestedPGN = data[0];
+						requestedPGN |= (static_cast<std::uint32_t>(data[1]) << 8);
+						requestedPGN |= (static_cast<std::uint32_t>(data[2]) << 8);
+
+						std::uint16_t requestedRate = data[3];
+						requestedRate |= (static_cast<std::uint16_t>(data[4]) << 8);
+
+						const std::lock_guard<std::mutex> lock(pgnRequestMutex);
+
+						for (auto repetitionRateCallback : repetitionRateCallbacks)
+						{
+							if (repetitionRateCallback.pgn == requestedPGN)
+							{
+								break;
+							}
+						}
+
+						// We can just ignore requests for repetition rate if we don't support them for this PGN. No need to NACK.
+						// From isobus.net:
+						// "CFs are not required to monitor the bus for this message."
+						// "If another CF cannot or does not want to use the requested repetition rate, which is necessary for systems with fixed timing control loops, it may ignore this message."
+					}
+					else
+					{
+						CANStackLogger::CAN_stack_log("[PR]: Received a malformed or broadcast request for repetition rate message. The message will not be processed.");
+					}
+				}
+				break;
+
+				case static_cast<std::uint32_t>(CANLibParameterGroupNumber::ParameterGroupNumberRequest):
+				{
+					if (message->get_data_length() >= PGN_REQUEST_LENGTH)
+					{
+						bool shouldAck = false;
+						bool anyCallbackProcessed = false;
+						auto data = message->get_data();
+						std::uint32_t requestedPGN = data[0];
+						requestedPGN |= (static_cast<std::uint32_t>(data[1]) << 8);
+						requestedPGN |= (static_cast<std::uint32_t>(data[2]) << 8);
+
+						const std::lock_guard<std::mutex> lock(pgnRequestMutex);
+
+						for (auto pgnRequestCallback : pgnRequestCallbacks)
+						{
+							if ((pgnRequestCallback.pgn == requestedPGN) &&
+							    (pgnRequestCallback.callbackFunction(requestedPGN, message->get_source_control_function(), shouldAck)))
+							{
+								// If we're here, the callback was able to process the PGN request.
+								anyCallbackProcessed = true;
+
+								// Now we need to know if we shoulc ACK it.
+								// We should not ACK messages that send the actual PGN as a result of requesting it. This behavior is up to
+								// the application layer to do properly.
+								if ((shouldAck) && (nullptr != message->get_destination_control_function()))
+								{
+									send_acknowledgement(AcknowledgementType::Positive,
+									                     requestedPGN,
+									                     reinterpret_cast<InternalControlFunction *>(message->get_destination_control_function()),
+									                     message->get_source_control_function());
+								}
+								// If this callback was able to process the PGN request, stop processing more.
+								break;
+							}
+						}
+
+						if ((!anyCallbackProcessed) && (nullptr != message->get_destination_control_function()))
+						{
+							send_acknowledgement(AcknowledgementType::Negative,
+							                     requestedPGN,
+							                     reinterpret_cast<InternalControlFunction *>(message->get_destination_control_function()),
+							                     message->get_source_control_function());
+							CANStackLogger::CAN_stack_log("[PR]: NACK-ing PGN request for PGN " + std::to_string(requestedPGN) + " because no callback could handle it.");
+						}
+					}
+					else
+					{
+						CANStackLogger::CAN_stack_log("[PR]: Received a malformed PGN request message. The message will not be processed.");
+					}
+				}
+				break;
+
+				default:
+				{
+				}
+				break;
+			}
+		}
+	}
+
+	void ParameterGroupNumberRequestProtocol::process_message(CANMessage *const message, void *parent)
+	{
+		if (nullptr != parent)
+		{
+			reinterpret_cast<ParameterGroupNumberRequestProtocol *>(parent)->process_message(message);
+		}
+	}
+
+	bool ParameterGroupNumberRequestProtocol::send_acknowledgement(AcknowledgementType type, std::uint32_t parameterGroupNumber, InternalControlFunction *source, ControlFunction *destination)
+	{
+		bool retVal = false;
+
+		if ((nullptr != source) && (nullptr != destination))
+		{
+			std::array<std::uint8_t, CAN_DATA_LENGTH> buffer;
+
+			buffer[0] = static_cast<std::uint8_t>(type);
+			buffer[1] = 0xFF;
+			buffer[2] = 0xFF;
+			buffer[3] = 0xFF;
+			buffer[4] = destination->get_address();
+			buffer[5] = static_cast<std::uint8_t>(parameterGroupNumber & 0xFF);
+			buffer[6] = static_cast<std::uint8_t>((parameterGroupNumber >> 8) & 0xFF);
+			buffer[7] = static_cast<std::uint8_t>((parameterGroupNumber >> 16) & 0xFF);
+
+			retVal = CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::Acknowledge),
+			                                                        buffer.data(),
+			                                                        CAN_DATA_LENGTH,
+			                                                        source,
+			                                                        destination);
+		}
+		return retVal;
+	}
+
+} // namespace isobus

--- a/isobus/src/isobus_diagnostic_protocol.cpp
+++ b/isobus/src/isobus_diagnostic_protocol.cpp
@@ -935,7 +935,10 @@ namespace isobus
 
 	void DiagnosticProtocol::process_message(CANMessage *const message)
 	{
-		if (nullptr != message)
+		if ((nullptr != message) &&
+		    (((nullptr == message->get_destination_control_function()) &&
+		      (BROADCAST_CAN_ADDRESS == message->get_identifier().get_destination_address())) ||
+		     (message->get_destination_control_function() == myControlFunction.get())))
 		{
 			switch (message->get_identifier().get_parameter_group_number())
 			{


### PR DESCRIPTION
## What's new in this PR?

* Added a new protocol to handle PGN requests and requests for repetition rate. This should make dealing with PGN requests easier, as the stack can handle request encoding, ACKs and NACKs. This will also make it easier to comply with the ISO 11783 rule "A NACK is required if the PGN is not supported" for PGN requests, as the stack can now do this for you.
* Converted the diagnostic protocol to use the new PGN request protocol instead of registering for all PGN requests
* Added a new example program that shows how to deal with PGN requests
* Fixed a memory double free issue in diagnostic protocol where a protocol instance could be doubly deleted
* Updated the README with current status
* Added `doxyfile` to the doxygen command in the README to be sure that it pulls the file in rather than relying on it implicitly