### PR TITLE
[#61]: Help prevent TP and ETP from being optimized out when using static libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,10 +123,12 @@ find_package(Threads)
 
 add_subdirectory(<path to this submodule>)
 
-target_link_libraries(<your executable name> isobus::Isobus isobus::HardwareIntegration isobus::SocketCANInterface)
+target_link_libraries(<your executable name> PRIVATE -Wl,--whole-archive isobus::Isobus -Wl,--no-whole-archive isobus::HardwareIntegration isobus::SocketCANInterface)
 ```
 
 A full example CMakeLists.txt file can be found on the tutorial website.
+
+`-Wl,--whole-archive` is required to ensure that some static singleton objects, such as the `TransportProtocolManager` don't get optimized out of your executable by your linker.
 
 ## Documentation
 

--- a/examples/diagnostic_protocol/CMakeLists.txt
+++ b/examples/diagnostic_protocol/CMakeLists.txt
@@ -7,8 +7,11 @@ find_package(Threads REQUIRED)
 
 add_executable(DiagnosticProtocolExampleTarget main.cpp)
 
-target_link_libraries(DiagnosticProtocolExampleTarget PRIVATE
+target_link_libraries(DiagnosticProtocolExampleTarget PRIVATE 
 	-Wl,--whole-archive
-	isobus::Isobus 
+	isobus::Isobus
 	-Wl,--no-whole-archive
-	isobus::HardwareIntegration Threads::Threads isobus::SystemTiming)
+	isobus::HardwareIntegration
+	Threads::Threads
+	isobus::SystemTiming
+)

--- a/examples/pgn_requests/CMakeLists.txt
+++ b/examples/pgn_requests/CMakeLists.txt
@@ -7,4 +7,11 @@ find_package(isobus CONFIG)  # Normally, you set REQUIRED, however if building f
 find_package(Threads REQUIRED)
 
 add_executable(PGNRequestExampleTarget main.cpp)
-target_link_libraries(PGNRequestExampleTarget isobus::Isobus isobus::HardwareIntegration Threads::Threads isobus::SystemTiming)
+target_link_libraries(PGNRequestExampleTarget PRIVATE
+	-Wl,--whole-archive
+	isobus::Isobus
+	-Wl,--no-whole-archive
+	isobus::HardwareIntegration
+	Threads::Threads
+	isobus::SystemTiming
+)

--- a/examples/transport_layer/CMakeLists.txt
+++ b/examples/transport_layer/CMakeLists.txt
@@ -7,4 +7,11 @@ find_package(isobus CONFIG)  # Normally, you set REQUIRED, however if building f
 find_package(Threads REQUIRED)
 
 add_executable(TransportLayerExampleTarget main.cpp)
-target_link_libraries(TransportLayerExampleTarget isobus::Isobus isobus::HardwareIntegration Threads::Threads isobus::SystemTiming)
+target_link_libraries(TransportLayerExampleTarget PRIVATE 
+	-Wl,--whole-archive
+	isobus::Isobus
+	-Wl,--no-whole-archive
+	isobus::HardwareIntegration
+	Threads::Threads
+	isobus::SystemTiming
+)

--- a/examples/vt_version_3_object_pool/CMakeLists.txt
+++ b/examples/vt_version_3_object_pool/CMakeLists.txt
@@ -7,7 +7,14 @@ find_package(isobus CONFIG)  # Normally, you set REQUIRED, however if building f
 find_package(Threads REQUIRED)
 
 add_executable(VT3ExampleTarget main.cpp objectPoolObjects.h)
-target_link_libraries(VT3ExampleTarget PRIVATE isobus::Isobus isobus::HardwareIntegration Threads::Threads isobus::SystemTiming)
+target_link_libraries(VT3ExampleTarget PRIVATE 
+    -Wl,--whole-archive
+    isobus::Isobus
+    -Wl,--no-whole-archive
+    isobus::HardwareIntegration
+    Threads::Threads
+    isobus::SystemTiming
+)
 
 add_custom_command(
         TARGET VT3ExampleTarget POST_BUILD

--- a/sphinx/source/FAQ.rst
+++ b/sphinx/source/FAQ.rst
@@ -37,7 +37,7 @@ Make sure your CMake links these to your executable:
    set(THREADS_PREFER_PTHREAD_FLAG ON)
    find_package(Threads)
 
-   target_link_libraries(<your executable name> Isobus HardwareIntegration ${CMAKE_THREAD_LIBS_INIT})
+   target_link_libraries(<your executable name> PRIVATE -Wl,--whole-archive isobus::Isobus -Wl,--no-whole-archive isobus::HardwareIntegration ${CMAKE_THREAD_LIBS_INIT})
 
 I have some other issue!
 -------------------------

--- a/sphinx/source/Installation.rst
+++ b/sphinx/source/Installation.rst
@@ -60,7 +60,9 @@ If your project is already using CMake to build your project, or this is a new p
 
    ...
 
-   target_link_libraries(<your target> Isobus HardwareIntegration ${CMAKE_THREAD_LIBS_INIT})
+   target_link_libraries(<your target> PRIVATE -Wl,--whole-archive isobus::Isobus -Wl,--no-whole-archive isobus::HardwareIntegration ${CMAKE_THREAD_LIBS_INIT})
+
+:code:`-Wl,--whole-archive` is required to ensure that some static singleton objects, such as the :code:`TransportProtocolManager` don't get optimized out of your executable by your linker.
 
 Using CMake has a lot of advantages, such as if the library is updated with additional files, or the file names change, it will not break your compilation.
    

--- a/sphinx/source/Tutorials/The ISOBUS Hello World.rst
+++ b/sphinx/source/Tutorials/The ISOBUS Hello World.rst
@@ -481,7 +481,7 @@ Add the following to a new file called CMakeLists.txt:
    
    add_executable(isobus_hello_world main.cpp)
    
-   target_link_libraries(isobus_hello_world Isobus HardwareIntegration ${CMAKE_THREAD_LIBS_INIT})
+   target_link_libraries(isobus_hello_world PRIVATE -Wl,--whole-archive isobus::Isobus -Wl,--no-whole-archive isobus::HardwareIntegration ${CMAKE_THREAD_LIBS_INIT})
 
 Save and close the file.
 


### PR DESCRIPTION
Also added `PRIVATE` to all example `target_link_libraries` calls

Basically here's what's happening... in all the examples when using static libraries the `TransportProtocolManager` and `ExtendedTransportProtocolManager` were not getting linked in from the library into the executable. This is because linkers do not need to do that if they think that translation unit is not referenced anywhere in the final executable. This was causing all transport layer functions to fail, as the transport layer relies on those static objects being instantiated. Using shared libraries fixes this, but because static is the default now, I've added some logic to CMake to force the whole isobus::Isobus archive to be linked.

@RFRIEDM-Trimble I would be interested in your opinion on this if you have one, as it feels a bit strange. This fix seems to work but I am not sure if there's a better way.