### PR TITLE
[Core]: Change all std::to_string calls to use a workaround

### DIFF
--- a/isobus/src/can_extended_transport_protocol.cpp
+++ b/isobus/src/can_extended_transport_protocol.cpp
@@ -13,6 +13,7 @@
 #include "can_network_configuration.hpp"
 #include "can_warning_logger.hpp"
 #include "system_timing.hpp"
+#include "to_string.hpp"
 
 #include <algorithm>
 
@@ -270,12 +271,12 @@ namespace isobus
 
 								if (get_session(session, message->get_destination_control_function(), message->get_source_control_function(), pgn))
 								{
-									CANStackLogger::CAN_stack_log("[ETP]: Received an abort for an session with PGN: " + std::to_string(pgn));
+									CANStackLogger::CAN_stack_log("[ETP]: Received an abort for an session with PGN: " + isobus::to_string(pgn));
 									close_session(session);
 								}
 								else
 								{
-									CANStackLogger::CAN_stack_log("[ETP]: Received an abort with no matching session with PGN: " + std::to_string(pgn));
+									CANStackLogger::CAN_stack_log("[ETP]: Received an abort with no matching session with PGN: " + isobus::to_string(pgn));
 								}
 							}
 							break;
@@ -385,7 +386,7 @@ namespace isobus
 			newSession->sessionMessage.set_identifier(messageVirtualID);
 			set_state(newSession, StateMachineState::RequestToSend);
 			activeSessions.push_back(newSession);
-			CANStackLogger::CAN_stack_log("[ETP]: New ETP Session. Dest: " + std::to_string(static_cast<int>(destination->get_address())));
+			CANStackLogger::CAN_stack_log("[ETP]: New ETP Session. Dest: " + isobus::to_string(static_cast<int>(destination->get_address())));
 			retVal = true;
 		}
 		return retVal;

--- a/isobus/src/can_network_manager.cpp
+++ b/isobus/src/can_network_manager.cpp
@@ -18,6 +18,7 @@
 #include "can_protocol.hpp"
 #include "can_warning_logger.hpp"
 #include "system_timing.hpp"
+#include "to_string.hpp"
 
 #include <algorithm>
 #include <cstring>
@@ -433,7 +434,7 @@ namespace isobus
 						partner->address = CANIdentifier(rxFrame.identifier).get_source_address();
 						activeControlFunctions.push_back(partner);
 						foundControlFunction = partner;
-						CANStackLogger::CAN_stack_log("[NM]: A Partner Has Claimed " + std::to_string(static_cast<int>(CANIdentifier(rxFrame.identifier).get_source_address())));
+						CANStackLogger::CAN_stack_log("[NM]: A Partner Has Claimed " + isobus::to_string(static_cast<int>(CANIdentifier(rxFrame.identifier).get_source_address())));
 						break;
 					}
 				}
@@ -442,7 +443,7 @@ namespace isobus
 				{
 					// New device, need to start keeping track of it
 					activeControlFunctions.push_back(new ControlFunction(NAME(claimedNAME), CANIdentifier(rxFrame.identifier).get_source_address(), rxFrame.channel));
-					CANStackLogger::CAN_stack_log("[NM]: New Control function " + std::to_string(static_cast<int>(CANIdentifier(rxFrame.identifier).get_source_address())));
+					CANStackLogger::CAN_stack_log("[NM]: New Control function " + isobus::to_string(static_cast<int>(CANIdentifier(rxFrame.identifier).get_source_address())));
 				}
 			}
 

--- a/isobus/src/can_parameter_group_number_request_protocol.cpp
+++ b/isobus/src/can_parameter_group_number_request_protocol.cpp
@@ -11,6 +11,7 @@
 #include "can_parameter_group_number_request_protocol.hpp"
 #include "can_general_parameter_group_numbers.hpp"
 #include "can_warning_logger.hpp"
+#include "to_string.hpp"
 
 #include <algorithm>
 
@@ -303,7 +304,7 @@ namespace isobus
 							                     requestedPGN,
 							                     reinterpret_cast<InternalControlFunction *>(message->get_destination_control_function()),
 							                     message->get_source_control_function());
-							CANStackLogger::CAN_stack_log("[PR]: NACK-ing PGN request for PGN " + std::to_string(requestedPGN) + " because no callback could handle it.");
+							CANStackLogger::CAN_stack_log("[PR]: NACK-ing PGN request for PGN " + isobus::to_string(requestedPGN) + " because no callback could handle it.");
 						}
 					}
 					else

--- a/isobus/src/can_transport_protocol.cpp
+++ b/isobus/src/can_transport_protocol.cpp
@@ -14,6 +14,7 @@
 #include "can_network_configuration.hpp"
 #include "can_warning_logger.hpp"
 #include "system_timing.hpp"
+#include "to_string.hpp"
 
 #include <algorithm>
 
@@ -101,7 +102,7 @@ namespace isobus
 									newSession->state = StateMachineState::RxDataSession;
 									newSession->timestamp_ms = SystemTiming::get_timestamp_ms();
 									activeSessions.push_back(newSession);
-									CANStackLogger::CAN_stack_log("[TP]: New BAM Session. Source: " + std::to_string(static_cast<int>(newSession->sessionMessage.get_source_control_function()->get_address())));
+									CANStackLogger::CAN_stack_log("[TP]: New BAM Session. Source: " + isobus::to_string(static_cast<int>(newSession->sessionMessage.get_source_control_function()->get_address())));
 								}
 								else
 								{

--- a/isobus/src/isobus_virtual_terminal_client.cpp
+++ b/isobus/src/isobus_virtual_terminal_client.cpp
@@ -12,6 +12,7 @@
 #include "can_network_manager.hpp"
 #include "can_warning_logger.hpp"
 #include "system_timing.hpp"
+#include "to_string.hpp"
 
 #include <algorithm>
 #include <cstring>
@@ -2306,11 +2307,11 @@ namespace isobus
 									parentVT->set_state(StateMachineState::Failed);
 									CANStackLogger::CAN_stack_log("[VT]: Error in end of object pool message." +
 									                              std::string("Faulty Object ") +
-									                              std::to_string(static_cast<int>(objectIDOfFaultyObject)) +
+									                              isobus::to_string(static_cast<int>(objectIDOfFaultyObject)) +
 									                              std::string(" Faulty Object Parent ") +
-									                              std::to_string(static_cast<int>(parentObjectIDOfFaultyObject)) +
+									                              isobus::to_string(static_cast<int>(parentObjectIDOfFaultyObject)) +
 									                              std::string(" Pool error bitmask value ") +
-									                              std::to_string(static_cast<int>(objectPoolErrorBitmask)));
+									                              isobus::to_string(static_cast<int>(objectPoolErrorBitmask)));
 									if (vtRanOutOfMemory)
 									{
 										CANStackLogger::CAN_stack_log("[VT]: Ran out of memory");

--- a/utility/CMakeLists.txt
+++ b/utility/CMakeLists.txt
@@ -22,6 +22,7 @@ set(SYSTEM_TIMING_INCLUDE
   "system_timing.hpp"
   "processing_flags.hpp"
   "iop_file_interface.hpp"
+  "to_string.hpp"
 )
 
 # Prepend the include directory path to all the include files

--- a/utility/include/to_string.hpp
+++ b/utility/include/to_string.hpp
@@ -1,0 +1,33 @@
+//================================================================================================
+/// @file to_string.hpp
+///
+/// @brief A compatibility template to replace `std::to_string`
+/// @details Some compilers don't support `std::to_string` so this file is meant to abstract it
+/// away with a workaround if it's not supported. This solution was inspired by Catch2's
+/// implementation.
+/// @author Adrian Del Grosso
+///
+/// @copyright 2022 Adrian Del Grosso
+//================================================================================================
+#ifndef TO_STRING_HPP
+#define TO_STRING_HPP
+
+#include <sstream>
+#include <string>
+
+namespace isobus
+{
+	template<typename T>
+	/// @brief A replacement for std::to_string
+	/// @tparam T The data type
+	/// @param t The thing to convert to string
+	/// @returns the string form of `t`
+	std::string to_string(T const &t)
+	{
+		std::ostringstream oss;
+		oss << t;
+		return oss.str();
+	}
+} // namespace isobus_utils
+
+#endif // TO_STRING_HPP


### PR DESCRIPTION
Changes logging calls that used `std::to_string` to use a workaround implementation.
This is to support tool-chains that do not implement `std::to_string`.
Closes #52 

Compiles with the esp32 compiler using Arduino IDE now:
```
Sketch uses 463952 bytes (35%) of program storage space. Maximum is 1310720 bytes.
Global variables use 23252 bytes (7%) of dynamic memory, leaving 304428 bytes for local variables. Maximum is 327680 bytes.
```

