### PR TITLE
[Core]: Fix a small memory leak in the socket CAN layer

### DIFF
--- a/socket_can/src/socket_can_interface.cpp
+++ b/socket_can/src/socket_can_interface.cpp
@@ -254,6 +254,7 @@ CANHardwareInterface::CANHardwareInterface()
 
 CANHardwareInterface::~CANHardwareInterface()
 {
+	set_number_of_can_channels(0);
 }
 
 bool CANHardwareInterface::assign_can_channel_frame_handler(std::uint8_t aCANChannel, std::string deviceName)
@@ -314,6 +315,15 @@ bool CANHardwareInterface::set_number_of_can_channels(uint8_t aValue)
 			{
 				pCANHardware = hardwareChannels.back();
 				hardwareChannels.pop_back();
+
+				if (nullptr != pCANHardware->frameHandler)
+				{
+					if (pCANHardware->frameHandler->get_is_valid())
+					{
+						pCANHardware->frameHandler->close();
+					}
+					delete pCANHardware->frameHandler;
+				}
 
 				delete pCANHardware;
 			}


### PR DESCRIPTION
When exiting, we now clean up the socket CAN layer better so that we delete any allocated frame handlers and stop relying on a user to do it. Previously this would leak about 232 bytes per CAN channel right at exit time.