### PR TITLE
[42] CMake Alias Targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,18 +54,28 @@ endif()
 # Make CTest available which adds the option BUILD_TESTING
 include(CTest)
 if(BUILD_TESTING)
-# Link GoogleTest
-include(FetchContent)
-FetchContent_Declare(
-  googletest
-  URL https://github.com/google/googletest/archive/609281088cfefc76f9d0ce82e1ff6c30cc3591e5.zip
-)
-# For Windows: Prevent overriding the parent project's compiler/linker settings
-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-FetchContent_MakeAvailable(googletest)
+find_package(GTest QUIET)
+if(NOT GTest_FOUND)
+  # Find GoogleTest
+  include(FetchContent)
+  FetchContent_Declare(
+    googletest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG release-1.12.1
+  )
+  # For Windows: Prevent overriding the parent project's compiler/linker settings
+  set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+  FetchContent_MakeAvailable(googletest)
+
+  # For before CMAKE 3.20, GTest::gtest_main didn't exist, so add it in
+  # All linking to gtest should be done using the new GTest::gtest_main library for forward compatability
+  if(NOT TARGET GTest::gtest_main)
+    add_library(GTest::gtest_main ALIAS GTest::Main)
+  endif()
+endif()
 
 add_executable(unit_tests test/address_claim_test.cpp test/test_CAN_glue.cpp test/identifier_tests.cpp)
-target_link_libraries(unit_tests gtest_main Isobus HardwareIntegration)
+target_link_libraries(unit_tests GTest::gtest_main ${PROJECT_NAME}::Isobus ${PROJECT_NAME}::HardwareIntegration)
 
 include(GoogleTest)
 gtest_discover_tests(unit_tests name_tests identifier_tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,12 @@ if(NOT GTest_FOUND)
   endif()
 endif()
 
+# For cmake<3.20 and older GTest
+if(NOT TARGET GTest::gtest_main)
+  set_target_properties(GTest::Main PROPERTIES IMPORTED_GLOBAL TRUE)
+  add_library(GTest::gtest_main ALIAS GTest::Main)
+endif()
+
 add_executable(unit_tests test/address_claim_test.cpp test/test_CAN_glue.cpp test/identifier_tests.cpp)
 target_link_libraries(unit_tests GTest::gtest_main ${PROJECT_NAME}::Isobus ${PROJECT_NAME}::HardwareIntegration)
 

--- a/README.md
+++ b/README.md
@@ -105,13 +105,14 @@ git submodule add https://github.com/ad3154/ISO11783-CAN-Stack.git <destination_
 git submodule update --init --recursive
 ```
 Then, if you're using cmake, make sure to add the submodule to your project, and link it.
+It is recommended to use the ALIAS targets exposed, which all follow the name `isobus::<target_name>`.
 
 ```
 find_package(Threads)
 
 add_subdirectory(<path to this submodule>)
 
-target_link_libraries(<your executable name> Isobus HardwareIntegration ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(<your executable name> isobus::Isobus isobus::HardwareIntegration isobus::SocketCANInterface)
 ```
 
 A full example CMakeLists.txt file can be found on the tutorial website.

--- a/examples/diagnostic_protocol/CMakeLists.txt
+++ b/examples/diagnostic_protocol/CMakeLists.txt
@@ -4,4 +4,5 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_executable(DiagnosticProtocolExampleTarget main.cpp)
-target_link_libraries(DiagnosticProtocolExampleTarget Isobus HardwareIntegration Threads::Threads SystemTiming)
+
+target_link_libraries(DiagnosticProtocolExampleTarget ${PROJECT_NAME}::Isobus ${PROJECT_NAME}::HardwareIntegration Threads::Threads ${PROJECT_NAME}::SystemTiming)

--- a/examples/pgn_requests/CMakeLists.txt
+++ b/examples/pgn_requests/CMakeLists.txt
@@ -4,4 +4,4 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_executable(PGNRequestExampleTarget main.cpp)
-target_link_libraries(PGNRequestExampleTarget Isobus HardwareIntegration Threads::Threads SystemTiming)
+target_link_libraries(PGNRequestExampleTarget ${PROJECT_NAME}::Isobus ${PROJECT_NAME}::HardwareIntegration Threads::Threads ${PROJECT_NAME}::SystemTiming)

--- a/examples/transport_layer/CMakeLists.txt
+++ b/examples/transport_layer/CMakeLists.txt
@@ -4,4 +4,4 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_executable(TransportLayerExampleTarget main.cpp)
-target_link_libraries(TransportLayerExampleTarget Isobus HardwareIntegration Threads::Threads SystemTiming)
+target_link_libraries(TransportLayerExampleTarget ${PROJECT_NAME}::Isobus ${PROJECT_NAME}::HardwareIntegration Threads::Threads ${PROJECT_NAME}::SystemTiming)

--- a/examples/vt_version_3_object_pool/CMakeLists.txt
+++ b/examples/vt_version_3_object_pool/CMakeLists.txt
@@ -4,7 +4,7 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_executable(VT3ExampleTarget main.cpp)
-target_link_libraries(VT3ExampleTarget Isobus HardwareIntegration Threads::Threads SystemTiming)
+target_link_libraries(VT3ExampleTarget ${PROJECT_NAME}::Isobus ${PROJECT_NAME}::HardwareIntegration Threads::Threads ${PROJECT_NAME}::SystemTiming)
 
 add_custom_command(
         TARGET VT3ExampleTarget POST_BUILD

--- a/hardware_integration/CMakeLists.txt
+++ b/hardware_integration/CMakeLists.txt
@@ -37,8 +37,8 @@ PREPEND(HARDWARE_INTEGRATION_INCLUDE ${HARDWARE_INTEGRATION_INCLUDE_DIR} ${HARDW
 
 # Create the library from the source and include files
 add_library(HardwareIntegration SHARED ${HARDWARE_INTEGRATION_SRC} ${HARDWARE_INTEGRATION_INCLUDE})
-
-target_link_libraries(HardwareIntegration PRIVATE SystemTiming Isobus)
+add_library(${PROJECT_NAME}::HardwareIntegration ALIAS HardwareIntegration)
+target_link_libraries(HardwareIntegration PRIVATE ${PROJECT_NAME}::SystemTiming ${PROJECT_NAME}::Isobus)
 
 # Specify the include directory to be exported for other moduels to use. The 
 # PUBLIC keyword here allows other libraries or exectuables to link to this

--- a/isobus/CMakeLists.txt
+++ b/isobus/CMakeLists.txt
@@ -64,6 +64,7 @@ PREPEND(ISOBUS_INCLUDE ${ISOBUS_INCLUDE_DIR} ${ISOBUS_INCLUDE})
 
 # Create the library from the source and include files
 add_library(Isobus SHARED ${ISOBUS_SRC} ${ISOBUS_INCLUDE})
+add_library(${PROJECT_NAME}::Isobus ALIAS Isobus)
 
 # Specify the include directory to be exported for other moduels to use. The 
 # PUBLIC keyword here allows other libraries or exectuables to link to this
@@ -73,7 +74,7 @@ target_include_directories(Isobus PUBLIC
   $<INSTALL_INTERFACE:${ISOBUS_PUBLIC_NAME}/include>
  ) 
  
-target_link_libraries(Isobus PRIVATE SystemTiming)
+target_link_libraries(Isobus PRIVATE ${PROJECT_NAME}::SystemTiming)
 
 # Add install instructions
 set_target_properties(Isobus PROPERTIES PUBLIC_HEADER "${ISOBUS_INCLUDE}")

--- a/utility/CMakeLists.txt
+++ b/utility/CMakeLists.txt
@@ -30,6 +30,7 @@ PREPEND(SYSTEM_TIMING_INCLUDE ${SYSTEM_TIMING_INCLUDE_DIR} ${SYSTEM_TIMING_INCLU
 
 # Create the library from the source and include files
 add_library(SystemTiming SHARED ${SYSTEM_TIMING_SRC} ${SYSTEM_TIMING_INCLUDE})
+add_library(${PROJECT_NAME}::SystemTiming ALIAS SystemTiming)
 
 # Specify the include directory to be exported for other moduels to use. The 
 # PUBLIC keyword here allows other libraries or exectuables to link to this


### PR DESCRIPTION
- Add CMake ALIAS targets for all current libraries
- Consume the new alias targets in all calls to target_link_libraries
- Update gtest to be found using either find_package or the fetchcontent method
- Add missing alias to gtest for pre cmake 3.20 support to be unified
- Solves #42

Signed-off-by: Ryan Friedman <ryan_friedman@trimble.com>