### PR TITLE
[Core]: Fix compilation on Alpine Linux

### DIFF
--- a/socket_can/src/socket_can_interface.cpp
+++ b/socket_can/src/socket_can_interface.cpp
@@ -20,6 +20,7 @@
 #include <chrono>
 #include <cstdint>
 #include <limits>
+#include <sys/time.h>
 
 std::thread *CANHardwareInterface::can_thread = nullptr;
 std::thread *CANHardwareInterface::updateCANLibPeriodicThread = nullptr;


### PR DESCRIPTION
For issue #44
`sys/time.h` include was missing. It seems to be brought in by `chrono` (I think) on RHEL and Ubuntu but not on Alpine.

With this fix the library appears to compile fine on Alpine:latest.