### PR TITLE
[Core]: Refactor CAN Hardware Abstraction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,11 +42,14 @@ ENDFUNCTION(PREPEND)
 # Add subdirectories
 add_subdirectory("utility")
 add_subdirectory("isobus")
-add_subdirectory("socket_can")
-add_subdirectory("examples/vt_version_3_object_pool")
-add_subdirectory("examples/transport_layer")
-add_subdirectory("examples/diagnostic_protocol")
-add_subdirectory("examples/pgn_requests")
+add_subdirectory("hardware_integration")
+
+if(NOT NO_EXAMPLES)
+    add_subdirectory("examples/vt_version_3_object_pool")
+    add_subdirectory("examples/transport_layer")
+    add_subdirectory("examples/diagnostic_protocol")
+    add_subdirectory("examples/pgn_requests")
+endif()
 
 # Make CTest available which adds the option BUILD_TESTING
 include(CTest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
 
 add_executable(unit_tests test/address_claim_test.cpp test/test_CAN_glue.cpp test/identifier_tests.cpp)
-target_link_libraries(unit_tests gtest_main Isobus SocketCANInterface)
+target_link_libraries(unit_tests gtest_main Isobus HardwareIntegration)
 
 include(GoogleTest)
 gtest_discover_tests(unit_tests name_tests identifier_tests)

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ find_package(Threads)
 
 add_subdirectory(<path to this submodule>)
 
-target_link_libraries(<your executable name> Isobus SocketCANInterface ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(<your executable name> Isobus HardwareIntegration ${CMAKE_THREAD_LIBS_INIT})
 ```
 
 A full example CMakeLists.txt file can be found on the tutorial website.

--- a/doxyfile
+++ b/doxyfile
@@ -814,6 +814,7 @@ WARN_LOGFILE           =
 # Note: If this tag is empty the current directory is searched.
 
 INPUT                  = "isobus"
+INPUT += "hardware_integration"
 INPUT += README.md
 
 # This tag can be used to specify the character encoding of the source files
@@ -856,7 +857,7 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                =
+EXCLUDE                = "hardware_integration/README.md"
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded

--- a/examples/diagnostic_protocol/CMakeLists.txt
+++ b/examples/diagnostic_protocol/CMakeLists.txt
@@ -4,4 +4,4 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_executable(DiagnosticProtocolExampleTarget main.cpp)
-target_link_libraries(DiagnosticProtocolExampleTarget Isobus SocketCANInterface Threads::Threads SystemTiming)
+target_link_libraries(DiagnosticProtocolExampleTarget Isobus HardwareIntegration Threads::Threads SystemTiming)

--- a/examples/diagnostic_protocol/main.cpp
+++ b/examples/diagnostic_protocol/main.cpp
@@ -1,4 +1,5 @@
 #include "can_general_parameter_group_numbers.hpp"
+#include "can_hardware_interface.hpp"
 #include "can_network_manager.hpp"
 #include "isobus_diagnostic_protocol.hpp"
 #include "socket_can_interface.hpp"
@@ -8,6 +9,7 @@
 #include <memory>
 
 static std::shared_ptr<isobus::InternalControlFunction> TestInternalECU = nullptr;
+static SocketCANInterface canDriver("can0");
 
 using namespace std;
 
@@ -31,7 +33,7 @@ void raw_can_glue(isobus::HardwareInterfaceCANFrame &rawFrame, void *parentPoint
 void setup()
 {
 	CANHardwareInterface::set_number_of_can_channels(1);
-	CANHardwareInterface::assign_can_channel_frame_handler(0, "can0");
+	CANHardwareInterface::assign_can_channel_frame_handler(0, &canDriver);
 	CANHardwareInterface::start();
 
 	CANHardwareInterface::add_can_lib_update_callback(update_CAN_network, nullptr);

--- a/examples/pgn_requests/CMakeLists.txt
+++ b/examples/pgn_requests/CMakeLists.txt
@@ -4,4 +4,4 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_executable(PGNRequestExampleTarget main.cpp)
-target_link_libraries(PGNRequestExampleTarget Isobus SocketCANInterface Threads::Threads SystemTiming)
+target_link_libraries(PGNRequestExampleTarget Isobus HardwareIntegration Threads::Threads SystemTiming)

--- a/examples/pgn_requests/main.cpp
+++ b/examples/pgn_requests/main.cpp
@@ -1,4 +1,5 @@
 #include "can_general_parameter_group_numbers.hpp"
+#include "can_hardware_interface.hpp"
 #include "can_network_configuration.hpp"
 #include "can_network_manager.hpp"
 #include "can_parameter_group_number_request_protocol.hpp"
@@ -11,6 +12,7 @@
 static std::shared_ptr<isobus::InternalControlFunction> TestInternalECU = nullptr;
 static std::uint32_t propARepetitionRate_ms = 0xFFFFFFFF;
 static isobus::ControlFunction *repetitionRateRequestor = nullptr;
+static SocketCANInterface canDriver("can0");
 
 using namespace std;
 
@@ -96,7 +98,7 @@ bool example_proprietary_a_request_for_repetition_rate_handler(std::uint32_t par
 void setup()
 {
 	CANHardwareInterface::set_number_of_can_channels(1);
-	CANHardwareInterface::assign_can_channel_frame_handler(0, "can0");
+	CANHardwareInterface::assign_can_channel_frame_handler(0, &canDriver);
 	CANHardwareInterface::start();
 
 	CANHardwareInterface::add_can_lib_update_callback(update_CAN_network, nullptr);

--- a/examples/transport_layer/CMakeLists.txt
+++ b/examples/transport_layer/CMakeLists.txt
@@ -4,4 +4,4 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_executable(TransportLayerExampleTarget main.cpp)
-target_link_libraries(TransportLayerExampleTarget Isobus SocketCANInterface Threads::Threads SystemTiming)
+target_link_libraries(TransportLayerExampleTarget Isobus HardwareIntegration Threads::Threads SystemTiming)

--- a/examples/transport_layer/main.cpp
+++ b/examples/transport_layer/main.cpp
@@ -1,4 +1,5 @@
 #include "can_general_parameter_group_numbers.hpp"
+#include "can_hardware_interface.hpp"
 #include "can_network_configuration.hpp"
 #include "can_network_manager.hpp"
 #include "can_partnered_control_function.hpp"
@@ -18,6 +19,7 @@ std::uint8_t *TPTestBuffer = nullptr;
 std::uint8_t *ETPTestBuffer = nullptr;
 constexpr std::uint16_t MAX_TP_SIZE_BYTES = 1785;
 constexpr std::uint32_t ETP_TEST_SIZE = 2048;
+static SocketCANInterface canDriver("vcan0");
 
 using namespace std;
 
@@ -60,7 +62,7 @@ void raw_can_glue(isobus::HardwareInterfaceCANFrame &rawFrame, void *parentPoint
 void setup()
 {
 	CANHardwareInterface::set_number_of_can_channels(1);
-	CANHardwareInterface::assign_can_channel_frame_handler(0, "can0");
+	CANHardwareInterface::assign_can_channel_frame_handler(0, &canDriver);
 	CANHardwareInterface::start();
 
 	CANHardwareInterface::add_can_lib_update_callback(update_CAN_network, nullptr);

--- a/examples/vt_version_3_object_pool/CMakeLists.txt
+++ b/examples/vt_version_3_object_pool/CMakeLists.txt
@@ -4,7 +4,7 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_executable(VT3ExampleTarget main.cpp)
-target_link_libraries(VT3ExampleTarget Isobus SocketCANInterface Threads::Threads SystemTiming)
+target_link_libraries(VT3ExampleTarget Isobus HardwareIntegration Threads::Threads SystemTiming)
 
 add_custom_command(
         TARGET VT3ExampleTarget POST_BUILD

--- a/examples/vt_version_3_object_pool/main.cpp
+++ b/examples/vt_version_3_object_pool/main.cpp
@@ -1,4 +1,5 @@
 #include "can_general_parameter_group_numbers.hpp"
+#include "can_hardware_interface.hpp"
 #include "can_network_manager.hpp"
 #include "can_partnered_control_function.hpp"
 #include "iop_file_interface.hpp"
@@ -16,6 +17,7 @@ static std::shared_ptr<isobus::VirtualTerminalClient> TestVirtualTerminalClient 
 std::vector<isobus::NAMEFilter> vtNameFilters;
 const isobus::NAMEFilter testFilter(isobus::NAME::NAMEParameters::FunctionCode, static_cast<std::uint8_t>(isobus::NAME::Function::VirtualTerminal));
 static std::vector<std::uint8_t> testPool;
+static SocketCANInterface canDriver("can0");
 
 using namespace std;
 
@@ -42,7 +44,7 @@ void raw_can_glue(isobus::HardwareInterfaceCANFrame &rawFrame, void *parentPoint
 void setup()
 {
 	CANHardwareInterface::set_number_of_can_channels(1);
-	CANHardwareInterface::assign_can_channel_frame_handler(0, "can0");
+	CANHardwareInterface::assign_can_channel_frame_handler(0, &canDriver);
 	CANHardwareInterface::start();
 
 	CANHardwareInterface::add_can_lib_update_callback(update_CAN_network, nullptr);

--- a/hardware_integration/CMakeLists.txt
+++ b/hardware_integration/CMakeLists.txt
@@ -12,6 +12,7 @@ set(SOCKET_CAN_INCLUDE_DIR "include")
 
 # Set source files 
 set(SOCKET_CAN_SRC 
+  "can_hardware_interface.cpp"
   "socket_can_interface.cpp"
 )
 
@@ -19,7 +20,9 @@ set(SOCKET_CAN_SRC
 PREPEND(SOCKET_CAN_SRC ${SOCKET_CAN_SRC_DIR} ${SOCKET_CAN_SRC})
 
 # Set the include files
-set(SOCKET_CAN_INCLUDE 
+set(SOCKET_CAN_INCLUDE
+  "can_hardware_interface.hpp"
+  "can_hardware_plugin.hpp"
   "socket_can_interface.hpp"
 )
 

--- a/hardware_integration/CMakeLists.txt
+++ b/hardware_integration/CMakeLists.txt
@@ -4,40 +4,46 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Set library public name
-set(SOCKET_CAN_INTERFACE_PUBLIC_NAME "SocketCANInterface")
+set(HARDWARE_INTEGRATION_PUBLIC_NAME "HardwareIntegration")
 
 # Set source and include directories
-set(SOCKET_CAN_SRC_DIR "src")
-set(SOCKET_CAN_INCLUDE_DIR "include")
+set(HARDWARE_INTEGRATION_SRC_DIR "src")
+set(HARDWARE_INTEGRATION_INCLUDE_DIR "include")
 
-# Set source files 
-set(SOCKET_CAN_SRC 
-  "can_hardware_interface.cpp"
-  "socket_can_interface.cpp"
-)
+if(NOT CAN_DRIVER)
+  message(AUTHOR_WARNING "No CAN driver specified, choosing Linux socket CAN by default. Use -DCAN_DRIVER=socketCAN to avoid this, or choose another driver and set it explicitly.")
+  set(CAN_DRIVER "socketCAN")
+endif()
+
+if(CAN_DRIVER AND CAN_DRIVER MATCHES "socketCAN") 
+	set(HARDWARE_INTEGRATION_SRC 
+	  "can_hardware_interface.cpp"
+	  "socket_can_interface.cpp"
+	)
+
+	# Set the include files
+	set(HARDWARE_INTEGRATION_INCLUDE
+	  "can_hardware_interface.hpp"
+	  "can_hardware_plugin.hpp"
+	  "socket_can_interface.hpp"
+	)
+endif()
 
 # Prepend the source directory path to all the source files
-PREPEND(SOCKET_CAN_SRC ${SOCKET_CAN_SRC_DIR} ${SOCKET_CAN_SRC})
-
-# Set the include files
-set(SOCKET_CAN_INCLUDE
-  "can_hardware_interface.hpp"
-  "can_hardware_plugin.hpp"
-  "socket_can_interface.hpp"
-)
+PREPEND(HARDWARE_INTEGRATION_SRC ${HARDWARE_INTEGRATION_SRC_DIR} ${HARDWARE_INTEGRATION_SRC})
 
 # Prepend the include directory path to all the include files
-PREPEND(SOCKET_CAN_INCLUDE ${SOCKET_CAN_INCLUDE_DIR} ${SOCKET_CAN_INCLUDE})
+PREPEND(HARDWARE_INTEGRATION_INCLUDE ${HARDWARE_INTEGRATION_INCLUDE_DIR} ${HARDWARE_INTEGRATION_INCLUDE})
 
 # Create the library from the source and include files
-add_library(SocketCANInterface SHARED ${SOCKET_CAN_SRC} ${SOCKET_CAN_INCLUDE})
+add_library(HardwareIntegration SHARED ${HARDWARE_INTEGRATION_SRC} ${HARDWARE_INTEGRATION_INCLUDE})
 
-target_link_libraries(SocketCANInterface PRIVATE SystemTiming Isobus)
+target_link_libraries(HardwareIntegration PRIVATE SystemTiming Isobus)
 
 # Specify the include directory to be exported for other moduels to use. The 
 # PUBLIC keyword here allows other libraries or exectuables to link to this
 # library and use its functionality.
-target_include_directories(SocketCANInterface PUBLIC
+target_include_directories(HardwareIntegration PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:${SOCKET_CAN_PUBLIC_NAME}/include>
  ) 

--- a/hardware_integration/README.md
+++ b/hardware_integration/README.md
@@ -1,0 +1,64 @@
+## CAN Hardware Integration
+
+This folder is where the boundary between the CAN stack reaches the actual hardware.
+
+The data flow for the CAN stack looks like this:
+
+```mermaid
+flowchart LR;
+	layer1(CAN Stack) --> layer2(Abstraction Boundary)
+	layer2(Abstraction Boundary) --> layer3(CAN Hardware Interface)
+	layer3(CAN Hardware Interface) --> layer4(Abstract CAN Hardware Plugin Interface)
+	layer4(Abstract CAN Hardware Plugin Interface) --> layer5(Your CAN Driver)
+	layer5(Your CAN Driver) --> layer6(Physical CAN Bus)
+```
+
+Let's discuss how these components work. Then, we'll go over how you can write your own CAN driver to easily integrate with the stack.
+
+### The Abstraction Boundary
+
+The CAN stack relies on a couple of functions being defined externally to function. This boundary keeps the core stack completely isolated from the hardware layer. Thus, the content of the `isobus` folder can function entirely on its own if that meets your needs better than using the built in hardware interface layer.
+These functions are:
+
+* `bool send_can_message_to_hardware(HardwareInterfaceCANFrame frame);`
+	- This is how the CAN stack will send a frame to the actual hardware.
+	- This is already defined in `CANHardwareInterface` and wraps the actual CAN driver calls.
+	- `CANHardwareInterface` Stores these frames in a queue that will be fed to your underlying CAN driver.
+	- `CANHardwareInterface` Will call `bool write_frame(const isobus::HardwareInterfaceCANFrame &canFrame)` in `CANHardwarePlugin` from the internal queuing mechanism, which is when the frame officially goes to your CAN driver.
+	
+* `void raw_can_glue(isobus::HardwareInterfaceCANFrame &rawFrame, void *parentPointer)`
+	- This function is how the CAN stack will receive frames
+	- The name is arbitrary. You can name it whatever you want as long as the signature is the same and it calls `isobus::CANNetworkManager::CANNetwork.can_lib_process_rx_message(rawFrame, parentPointer);` inside it.
+	- The `CANHardwareInterface` will take care of calling this. You just need to tell it what function to call, like this `CANHardwareInterface::add_raw_can_message_rx_callback(raw_can_glue, nullptr);`
+
+* `void update_CAN_network()`
+	- You need some void function like this that calls `isobus::CANNetworkManager::CANNetwork.update();` periodically.
+	- The `CANHardwareInterface` provides this periodic update. You just need to add your function, like this `CANHardwareInterface::add_can_lib_update_callback(update_CAN_network, nullptr);`
+
+### The CANHardwareInterface
+
+The `CANHardwareInterface` class was created to provide a common queuing and thread layer for running the CAN stack and all CAN drivers to simplify integration and crucially to provide a consistent, safe order of operations for all the function calls needed to properly drive the stack.
+
+For example, although receiving and sending CAN messages is multi-threaded, the stack avoids a lot of complexity by making the consumption of the receive message queue and update of protocols effectively single threaded so no expensive mutexing is needed in the core of the stack.
+
+The `CANHardwareInterface` also is designed to deal with the generic base class for a CAN driver, called `CANHardwarePlugin`, so that it too is completely hardware agnostic.
+
+### The CANHardwarePlugin
+
+This class is a generic base class for a CAN driver. It's meant to provide a common interface for `CANHardwareInterface` to send and receive messages for the stack.
+
+This is the class that you need to implement if you want to integrate CAN hardware the stack doesn't support (yet). 
+
+Consider making a PR back to the stack with your CAN driver if you write one!
+
+### The Actual CAN Driver
+
+This is where the platform specific code should go. Then, just use CMake to compile the appropriate one!
+
+## Writing A New CAN Driver for the Stack
+
+If the CAN stack doesn't support your target platform, you can add support! Adding a new CAN driver helps the entire community.
+
+A CAN driver just needs to inherit from `CANHardwarePlugin` and implement all the functions defined in it (don't worry, there's only 5).
+
+Make sure you follow the repo's contribution standards and code of conduct, then open a PR for it!

--- a/hardware_integration/include/can_hardware_interface.hpp
+++ b/hardware_integration/include/can_hardware_interface.hpp
@@ -21,89 +21,168 @@
 #include "can_hardware_abstraction.hpp"
 #include "can_hardware_plugin.hpp"
 
+//================================================================================================
+/// @class CANHardwareInterface
+///
+/// @brief Provides a common queuing and thread layer for running the CAN stack and all CAN drivers
+///
+/// @details The `CANHardwareInterface` class was created to provide a common queuing and thread
+/// layer for running the CAN stack and all CAN drivers to simplify integration and crucially to
+/// provide a consistent, safe order of operations for all the function calls needed to properly
+/// drive the stack.
+//================================================================================================
 class CANHardwareInterface
 {
 public:
+	/// @brief A class to store information about CAN lib update callbacks
 	class CanLibUpdateCallbackInfo
 	{
 	public:
+		/// @brief Constructs a `CanLibUpdateCallbackInfo`, sets default values
 		CanLibUpdateCallbackInfo();
 
+		/// @brief Allows easy comparison of callback data
+		/// @param obj the object to compare against
 		bool operator==(const CanLibUpdateCallbackInfo &obj);
 
-		void (*callback)();
-		void *parent;
+		void (*callback)(); ///< The callback
+		void *parent; ///< Context variable, the owner of the callback
 	};
 
+	/// @brief A class to store information about Rx callbacks
 	class RawCanMessageCallbackInfo
 	{
 	public:
+		/// @brief Constructs a `RawCanMessageCallbackInfo`, sets default values
 		RawCanMessageCallbackInfo();
 
+		/// @brief Allows easy comparison of callback data
+		/// @param obj the object to compare against
 		bool operator==(const RawCanMessageCallbackInfo &obj);
 
-		void (*callback)(isobus::HardwareInterfaceCANFrame &rxFrame, void *parentPointer);
-		void *parent;
+		void (*callback)(isobus::HardwareInterfaceCANFrame &rxFrame, void *parentPointer); ///< The callback
+		void *parent; ///< Context variable, the owner of the callback
 	};
 
-	static CANHardwareInterface CAN_HARDWARE_INTERFACE;
+	static CANHardwareInterface CAN_HARDWARE_INTERFACE; ///< Static singleton instance of this class
 
+	/// @brief Returns the number of configured CAN channels that the class is managing
+	/// @returns The number of configured CAN channels that the class is managing
 	static std::uint8_t get_number_of_can_channels();
+
+	/// @brief Sets the number of CAN channels to manage
+	/// @details Allocates the proper number of `CanHardware` objects to track
+	/// each CAN channel's Tx and Rx message queues. If you pass in a smaller number than what was
+	/// already configured, it will delete the unneeded `CanHardware` objects.
+	/// @note All changes to channel count will be ignored if `start` has been called and the threads are running
+	/// @param value The number of CAN channels to manage
+	/// @returns `true` if the channel count was set, otherwise `false`.
 	static bool set_number_of_can_channels(std::uint8_t value);
 
-	static bool assign_can_channel_frame_handler(std::uint8_t aCANChannel, CANHardwarePlugin *deviceName);
+	/// @brief Assigns a CAN driver to a channel
+	/// @param[in] aCANChannel The channel to assign to
+	/// @param[in] canDriver The driver to assign to the channel
+	/// @note All changes to driver assignment will be ignored if `start` has been called and the threads are running
+	/// @returns `true` if the driver was assigned to the channel, otherwise `false`
+	static bool assign_can_channel_frame_handler(std::uint8_t aCANChannel, CANHardwarePlugin *canDriver);
 
+	/// @brief Starts the threads for managing the CAN stack and CAN drivers
+	/// @returns `true` if the threads were started, otherwise false (perhaps they are already running)
 	static bool start();
+
+	/// @brief Stops all CAN management threads and discards all remaining messages in the Tx and Rx queues.
+	/// @returns `true` if the threads were stopped, otherwise `false`
 	static bool stop();
 
+	/// @brief Called externally, adds a message to a CAN channel's Tx queue
+	/// @param[in] packet The packet to add to the Tx queue
+	/// @returns `true` if the packet was accepted, otherwise `false` (maybe wrong channel assigned)
 	static bool transmit_can_message(isobus::HardwareInterfaceCANFrame &packet);
+
+	/// @brief Adds an Rx callback. The added callback will be called any time a CAN message is received.
+	/// @param[in] callback The callback to add
+	/// @param[in] parentPointer Generic context variable, usually a pointer to the owner class for this callback
+	/// @returns `true` if the callback was added, `false` if it was already in the list
 	static bool add_raw_can_message_rx_callback(void (*callback)(isobus::HardwareInterfaceCANFrame &rxFrame, void *parentPointer), void *parentPointer);
+
+	/// @brief Removes a Rx callback
+	/// @param[in] callback The callback to remove
+	/// @param[in] parentPointer Generic context variable, usually a pointer to the owner class for this callback
+	/// @returns `true` if the callback was removed, `false` if no callback matched the two parameters
 	static bool remove_raw_can_message_rx_callback(void (*callback)(isobus::HardwareInterfaceCANFrame &rxFrame, void *parentPointer), void *parentPointer);
 
+	/// @brief Adds a periodic udpate callback
+	/// @param[in] callback The callback to add
+	/// @param[in] parentPointer Generic context variable, usually a pointer to the owner class for this callback
+	/// @returns `true` if the callback was added, `false` if it was already in the list
 	static bool add_can_lib_update_callback(void (*callback)(), void *parentPointer);
+
+	/// @brief Removes a periodic update callback
+	/// @param[in] callback The callback to remove
+	/// @param[in] parentPointer Generic context variable, usually a pointer to the owner class for this callback
+	/// @returns `true` if the callback was removed, `false` if no callback matched the two parameters
 	static bool remove_can_lib_update_callback(void (*callback)(), void *parentPointer);
 
 private:
+	/// @brief Private constructor, prevents more of these classes from being needlessly created
 	CANHardwareInterface();
+
+	/// @brief Private destructor
 	~CANHardwareInterface();
 
+	/// @brief Stores the Tx/Rx queues, mutexes, and driver needed to run a single CAN channel
 	struct CanHardware
 	{
-		std::mutex messagesToBeTransmittedMutex;
-		std::deque<isobus::HardwareInterfaceCANFrame> messagesToBeTransmitted;
+		std::mutex messagesToBeTransmittedMutex; ///< Mutex to protect the Tx queue
+		std::deque<isobus::HardwareInterfaceCANFrame> messagesToBeTransmitted; ///< Tx message queue for a CAN channel
 
-		std::mutex receivedMessagesMutex;
-		std::deque<isobus::HardwareInterfaceCANFrame> receivedMessages;
+		std::mutex receivedMessagesMutex; ///< Mutex to protect the Rx queue
+		std::deque<isobus::HardwareInterfaceCANFrame> receivedMessages; ///< Rx message queue for a CAN channel
 
-		std::thread *receiveMessageThread;
+		std::thread *receiveMessageThread; ///< Thread to manage getting messages from a CAN channel
 
-		CANHardwarePlugin *frameHandler;
+		CANHardwarePlugin *frameHandler; ///< The CAN driver to use for a CAN channel
 	};
 
+	/// @brief A hard-coded update interval for the CAN stack. Mostly arbitrary
 	static const std::uint32_t CANLIB_UPDATE_RATE = 4;
 
+	/// @brief The main CAN thread executes this function. Does most of the work of this class
 	static void can_thread_function();
+
+	/// @brief The receive thread(s) execute this function
+	/// @param[in] aCANChannel The associated CAN channel for the thread
 	static void receive_message_thread_function(std::uint8_t aCANChannel);
+
+	/// @brief Attempts to write a frame using the driver assigned to a packet's channel
+	/// @param[in] packet The packet to try and write to the bus
 	static bool transmit_can_message_from_buffer(isobus::HardwareInterfaceCANFrame &packet);
+
+	/// @brief The periodic update thread executes this function
 	static void update_can_lib_periodic_function();
+
+	/// @brief This function sets the `canLibNeedsUpdate` variable and deals with its mutex
 	static void set_can_lib_needs_update();
+
+	/// @brief This returns and clears the `canLibNeedsUpdate` variable plus deals with its mutex
+	/// @returns The state of `canLibNeedsUpdate` before it was cleared
 	static bool get_clear_can_lib_needs_update();
 
-	static std::thread *can_thread;
-	static std::thread *updateCANLibPeriodicThread;
+	static std::thread *can_thread; ///< The main CAN thread
+	static std::thread *updateCANLibPeriodicThread; ///< A thread that periodically wakes up to update the CAN stack
 
-	static std::vector<CanHardware *> hardwareChannels;
-	static std::vector<RawCanMessageCallbackInfo> rxCallbacks;
-	static std::vector<CanLibUpdateCallbackInfo> canLibUpdateCallbacks;
+	static std::vector<CanHardware *> hardwareChannels; ///< A list of all CAN channel's metadata
+	static std::vector<RawCanMessageCallbackInfo> rxCallbacks; ///< A list of all registered Rx callbacks
+	static std::vector<CanLibUpdateCallbackInfo> canLibUpdateCallbacks; ///< A list of all registered periodic update callbacks
 
-	static std::mutex hardwareChannelsMutex;
-	static std::mutex threadMutex;
-	static std::mutex rxCallbackMutex;
-	static std::mutex canLibNeedsUpdateMutex;
-	static std::mutex canLibUpdateCallbacksMutex;
-	static std::condition_variable threadConditionVariable;
-	static bool threadsStarted;
-	static bool canLibNeedsUpdate;
+	static std::mutex hardwareChannelsMutex; ///< Mutex to protect `hardwareChannels`
+	static std::mutex threadMutex; ///< A mutex for the main CAN thread
+	static std::mutex rxCallbackMutex; ///< A mutex for protecting the `rxCallbacks`
+	static std::mutex canLibNeedsUpdateMutex; ///< A mutex for protecting the `canLibNeedsUpdate` variable
+	static std::mutex canLibUpdateCallbacksMutex; ///< A mutex for protecting the `canLibUpdateCallbacks`
+	static std::condition_variable threadConditionVariable; ///< A condition variable to allow for signaling the CAN thread from `updateCANLibPeriodicThread`
+	static bool threadsStarted; ///< Stores if `start` has been called yet
+	static bool canLibNeedsUpdate; ///< Stores if the CAN thread needs to update the CAN stack this iteration
 };
 
 #endif // CAN_HARDWARE_INTERFACE_HPP

--- a/hardware_integration/include/can_hardware_interface.hpp
+++ b/hardware_integration/include/can_hardware_interface.hpp
@@ -1,14 +1,13 @@
 //================================================================================================
-/// @file socket_can_interface.hpp
+/// @file can_hardware_interface.hpp
 ///
-/// @brief An interface for using socket CAN on linux. Mostly for testing, but it could be
-/// used in any application to get the stack hooked up to the bus.
+/// @brief The hardware abstraction layer that separates the stack from the underlying CAN driver
 /// @author Adrian Del Grosso
 ///
 /// @copyright 2022 Adrian Del Grosso
 //================================================================================================
-#ifndef SOCKET_CAN_INTERFACE_HPP
-#define SOCKET_CAN_INTERFACE_HPP
+#ifndef CAN_HARDWARE_INTERFACE_HPP
+#define CAN_HARDWARE_INTERFACE_HPP
 
 #include <condition_variable>
 #include <cstdint>
@@ -20,29 +19,20 @@
 
 #include "can_frame.hpp"
 #include "can_hardware_abstraction.hpp"
+#include "can_hardware_plugin.hpp"
 
 class CANHardwareInterface
 {
 public:
-	class SocketCANFrameHandler
+	class CanLibUpdateCallbackInfo
 	{
 	public:
-		explicit SocketCANFrameHandler(const std::string deviceName);
-		~SocketCANFrameHandler();
+		CanLibUpdateCallbackInfo();
 
-		bool get_is_valid() const;
+		bool operator==(const CanLibUpdateCallbackInfo &obj);
 
-		std::string get_device_name() const;
-
-		void close();
-		void open();
-		bool read_frame(isobus::HardwareInterfaceCANFrame &canFrame);
-		bool write_frame(const isobus::HardwareInterfaceCANFrame &canFrame);
-
-	private:
-		struct sockaddr_can *pCANDevice;
-		const std::string name;
-		int fileDescriptor;
+		void (*callback)();
+		void *parent;
 	};
 
 	class RawCanMessageCallbackInfo
@@ -56,23 +46,12 @@ public:
 		void *parent;
 	};
 
-	class CanLibUpdateCallbackInfo
-	{
-	public:
-		CanLibUpdateCallbackInfo();
-
-		bool operator==(const CanLibUpdateCallbackInfo &obj);
-
-		void (*callback)();
-		void *parent;
-	};
-
 	static CANHardwareInterface CAN_HARDWARE_INTERFACE;
 
 	static std::uint8_t get_number_of_can_channels();
 	static bool set_number_of_can_channels(std::uint8_t value);
 
-	static bool assign_can_channel_frame_handler(std::uint8_t aCANChannel, std::string deviceName);
+	static bool assign_can_channel_frame_handler(std::uint8_t aCANChannel, CANHardwarePlugin *deviceName);
 
 	static bool start();
 	static bool stop();
@@ -98,7 +77,7 @@ private:
 
 		std::thread *receiveMessageThread;
 
-		SocketCANFrameHandler *frameHandler;
+		CANHardwarePlugin *frameHandler;
 	};
 
 	static const std::uint32_t CANLIB_UPDATE_RATE = 4;
@@ -127,4 +106,4 @@ private:
 	static bool canLibNeedsUpdate;
 };
 
-#endif // SOCKET_CAN_INTERFACE_HPP
+#endif // CAN_HARDWARE_INTERFACE_HPP

--- a/hardware_integration/include/can_hardware_plugin.hpp
+++ b/hardware_integration/include/can_hardware_plugin.hpp
@@ -11,13 +11,34 @@
 
 #include "can_frame.hpp"
 
+//================================================================================================
+/// @class CANHardwarePlugin
+///
+/// @brief An abstract base class for a CAN driver
+//================================================================================================
 class CANHardwarePlugin
 {
 public:
+	/// @brief Returns if the driver is ready and in a good state
+	/// @details This should return `false` until `open` is called, and after `close` is called, or
+	/// if anything happens that causes the driver to be invalid, like the hardware is disconnected.
+	/// @returns `true` if the driver is good/connected, `false` if the driver is not usable
 	virtual bool get_is_valid() const = 0;
+
+	/// @brief Disconnects the driver from the hardware
 	virtual void close() = 0;
+
+	/// @brief Connects the driver to the hardware
 	virtual void open() = 0;
+
+	/// @brief Reads one frame from the bus synchronously
+	/// @param[in, out] canFrame The CAN frame that was read
+	/// @returns `true` if a CAN frame was read, otherwise `false`
 	virtual bool read_frame(isobus::HardwareInterfaceCANFrame &canFrame) = 0;
+
+	/// @brief Writes a frame to the bus (synchronous)
+	/// @param[in] canFrame The frame to write to the bus
+	/// @returns `true` if the frame was written, otherwise `false`
 	virtual bool write_frame(const isobus::HardwareInterfaceCANFrame &canFrame) = 0;
 };
 

--- a/hardware_integration/include/can_hardware_plugin.hpp
+++ b/hardware_integration/include/can_hardware_plugin.hpp
@@ -1,0 +1,24 @@
+//================================================================================================
+/// @file can_hardware_plugin.hpp
+///
+/// @brief A base class for a CAN driver. Can be derived into your platform's required interface.
+/// @author Adrian Del Grosso
+///
+/// @copyright 2022 Adrian Del Grosso
+//================================================================================================
+#ifndef CAN_HARDEWARE_PLUGIN_HPP
+#define CAN_HARDEWARE_PLUGIN_HPP
+
+#include "can_frame.hpp"
+
+class CANHardwarePlugin
+{
+public:
+	virtual bool get_is_valid() const = 0;
+	virtual void close() = 0;
+	virtual void open() = 0;
+	virtual bool read_frame(isobus::HardwareInterfaceCANFrame &canFrame) = 0;
+	virtual bool write_frame(const isobus::HardwareInterfaceCANFrame &canFrame) = 0;
+};
+
+#endif // CAN_HARDEWARE_PLUGIN_HPP

--- a/hardware_integration/include/socket_can_interface.hpp
+++ b/hardware_integration/include/socket_can_interface.hpp
@@ -1,0 +1,41 @@
+//================================================================================================
+/// @file socket_can_interface.hpp
+///
+/// @brief An interface for using socket CAN on linux. Mostly for testing, but it could be
+/// used in any application to get the stack hooked up to the bus.
+/// @author Adrian Del Grosso
+///
+/// @copyright 2022 Adrian Del Grosso
+//================================================================================================
+#ifndef SOCKET_CAN_INTERFACE_HPP
+#define SOCKET_CAN_INTERFACE_HPP
+
+#include <cstdint>
+#include <string>
+
+#include "can_frame.hpp"
+#include "can_hardware_abstraction.hpp"
+#include "can_hardware_plugin.hpp"
+
+class SocketCANInterface : public CANHardwarePlugin
+{
+public:
+	explicit SocketCANInterface(const std::string deviceName);
+	~SocketCANInterface();
+
+	bool get_is_valid() const override;
+
+	std::string get_device_name() const;
+
+	void close() override;
+	void open() override;
+	bool read_frame(isobus::HardwareInterfaceCANFrame &canFrame) override;
+	bool write_frame(const isobus::HardwareInterfaceCANFrame &canFrame) override;
+
+private:
+	struct sockaddr_can *pCANDevice;
+	const std::string name;
+	int fileDescriptor;
+};
+
+#endif // SOCKET_CAN_INTERFACE_HPP

--- a/hardware_integration/include/socket_can_interface.hpp
+++ b/hardware_integration/include/socket_can_interface.hpp
@@ -10,32 +10,55 @@
 #ifndef SOCKET_CAN_INTERFACE_HPP
 #define SOCKET_CAN_INTERFACE_HPP
 
-#include <cstdint>
 #include <string>
 
 #include "can_frame.hpp"
 #include "can_hardware_abstraction.hpp"
 #include "can_hardware_plugin.hpp"
 
+//================================================================================================
+/// @class SocketCANInterface
+///
+/// @brief A CAN Driver for Linux socket CAN
+//================================================================================================
 class SocketCANInterface : public CANHardwarePlugin
 {
 public:
+	/// @brief Constructor for the socket CAN driver
+	/// @param[in] deviceName The device name to use, like "can0" or "vcan0"
 	explicit SocketCANInterface(const std::string deviceName);
+
+	/// @brief The destructor for SocketCANInterface
 	~SocketCANInterface();
 
+	/// @brief Returns if the socket connection is valid
+	/// @returns `true` if connected, `false` if not connected
 	bool get_is_valid() const override;
 
+	/// @brief Returns the device name the driver is using
+	/// @returns The device name the driver is using, such as "can0" or "vcan0"
 	std::string get_device_name() const;
 
+	/// @brief Closes the socket
 	void close() override;
+
+	/// @brief Connects to the socket
 	void open() override;
+
+	/// @brief Returns a frame from the hardware (synchronous), or `false` if no frame can be read.
+	/// @param[in, out] canFrame The CAN frame that was read
+	/// @returns `true` if a CAN frame was read, otherwise `false`
 	bool read_frame(isobus::HardwareInterfaceCANFrame &canFrame) override;
+
+	/// @brief Writes a frame to the bus (synchronous)
+	/// @param[in] canFrame The frame to write to the bus
+	/// @returns `true` if the frame was written, otherwise `false`
 	bool write_frame(const isobus::HardwareInterfaceCANFrame &canFrame) override;
 
 private:
-	struct sockaddr_can *pCANDevice;
-	const std::string name;
-	int fileDescriptor;
+	struct sockaddr_can *pCANDevice; ///< The structure for CAN sockets
+	const std::string name; ///< The device name
+	int fileDescriptor; ///< File descriptor for the socket
 };
 
 #endif // SOCKET_CAN_INTERFACE_HPP

--- a/hardware_integration/src/can_hardware_interface.cpp
+++ b/hardware_integration/src/can_hardware_interface.cpp
@@ -121,15 +121,6 @@ bool CANHardwareInterface::set_number_of_can_channels(uint8_t aValue)
 			{
 				pCANHardware = hardwareChannels.back();
 				hardwareChannels.pop_back();
-
-				if (nullptr != pCANHardware->frameHandler)
-				{
-					if (pCANHardware->frameHandler->get_is_valid())
-					{
-						pCANHardware->frameHandler->close();
-					}
-				}
-
 				delete pCANHardware;
 			}
 			retVal = true;

--- a/hardware_integration/src/can_hardware_interface.cpp
+++ b/hardware_integration/src/can_hardware_interface.cpp
@@ -1,5 +1,5 @@
 //================================================================================================
-/// @file socket_can_interface.cpp
+/// @file can_hardware_interface.cpp
 ///
 /// @brief An interface for using socket CAN on linux. Mostly for testing, but it could be
 /// used in any application to get the stack hooked up to the bus.

--- a/hardware_integration/src/can_hardware_interface.cpp
+++ b/hardware_integration/src/can_hardware_interface.cpp
@@ -7,7 +7,7 @@
 ///
 /// @copyright 2022 Adrian Del Grosso
 //================================================================================================
-#include "socket_can_interface.hpp"
+#include "can_hardware_interface.hpp"
 #include "system_timing.hpp"
 
 #include <linux/can.h>
@@ -42,191 +42,6 @@ bool isobus::send_can_message_to_hardware(HardwareInterfaceCANFrame frame)
 	return CANHardwareInterface::transmit_can_message(frame);
 }
 
-CANHardwareInterface::SocketCANFrameHandler::SocketCANFrameHandler(const std::string deviceName) :
-  pCANDevice(new sockaddr_can),
-  name(deviceName),
-  fileDescriptor(-1)
-{
-	if (nullptr != pCANDevice)
-	{
-		memset(pCANDevice, 0, sizeof(struct sockaddr_can));
-	}
-}
-
-CANHardwareInterface::SocketCANFrameHandler::~SocketCANFrameHandler()
-{
-	close();
-
-	if (nullptr != pCANDevice)
-	{
-		delete pCANDevice;
-		pCANDevice = nullptr;
-	}
-}
-
-bool CANHardwareInterface::SocketCANFrameHandler::get_is_valid() const
-{
-	return (-1 != fileDescriptor);
-}
-
-std::string CANHardwareInterface::SocketCANFrameHandler::get_device_name() const
-{
-	return name;
-}
-
-void CANHardwareInterface::SocketCANFrameHandler::close()
-{
-	::close(fileDescriptor);
-	fileDescriptor = -1;
-}
-
-void CANHardwareInterface::SocketCANFrameHandler::open()
-{
-	fileDescriptor = socket(PF_CAN, SOCK_RAW, CAN_RAW);
-
-	if (fileDescriptor >= 0)
-	{
-		struct ifreq interfaceRequestStructure;
-		const int RECEIVE_OWN_MESSAGES = 0;
-		const int DROP_MONITOR = 1;
-		const int TIMESTAMPING = 0x58;
-		const int TIMESTAMP = 1;
-		memset(&interfaceRequestStructure, 0, sizeof(interfaceRequestStructure));
-		strncpy(interfaceRequestStructure.ifr_name, name.c_str(), sizeof(interfaceRequestStructure.ifr_name));
-		setsockopt(fileDescriptor, SOL_CAN_RAW, CAN_RAW_RECV_OWN_MSGS, &RECEIVE_OWN_MESSAGES, sizeof(RECEIVE_OWN_MESSAGES));
-		setsockopt(fileDescriptor, SOL_SOCKET, SO_RXQ_OVFL, &DROP_MONITOR, sizeof(DROP_MONITOR));
-
-		if (setsockopt(fileDescriptor, SOL_SOCKET, SO_TIMESTAMPING, &TIMESTAMPING, sizeof(TIMESTAMPING)) < 0)
-		{
-			setsockopt(fileDescriptor, SOL_SOCKET, SO_TIMESTAMP, &TIMESTAMP, sizeof(TIMESTAMP));
-		}
-
-		if (ioctl(fileDescriptor, SIOCGIFINDEX, &interfaceRequestStructure) >= 0)
-		{
-			memset(pCANDevice, 0, sizeof(sockaddr_can));
-			pCANDevice->can_family = AF_CAN;
-			pCANDevice->can_ifindex = interfaceRequestStructure.ifr_ifindex;
-
-			if (bind(fileDescriptor, (struct sockaddr *)pCANDevice, sizeof(struct sockaddr)) < 0)
-			{
-				::close(fileDescriptor);
-				fileDescriptor = -1;
-			}
-		}
-		else
-		{
-			::close(fileDescriptor);
-			fileDescriptor = -1;
-		}
-	}
-	else
-	{
-		::close(fileDescriptor);
-		fileDescriptor = -1;
-	}
-}
-
-bool CANHardwareInterface::SocketCANFrameHandler::read_frame(isobus::HardwareInterfaceCANFrame &canFrame)
-{
-	struct pollfd pollingFileDescriptor;
-	bool retVal = false;
-
-	pollingFileDescriptor.fd = fileDescriptor;
-	pollingFileDescriptor.events = POLLIN;
-	pollingFileDescriptor.revents = 0;
-
-	if (1 == poll(&pollingFileDescriptor, 1, 100))
-	{
-		canFrame.timestamp_us = std::numeric_limits<std::uint64_t>::max();
-		struct can_frame txFrame;
-		struct msghdr message;
-		struct iovec segment;
-
-		char lControlMessage[CMSG_SPACE(sizeof(struct timeval) + (3 * sizeof(struct timespec)) + sizeof(std::uint32_t))];
-
-		segment.iov_base = &txFrame;
-		segment.iov_len = sizeof(struct can_frame);
-		message.msg_iov = &segment;
-		message.msg_iovlen = 1;
-		message.msg_control = &lControlMessage;
-		message.msg_controllen = sizeof(lControlMessage);
-		message.msg_name = pCANDevice;
-		message.msg_namelen = sizeof(struct sockaddr_can);
-		message.msg_flags = 0;
-
-		if (recvmsg(fileDescriptor, &message, 0) > 0)
-		{
-			if (0 == (txFrame.can_id & CAN_ERR_FLAG))
-			{
-				if (0 != (txFrame.can_id & CAN_EFF_FLAG))
-				{
-					canFrame.identifier = (txFrame.can_id & CAN_EFF_MASK);
-					canFrame.isExtendedFrame = true;
-				}
-				else
-				{
-					canFrame.identifier = (txFrame.can_id & CAN_SFF_MASK);
-					canFrame.isExtendedFrame = false;
-				}
-				canFrame.dataLength = txFrame.can_dlc;
-				memset(canFrame.data, 0, sizeof(canFrame.data));
-				memcpy(canFrame.data, txFrame.data, canFrame.dataLength);
-
-				for (struct cmsghdr *pControlMessage = CMSG_FIRSTHDR(&message); (nullptr != pControlMessage) && (SOL_SOCKET == pControlMessage->cmsg_level); pControlMessage = CMSG_NXTHDR(&message, pControlMessage))
-				{
-					switch (pControlMessage->cmsg_type)
-					{
-						case SO_TIMESTAMP:
-						{
-							struct timeval *time = (struct timeval *)CMSG_DATA(pControlMessage);
-
-							if (std::numeric_limits<std::uint64_t>::max() == canFrame.timestamp_us)
-							{
-								canFrame.timestamp_us = static_cast<std::uint64_t>(time->tv_usec) + (static_cast<std::uint64_t>(time->tv_sec) * 1000000);
-							}
-						}
-						break;
-
-						case SO_TIMESTAMPING:
-						{
-							struct timespec *time = (struct timespec *)(CMSG_DATA(pControlMessage));
-							canFrame.timestamp_us = (static_cast<std::uint64_t>(time[2].tv_nsec) / 1000) + (static_cast<std::uint64_t>(time[2].tv_sec) * 1000000);
-						}
-						break;
-					}
-				}
-				retVal = true;
-			}
-		}
-	}
-	else if (pollingFileDescriptor.revents & (POLLERR | POLLHUP))
-	{
-		close();
-	}
-	return retVal;
-}
-
-bool CANHardwareInterface::SocketCANFrameHandler::write_frame(const isobus::HardwareInterfaceCANFrame &canFrame)
-{
-	struct can_frame txFrame;
-	bool retVal = false;
-
-	txFrame.can_id = canFrame.identifier;
-	txFrame.can_dlc = canFrame.dataLength;
-	memcpy(txFrame.data, canFrame.data, canFrame.dataLength);
-
-	if (canFrame.isExtendedFrame)
-	{
-		txFrame.can_id |= CAN_EFF_FLAG;
-	}
-
-	if (write(fileDescriptor, &txFrame, sizeof(struct can_frame)) > 0)
-	{
-		retVal = true;
-	}
-	return retVal;
-}
-
 CANHardwareInterface::RawCanMessageCallbackInfo::RawCanMessageCallbackInfo() :
   callback(nullptr),
   parent(nullptr)
@@ -258,7 +73,7 @@ CANHardwareInterface::~CANHardwareInterface()
 	set_number_of_can_channels(0);
 }
 
-bool CANHardwareInterface::assign_can_channel_frame_handler(std::uint8_t aCANChannel, std::string deviceName)
+bool CANHardwareInterface::assign_can_channel_frame_handler(std::uint8_t aCANChannel, CANHardwarePlugin *driver)
 {
 	bool retVal = false;
 
@@ -267,21 +82,11 @@ bool CANHardwareInterface::assign_can_channel_frame_handler(std::uint8_t aCANCha
 		if ((!threadsStarted) &&
 		    (aCANChannel < hardwareChannels.size()))
 		{
-			if (nullptr == hardwareChannels[aCANChannel]->frameHandler)
+			if ((nullptr == hardwareChannels[aCANChannel]->frameHandler) ||
+			    (driver == hardwareChannels[aCANChannel]->frameHandler))
 			{
 				retVal = true;
-				hardwareChannels[aCANChannel]->frameHandler = new SocketCANFrameHandler(deviceName);
-			}
-			else
-			{
-				retVal = true;
-
-				if (hardwareChannels[aCANChannel]->frameHandler->get_device_name() != deviceName)
-				{
-					hardwareChannels[aCANChannel]->frameHandler->close();
-					delete hardwareChannels[aCANChannel]->frameHandler;
-					hardwareChannels[aCANChannel]->frameHandler = new SocketCANFrameHandler(deviceName);
-				}
+				hardwareChannels[aCANChannel]->frameHandler = driver;
 			}
 		}
 		hardwareChannelsMutex.unlock();
@@ -323,7 +128,6 @@ bool CANHardwareInterface::set_number_of_can_channels(uint8_t aValue)
 					{
 						pCANHardware->frameHandler->close();
 					}
-					delete pCANHardware->frameHandler;
 				}
 
 				delete pCANHardware;

--- a/hardware_integration/src/socket_can_interface.cpp
+++ b/hardware_integration/src/socket_can_interface.cpp
@@ -1,8 +1,7 @@
 //================================================================================================
 /// @file socket_can_interface.cpp
 ///
-/// @brief An interface for using socket CAN on linux. Mostly for testing, but it could be
-/// used in any application to get the stack hooked up to the bus.
+/// @brief An CAN driver for socket CAN on linux.
 /// @author Adrian Del Grosso
 ///
 /// @copyright 2022 Adrian Del Grosso

--- a/hardware_integration/src/socket_can_interface.cpp
+++ b/hardware_integration/src/socket_can_interface.cpp
@@ -1,0 +1,209 @@
+//================================================================================================
+/// @file socket_can_interface.cpp
+///
+/// @brief An interface for using socket CAN on linux. Mostly for testing, but it could be
+/// used in any application to get the stack hooked up to the bus.
+/// @author Adrian Del Grosso
+///
+/// @copyright 2022 Adrian Del Grosso
+//================================================================================================
+#include "socket_can_interface.hpp"
+#include "system_timing.hpp"
+
+#include <linux/can.h>
+#include <linux/can/raw.h>
+#include <net/if.h>
+#include <poll.h>
+#include <sys/ioctl.h>
+#include <sys/time.h>
+#include <unistd.h>
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+
+SocketCANInterface::SocketCANInterface(const std::string deviceName) :
+  pCANDevice(new sockaddr_can),
+  name(deviceName),
+  fileDescriptor(-1)
+{
+	if (nullptr != pCANDevice)
+	{
+		std::memset(pCANDevice, 0, sizeof(struct sockaddr_can));
+	}
+}
+
+SocketCANInterface::~SocketCANInterface()
+{
+	close();
+
+	if (nullptr != pCANDevice)
+	{
+		delete pCANDevice;
+		pCANDevice = nullptr;
+	}
+}
+
+bool SocketCANInterface::get_is_valid() const
+{
+	return (-1 != fileDescriptor);
+}
+
+std::string SocketCANInterface::get_device_name() const
+{
+	return name;
+}
+
+void SocketCANInterface::close()
+{
+	::close(fileDescriptor);
+	fileDescriptor = -1;
+}
+
+void SocketCANInterface::open()
+{
+	fileDescriptor = socket(PF_CAN, SOCK_RAW, CAN_RAW);
+
+	if (fileDescriptor >= 0)
+	{
+		struct ifreq interfaceRequestStructure;
+		const int RECEIVE_OWN_MESSAGES = 0;
+		const int DROP_MONITOR = 1;
+		const int TIMESTAMPING = 0x58;
+		const int TIMESTAMP = 1;
+		memset(&interfaceRequestStructure, 0, sizeof(interfaceRequestStructure));
+		strncpy(interfaceRequestStructure.ifr_name, name.c_str(), sizeof(interfaceRequestStructure.ifr_name));
+		setsockopt(fileDescriptor, SOL_CAN_RAW, CAN_RAW_RECV_OWN_MSGS, &RECEIVE_OWN_MESSAGES, sizeof(RECEIVE_OWN_MESSAGES));
+		setsockopt(fileDescriptor, SOL_SOCKET, SO_RXQ_OVFL, &DROP_MONITOR, sizeof(DROP_MONITOR));
+
+		if (setsockopt(fileDescriptor, SOL_SOCKET, SO_TIMESTAMPING, &TIMESTAMPING, sizeof(TIMESTAMPING)) < 0)
+		{
+			setsockopt(fileDescriptor, SOL_SOCKET, SO_TIMESTAMP, &TIMESTAMP, sizeof(TIMESTAMP));
+		}
+
+		if (ioctl(fileDescriptor, SIOCGIFINDEX, &interfaceRequestStructure) >= 0)
+		{
+			memset(pCANDevice, 0, sizeof(sockaddr_can));
+			pCANDevice->can_family = AF_CAN;
+			pCANDevice->can_ifindex = interfaceRequestStructure.ifr_ifindex;
+
+			if (bind(fileDescriptor, (struct sockaddr *)pCANDevice, sizeof(struct sockaddr)) < 0)
+			{
+				::close(fileDescriptor);
+				fileDescriptor = -1;
+			}
+		}
+		else
+		{
+			::close(fileDescriptor);
+			fileDescriptor = -1;
+		}
+	}
+	else
+	{
+		::close(fileDescriptor);
+		fileDescriptor = -1;
+	}
+}
+
+bool SocketCANInterface::read_frame(isobus::HardwareInterfaceCANFrame &canFrame)
+{
+	struct pollfd pollingFileDescriptor;
+	bool retVal = false;
+
+	pollingFileDescriptor.fd = fileDescriptor;
+	pollingFileDescriptor.events = POLLIN;
+	pollingFileDescriptor.revents = 0;
+
+	if (1 == poll(&pollingFileDescriptor, 1, 100))
+	{
+		canFrame.timestamp_us = std::numeric_limits<std::uint64_t>::max();
+		struct can_frame txFrame;
+		struct msghdr message;
+		struct iovec segment;
+
+		char lControlMessage[CMSG_SPACE(sizeof(struct timeval) + (3 * sizeof(struct timespec)) + sizeof(std::uint32_t))];
+
+		segment.iov_base = &txFrame;
+		segment.iov_len = sizeof(struct can_frame);
+		message.msg_iov = &segment;
+		message.msg_iovlen = 1;
+		message.msg_control = &lControlMessage;
+		message.msg_controllen = sizeof(lControlMessage);
+		message.msg_name = pCANDevice;
+		message.msg_namelen = sizeof(struct sockaddr_can);
+		message.msg_flags = 0;
+
+		if (recvmsg(fileDescriptor, &message, 0) > 0)
+		{
+			if (0 == (txFrame.can_id & CAN_ERR_FLAG))
+			{
+				if (0 != (txFrame.can_id & CAN_EFF_FLAG))
+				{
+					canFrame.identifier = (txFrame.can_id & CAN_EFF_MASK);
+					canFrame.isExtendedFrame = true;
+				}
+				else
+				{
+					canFrame.identifier = (txFrame.can_id & CAN_SFF_MASK);
+					canFrame.isExtendedFrame = false;
+				}
+				canFrame.dataLength = txFrame.can_dlc;
+				memset(canFrame.data, 0, sizeof(canFrame.data));
+				memcpy(canFrame.data, txFrame.data, canFrame.dataLength);
+
+				for (struct cmsghdr *pControlMessage = CMSG_FIRSTHDR(&message); (nullptr != pControlMessage) && (SOL_SOCKET == pControlMessage->cmsg_level); pControlMessage = CMSG_NXTHDR(&message, pControlMessage))
+				{
+					switch (pControlMessage->cmsg_type)
+					{
+						case SO_TIMESTAMP:
+						{
+							struct timeval *time = (struct timeval *)CMSG_DATA(pControlMessage);
+
+							if (std::numeric_limits<std::uint64_t>::max() == canFrame.timestamp_us)
+							{
+								canFrame.timestamp_us = static_cast<std::uint64_t>(time->tv_usec) + (static_cast<std::uint64_t>(time->tv_sec) * 1000000);
+							}
+						}
+						break;
+
+						case SO_TIMESTAMPING:
+						{
+							struct timespec *time = (struct timespec *)(CMSG_DATA(pControlMessage));
+							canFrame.timestamp_us = (static_cast<std::uint64_t>(time[2].tv_nsec) / 1000) + (static_cast<std::uint64_t>(time[2].tv_sec) * 1000000);
+						}
+						break;
+					}
+				}
+				retVal = true;
+			}
+		}
+	}
+	else if (pollingFileDescriptor.revents & (POLLERR | POLLHUP))
+	{
+		close();
+	}
+	return retVal;
+}
+
+bool SocketCANInterface::write_frame(const isobus::HardwareInterfaceCANFrame &canFrame)
+{
+	struct can_frame txFrame;
+	bool retVal = false;
+
+	txFrame.can_id = canFrame.identifier;
+	txFrame.can_dlc = canFrame.dataLength;
+	memcpy(txFrame.data, canFrame.data, canFrame.dataLength);
+
+	if (canFrame.isExtendedFrame)
+	{
+		txFrame.can_id |= CAN_EFF_FLAG;
+	}
+
+	if (write(fileDescriptor, &txFrame, sizeof(struct can_frame)) > 0)
+	{
+		retVal = true;
+	}
+	return retVal;
+}

--- a/sphinx/source/FAQ.rst
+++ b/sphinx/source/FAQ.rst
@@ -37,7 +37,7 @@ Make sure your CMake links these to your executable:
    set(THREADS_PREFER_PTHREAD_FLAG ON)
    find_package(Threads)
 
-   target_link_libraries(<your executable name> Isobus SocketCANInterface ${CMAKE_THREAD_LIBS_INIT})
+   target_link_libraries(<your executable name> Isobus HardwareIntegration ${CMAKE_THREAD_LIBS_INIT})
 
 I have some other issue!
 -------------------------

--- a/sphinx/source/Installation.rst
+++ b/sphinx/source/Installation.rst
@@ -60,7 +60,7 @@ If your project is already using CMake to build your project, or this is a new p
 
    ...
 
-   target_link_libraries(<your target> Isobus SocketCANInterface ${CMAKE_THREAD_LIBS_INIT})
+   target_link_libraries(<your target> Isobus HardwareIntegration ${CMAKE_THREAD_LIBS_INIT})
 
 Using CMake has a lot of advantages, such as if the library is updated with additional files, or the file names change, it will not break your compilation.
    

--- a/sphinx/source/Tutorials/Adding a Destination.rst
+++ b/sphinx/source/Tutorials/Adding a Destination.rst
@@ -95,6 +95,7 @@ The final program for this tutorial (including the code from the previous Hello 
 
    #include "can_network_manager.hpp"
    #include "socket_can_interface.hpp"
+   #include "can_hardware_interface.hpp"
    #include "can_partnered_control_function.hpp"
 
    #include <memory>
@@ -121,6 +122,7 @@ The final program for this tutorial (including the code from the previous Hello 
     isobus::NAME myNAME(0); // Create an empty NAME
     std::shared_ptr<isobus::InternalControlFunction> myECU = nullptr; // A pointer to hold our InternalControlFunction
     std::shared_ptr<isobus::PartneredControlFunction> myPartner = nullptr; // A pointer to hold a partner
+    SocketCANInterface canDriver("can0"); // The CAN driver to use for this program. In this case, we're using socket CAN.
 
     // Define a NAME filter for our partner
     std::vector<isobus::NAMEFilter> myPartnerFilter;
@@ -129,7 +131,7 @@ The final program for this tutorial (including the code from the previous Hello 
 
     // Set up the hardware layer to use "can0"
     CANHardwareInterface::set_number_of_can_channels(1);
-    CANHardwareInterface::assign_can_channel_frame_handler(0, "can0");
+    CANHardwareInterface::assign_can_channel_frame_handler(0, &canDriver);
     CANHardwareInterface::start();
 
     // Handle control+c

--- a/sphinx/source/Tutorials/Receiving Messages.rst
+++ b/sphinx/source/Tutorials/Receiving Messages.rst
@@ -70,6 +70,7 @@ So, our updated tutorial program now should look like this:
 
    #include "can_network_manager.hpp"
    #include "socket_can_interface.hpp"
+   #include "can_hardware_interface.hpp"
    #include "can_partnered_control_function.hpp"
 
    #include <memory>
@@ -105,6 +106,7 @@ So, our updated tutorial program now should look like this:
     isobus::NAME myNAME(0); // Create an empty NAME
     std::shared_ptr<isobus::InternalControlFunction> myECU = nullptr; // A pointer to hold our InternalControlFunction
     std::shared_ptr<isobus::PartneredControlFunction> myPartner = nullptr; // A pointer to hold a partner
+    SocketCANInterface canDriver("can0"); // The CAN driver to use for this program. In this case, we're using socket CAN.
 
     // Define a NAME filter for our partner
     std::vector<isobus::NAMEFilter> myPartnerFilter;
@@ -113,7 +115,7 @@ So, our updated tutorial program now should look like this:
 
     // Set up the hardware layer to use "can0"
     CANHardwareInterface::set_number_of_can_channels(1);
-    CANHardwareInterface::assign_can_channel_frame_handler(0, "can0");
+    CANHardwareInterface::assign_can_channel_frame_handler(0, &canDriver);
     CANHardwareInterface::start();
 
     // Handle control+c

--- a/sphinx/source/Tutorials/The ISOBUS Hello World.rst
+++ b/sphinx/source/Tutorials/The ISOBUS Hello World.rst
@@ -28,6 +28,7 @@ Let's set up a standard, empty C++ program in a file called "main.cpp", and incl
 
    #include "can_network_manager.hpp"
    #include "socket_can_interface.hpp"
+   #include "can_hardware_interface.hpp"
    #include "can_partnered_control_function.hpp"
    
    int main()
@@ -59,6 +60,7 @@ NOTE: Everything that is part of the stack is in the namespace `"isobus" <https:
 
    #include "can_network_manager.hpp"
    #include "socket_can_interface.hpp"
+   #include "can_hardware_interface.hpp"
    #include "can_partnered_control_function.hpp"
    
    int main()
@@ -74,6 +76,7 @@ Now we have a NAME instantiated. We still need to populate it with our control f
 
    #include "can_network_manager.hpp"
    #include "socket_can_interface.hpp"
+   #include "can_hardware_interface.hpp"
    #include "can_partnered_control_function.hpp"
    
    int main()
@@ -113,6 +116,7 @@ In this example, I'll use a shared_ptr to store my InternalControlFunction, but 
 
    #include "can_network_manager.hpp"
    #include "socket_can_interface.hpp"
+   #include "can_hardware_interface.hpp"
    #include "can_partnered_control_function.hpp"
 
    #include <memory>
@@ -171,8 +175,9 @@ There are a few lines we'll need to add:
 
 .. code-block:: c++
 
+   SocketCANInterface canDriver("can0");
    CANHardwareInterface::set_number_of_can_channels(1);
-   CANHardwareInterface::assign_can_channel_frame_handler(0, "can0");
+   CANHardwareInterface::assign_can_channel_frame_handler(0, &canDriver);
    CANHardwareInterface::start();
 
 The "CANHardwareInterface" is an independent component that is not actually directly tied to the CAN stack. It serves as a way for the stack to abstract away whatever hardware is being used.
@@ -222,6 +227,7 @@ Let's see what we've got so far:
 
    #include "can_network_manager.hpp"
    #include "socket_can_interface.hpp"
+   #include "can_hardware_interface.hpp"
    #include "can_partnered_control_function.hpp"
 
    #include <memory>
@@ -242,8 +248,9 @@ Let's see what we've got so far:
     std::shared_ptr<isobus::InternalControlFunction> myECU = nullptr; // A pointer to hold our InternalControlFunction
 
     // Set up the hardware layer to use "can0"
+    SocketCANInterface canDriver("can0");
     CANHardwareInterface::set_number_of_can_channels(1);
-    CANHardwareInterface::assign_can_channel_frame_handler(0, "can0");
+    CANHardwareInterface::assign_can_channel_frame_handler(0, &canDriver);
     CANHardwareInterface::start();
 
     CANHardwareInterface::add_can_lib_update_callback(update_CAN_network, nullptr);
@@ -281,6 +288,7 @@ Make sure to include `csignal`.
 
    #include "can_network_manager.hpp"
    #include "socket_can_interface.hpp"
+   #include "can_hardware_interface.hpp"
    #include "can_partnered_control_function.hpp"
 
    #include <memory>
@@ -308,8 +316,9 @@ Make sure to include `csignal`.
     std::shared_ptr<isobus::InternalControlFunction> myECU = nullptr; // A pointer to hold our InternalControlFunction
 
     // Set up the hardware layer to use "can0"
+    SocketCANInterface canDriver("can0");
     CANHardwareInterface::set_number_of_can_channels(1);
-    CANHardwareInterface::assign_can_channel_frame_handler(0, "can0");
+    CANHardwareInterface::assign_can_channel_frame_handler(0, &canDriver);
     CANHardwareInterface::start();
 
     // Handle control+c
@@ -353,6 +362,7 @@ The total result:
 
    #include "can_network_manager.hpp"
    #include "socket_can_interface.hpp"
+   #include "can_hardware_interface.hpp"
    #include "can_partnered_control_function.hpp"
 
    #include <memory>
@@ -380,8 +390,9 @@ The total result:
     std::shared_ptr<isobus::InternalControlFunction> myECU = nullptr; // A pointer to hold our InternalControlFunction
 
     // Set up the hardware layer to use "can0"
+    SocketCANInterface canDriver("can0");
     CANHardwareInterface::set_number_of_can_channels(1);
-    CANHardwareInterface::assign_can_channel_frame_handler(0, "can0");
+    CANHardwareInterface::assign_can_channel_frame_handler(0, &canDriver);
     CANHardwareInterface::start();
 
     // Handle control+c

--- a/sphinx/source/Tutorials/The ISOBUS Hello World.rst
+++ b/sphinx/source/Tutorials/The ISOBUS Hello World.rst
@@ -470,7 +470,7 @@ Add the following to a new file called CMakeLists.txt:
    
    add_executable(isobus_hello_world main.cpp)
    
-   target_link_libraries(isobus_hello_world Isobus SocketCANInterface ${CMAKE_THREAD_LIBS_INIT})
+   target_link_libraries(isobus_hello_world Isobus HardwareIntegration ${CMAKE_THREAD_LIBS_INIT})
 
 Save and close the file.
 

--- a/test/address_claim_test.cpp
+++ b/test/address_claim_test.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include "can_constants.hpp"
+#include "can_hardware_interface.hpp"
 #include "can_internal_control_function.hpp"
 #include "can_network_manager.hpp"
 #include "socket_can_interface.hpp"
@@ -35,8 +36,9 @@ TEST(ADDRESS_CLAIM_TESTS, NAMETests)
 
 TEST(ADDRESS_CLAIM_TESTS, AddressClaiming)
 {
+	SocketCANInterface canDriver("can0");
 	CANHardwareInterface::set_number_of_can_channels(1);
-	CANHardwareInterface::assign_can_channel_frame_handler(0, "vcan0");
+	CANHardwareInterface::assign_can_channel_frame_handler(0, &canDriver);
 	CANHardwareInterface::start();
 
 	CANHardwareInterface::add_can_lib_update_callback(update_CAN_network, nullptr);


### PR DESCRIPTION
## What's New

* Broke-up the socket-can layer to be a more generic abstraction layer.
    - Now, if you want to implement your own driver for some other CAN interface, you just need to inherit from `CANHardwarePlugin` and write the 5 functions needed. Then, pass that class to `CANHardwareInterface` instead of the device name like before. See the examples or tutorial for how to do this.
* Added a way to not build the examples! Just define NO_EXAMPLES when configuring via CMake `-DNO_EXAMPLES`
* Added a CMake way to allow selecting other CAN drivers that aren't socket CAN (right now that's still the only option)

## Breaking Change!

Renamed the `SocketCANInterface` library to `HardwareIntegration`. _You may need to update your CMake!_