### PR TITLE
[Meta]: Fix submodule instructions in tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ sudo dnf install cmake
 Then, submodule the repository into your project:
 
 ```
-git submodule add git@github.com:ad3154/ISO11783-CAN-Stack.git <destination_folder>
+git submodule add https://github.com/ad3154/ISO11783-CAN-Stack.git <destination_folder>
 git submodule update --init --recursive
 ```
 Then, if you're using cmake, make sure to add the submodule to your project, and link it.

--- a/sphinx/source/Installation.rst
+++ b/sphinx/source/Installation.rst
@@ -36,9 +36,10 @@ In your project that you want to add the CAN stack to, add the CAN stack as a su
 
 .. code-block:: bash
 
-   git clone git@github.com:ad3154/ISO11783-CAN-Stack.git
+   git submodule add https://github.com/ad3154/ISO11783-CAN-Stack.git
+   git submodule update --init --recursive
 
-This will place the CAN stack in a folder within your project called 'ISO11783-CAN-Stack'
+This will place the CAN stack in a folder within your project called 'ISO11783-CAN-Stack'.
 
 Building the CAN Stack
 -----------------------
@@ -67,4 +68,6 @@ Non-CMake:
 ^^^^^^^^^^
 
 If you are not using CMake, just make sure to add all the files from the 'ISO11783-CAN-Stack/isobus' folder to your project so they all get compiled. You'll want to make sure the 'ISO11783-CAN-Stack/isobus/include' folder is part of your include path.
+
+If you're using socket CAN, make sure 'socket_can/include' is also in your include path.
 


### PR DESCRIPTION
Tutorial stated to use `git clone` instead of `git submodule add`. Also changed to use https for the submodule add step instead of ssh just in case the user does not have ssh set up and reflected this change in README as well.