### PR TITLE
[DP] Add support for J1939 Diagnostic Message 13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,8 +81,8 @@ if(NOT TARGET GTest::gtest_main)
   add_library(GTest::gtest_main ALIAS GTest::Main)
 endif()
 
-add_executable(unit_tests test/address_claim_test.cpp test/test_CAN_glue.cpp test/identifier_tests.cpp)
-target_link_libraries(unit_tests PRIVATE GTest::gtest_main ${PROJECT_NAME}::Isobus ${PROJECT_NAME}::HardwareIntegration)
+add_executable(unit_tests test/address_claim_test.cpp test/test_CAN_glue.cpp test/identifier_tests.cpp test/dm_13_tests.cpp)
+target_link_libraries(unit_tests PRIVATE GTest::gtest_main ${PROJECT_NAME}::Isobus ${PROJECT_NAME}::HardwareIntegration ${PROJECT_NAME}::SystemTiming)
 
 include(GoogleTest)
 gtest_discover_tests(unit_tests name_tests identifier_tests)

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This is a work in progress.
     - Diagnostic Message 2: Complete :white_check_mark:
     - Diagnostic Message 3: Complete :white_check_mark:
     - Diagnostic Message 11: Complete :white_check_mark:
+    - Diagnostic Message 13: Complete :white_check_mark:
     - Diagnostic Message 22: Complete :white_check_mark:
     - Product Identification: Complete :white_check_mark:
     - Diagnostic Protocol message Complete :white_check_mark:
@@ -37,8 +38,8 @@ This is a work in progress.
 - ISO11783 File Server (Client-side): In progress :hourglass:
 ### Planned Features (in no particular order):
 - ISO11783 Task Controller (currently planned to be client only)
+- ISO11783 File Server (Server-side)
 - Common ISO11783-5 Messages (guidance command, machine selected speed, etc.)
-- J1939 DM13 (Stop/Start Broadcast)
 - NMEA2000 Fast Packet Protocol
 - NMEA2000 ISOBUS messages (GNSS)
 - Meta: Windows OS support via some common CAN driver layers (PEAK P-CAN, for example)

--- a/examples/diagnostic_protocol/CMakeLists.txt
+++ b/examples/diagnostic_protocol/CMakeLists.txt
@@ -7,4 +7,8 @@ find_package(Threads REQUIRED)
 
 add_executable(DiagnosticProtocolExampleTarget main.cpp)
 
-target_link_libraries(DiagnosticProtocolExampleTarget isobus::Isobus isobus::HardwareIntegration Threads::Threads isobus::SystemTiming)
+target_link_libraries(DiagnosticProtocolExampleTarget PRIVATE
+	-Wl,--whole-archive
+	isobus::Isobus 
+	-Wl,--no-whole-archive
+	isobus::HardwareIntegration Threads::Threads isobus::SystemTiming)

--- a/isobus/include/isobus/isobus/can_general_parameter_group_numbers.hpp
+++ b/isobus/include/isobus/isobus/can_general_parameter_group_numbers.hpp
@@ -20,6 +20,7 @@ namespace isobus
 		ExtendedTransportProtocolDataTransfer = 0xC700,
 		ExtendedTransportProtocolConnectionManagement = 0xC800,
 		RequestForRepetitionRate = 0xCC00,
+		DiagnosticMessage13 = 0xDF00,
 		VirtualTerminalToECU = 0xE600,
 		ECUtoVirtualTerminal = 0xE700,
 		Acknowledge = 0xE800,

--- a/test/dm_13_tests.cpp
+++ b/test/dm_13_tests.cpp
@@ -1,0 +1,34 @@
+#include <gtest/gtest.h>
+
+#include "isobus/isobus/can_managed_message.hpp"
+#include "isobus/isobus/isobus_diagnostic_protocol.hpp"
+
+using namespace isobus;
+
+TEST(DM13_TESTS, TestNetworkParsing)
+{
+	std::uint32_t testNetworkStates = 0;
+	CANIdentifier testID(CANIdentifier::Type::Extended,
+	                     0xDF00,
+	                     CANIdentifier::CANPriority::PriorityDefault6,
+	                     0xFF,
+	                     0x80);
+	CANLibManagedMessage testDM13Message(0);
+	testDM13Message.set_identifier(testID);
+	testDM13Message.set_data_size(8);
+	EXPECT_EQ(true, DiagnosticProtocol::parse_j1939_network_states(&testDM13Message, testNetworkStates));
+}
+
+TEST(DM13_TESTS, TestInvalidDM13Rejection)
+{
+	std::uint32_t testNetworkStates = 0;
+	CANIdentifier testID(CANIdentifier::Type::Extended,
+	                     0xDF00,
+	                     CANIdentifier::CANPriority::PriorityDefault6,
+	                     0xFF,
+	                     0x80);
+	CANLibManagedMessage testDM13Message(0);
+	testDM13Message.set_identifier(testID);
+	testDM13Message.set_data_size(4);
+	EXPECT_EQ(false, DiagnosticProtocol::parse_j1939_network_states(&testDM13Message, testNetworkStates));
+}


### PR DESCRIPTION
*Added J1939 DM13

DM13 stops and starts broadcast messages for a specific channel, reducing the bus load under some conditions.
As part of the Diagnostic Protocol, it will automatically stop the DM1 message if the DM13 for your network is received.
You can use this protocol's broadcast state in your application to further reduce your bus load if you desire.
You can also suspend your own broadcasts by sending the DM13 to the network if you want.