### PR TITLE
[#66] Add CAN interface down warnings

### DIFF
--- a/examples/diagnostic_protocol/main.cpp
+++ b/examples/diagnostic_protocol/main.cpp
@@ -5,6 +5,7 @@
 #include "isobus/isobus/isobus_diagnostic_protocol.hpp"
 
 #include <csignal>
+#include <iostream>
 #include <iterator>
 #include <memory>
 
@@ -34,7 +35,11 @@ void setup()
 {
 	CANHardwareInterface::set_number_of_can_channels(1);
 	CANHardwareInterface::assign_can_channel_frame_handler(0, &canDriver);
-	CANHardwareInterface::start();
+
+	if ((!CANHardwareInterface::start()) || (!canDriver.get_is_valid()))
+	{
+		std::cout << "Failed to connect to the socket. The interface might be down." << std::endl;
+	}
 
 	CANHardwareInterface::add_can_lib_update_callback(update_CAN_network, nullptr);
 	CANHardwareInterface::add_raw_can_message_rx_callback(raw_can_glue, nullptr);

--- a/examples/pgn_requests/main.cpp
+++ b/examples/pgn_requests/main.cpp
@@ -99,7 +99,11 @@ void setup()
 {
 	CANHardwareInterface::set_number_of_can_channels(1);
 	CANHardwareInterface::assign_can_channel_frame_handler(0, &canDriver);
-	CANHardwareInterface::start();
+
+	if ((!CANHardwareInterface::start()) || (!canDriver.get_is_valid()))
+	{
+		std::cout << "Failed to connect to the socket. The interface might be down." << std::endl;
+	}
 
 	CANHardwareInterface::add_can_lib_update_callback(update_CAN_network, nullptr);
 	CANHardwareInterface::add_raw_can_message_rx_callback(raw_can_glue, nullptr);

--- a/examples/transport_layer/main.cpp
+++ b/examples/transport_layer/main.cpp
@@ -63,7 +63,11 @@ void setup()
 {
 	CANHardwareInterface::set_number_of_can_channels(1);
 	CANHardwareInterface::assign_can_channel_frame_handler(0, &canDriver);
-	CANHardwareInterface::start();
+
+	if ((!CANHardwareInterface::start()) || (!canDriver.get_is_valid()))
+	{
+		std::cout << "Failed to connect to the socket. The interface might be down." << std::endl;
+	}
 
 	CANHardwareInterface::add_can_lib_update_callback(update_CAN_network, nullptr);
 	CANHardwareInterface::add_raw_can_message_rx_callback(raw_can_glue, nullptr);

--- a/examples/vt_version_3_object_pool/main.cpp
+++ b/examples/vt_version_3_object_pool/main.cpp
@@ -90,7 +90,11 @@ void setup()
 {
 	CANHardwareInterface::set_number_of_can_channels(1);
 	CANHardwareInterface::assign_can_channel_frame_handler(0, &canDriver);
-	CANHardwareInterface::start();
+
+	if ((!CANHardwareInterface::start()) || (!canDriver.get_is_valid()))
+	{
+		std::cout << "Failed to connect to the socket. The interface might be down." << std::endl;
+	}
 
 	CANHardwareInterface::add_can_lib_update_callback(update_CAN_network, nullptr);
 	CANHardwareInterface::add_raw_can_message_rx_callback(raw_can_glue, nullptr);

--- a/sphinx/source/Tutorials/Adding a Destination.rst
+++ b/sphinx/source/Tutorials/Adding a Destination.rst
@@ -59,7 +59,7 @@ Above, we've just instantiated a partner *on CAN channel 0* using the filter we 
 
 Whenever a device comes onto the bus matching that filter, the CAN stack will associate it with our `PartneredControlFunction <https://delgrossoengineering.com/isobus-docs/classisobus_1_1PartneredControlFunction.html>`_.
 
-Think of this as the "destination" for your messages. When you send a destination specific message, you must provide a `PartneredControlFunction` to the `send_can_message` function.
+Think of this as the "destination" for your messages. When you send a destination specific message, you must provide a :code:`PartneredControlFunction` to the :code:`send_can_message` function.
 
 Now let's send the message!
 
@@ -74,9 +74,9 @@ In this step, we will construct and send a proprietary A message to our partner.
 
    isobus::CANNetworkManager::CANNetwork.send_can_message(0xEF00, messageData.data(), isobus::CAN_DATA_LENGTH, myECU.get(), myPartner.get());
 
-As you can see, the call to the network manager to send the message is nearly identical to the one to send it to the broadcast address, but with the addition of our partner `myPartner`.
+As you can see, the call to the network manager to send the message is nearly identical to the one to send it to the broadcast address, but with the addition of our partner :code:`myPartner`.
 
-It is highly recommended that you review all possible parameters for `send_can_message` so you know what options are available.
+It is highly recommended that you review all possible parameters for :code:`send_can_message` so you know what options are available.
 
 Check out the documentation for it `here <https://delgrossoengineering.com/isobus-docs/classisobus_1_1CANNetworkManager.html>`_.
 
@@ -132,7 +132,11 @@ The final program for this tutorial (including the code from the previous Hello 
     // Set up the hardware layer to use "can0"
     CANHardwareInterface::set_number_of_can_channels(1);
     CANHardwareInterface::assign_can_channel_frame_handler(0, &canDriver);
-    CANHardwareInterface::start();
+    
+    if ((!CANHardwareInterface::start()) || (!canDriver.get_is_valid()))
+    {
+	    std::cout << "Failed to connect to the socket. The interface might be down." << std::endl;
+    }
 
     // Handle control+c
     std::signal(SIGINT, signal_handler);
@@ -175,6 +179,6 @@ The final program for this tutorial (including the code from the previous Hello 
     return 0;
    }
   
-Like before, you can compile it with `cmake --build build` and run it!
+Like before, you can compile it with :code:`cmake --build build` and run it!
 
 In our next tutorial, we'll cover receiving messages.

--- a/sphinx/source/Tutorials/Receiving Messages.rst
+++ b/sphinx/source/Tutorials/Receiving Messages.rst
@@ -44,7 +44,7 @@ Now, we just need to tell the CAN stack to call that callback when an appropriat
 
    isobus::CANNetworkManager::CANNetwork.add_global_parameter_group_number_callback(0xEF00, propa_callback, nullptr);
 
-So in the above code, we're telling the stack that for any broadcasts with PGN 0xEF00 to call that function. The `nullptr` variable is a generic context variable. Whatever you pass in for that variable will be passed into broadcast_propa_callback when it is called later. 
+So in the above code, we're telling the stack that for any broadcasts with PGN 0xEF00 to call that function. The :code:`nullptr` variable is a generic context variable. Whatever you pass in for that variable will be passed into broadcast_propa_callback when it is called later. 
 This can be useful for figuring out what object wanted the callback. For example, if we were registering this callback for a particular class, that class could pass in `this` as that argument to have its own pointer passed back to it in the callback.
 
 It's OK if you don't understand that last variable's usage for now. In our example, we're just ignoring it.
@@ -116,7 +116,11 @@ So, our updated tutorial program now should look like this:
     // Set up the hardware layer to use "can0"
     CANHardwareInterface::set_number_of_can_channels(1);
     CANHardwareInterface::assign_can_channel_frame_handler(0, &canDriver);
-    CANHardwareInterface::start();
+    
+    if ((!CANHardwareInterface::start()) || (!canDriver.get_is_valid()))
+    {
+	    std::cout << "Failed to connect to the socket. The interface might be down." << std::endl;
+    }
 
     // Handle control+c
     std::signal(SIGINT, signal_handler);

--- a/sphinx/source/Tutorials/Virtual Terminal Basics.rst
+++ b/sphinx/source/Tutorials/Virtual Terminal Basics.rst
@@ -18,9 +18,9 @@ It is assumed you have completed all the other tutorials, as this tutorial cover
 The Virtual Terminal Client
 ----------------------------
 
-The first step in communicating with a VT is creating an object called `VirtualTerminalClient`. 
+The first step in communicating with a VT is creating an object called :code:`VirtualTerminalClient`. 
 This object will act as your interface for all VT communication. 
-The client requires two things to instantiate, a `PartneredControlFunction` and a `InternalControlFunction`. 
+The client requires two things to instantiate, a :code:`PartneredControlFunction` and a :code:`InternalControlFunction`. 
 This is so that it can send messages on your behalf needed to maintain the connection and simplify the API over sending raw CAN messages to the VT.
 
 Let's start our program similarly to the other tutorials, complete with the requisite control functions.
@@ -66,7 +66,11 @@ Let's start our program similarly to the other tutorials, complete with the requ
 	{
 		CANHardwareInterface::set_number_of_can_channels(1);
 		CANHardwareInterface::assign_can_channel_frame_handler(0, &canDriver);
-		CANHardwareInterface::start();
+
+		if ((!CANHardwareInterface::start()) || (!canDriver.get_is_valid()))
+		{
+			std::cout << "Failed to connect to the socket. The interface might be down." << std::endl;
+		}
 
 		CANHardwareInterface::add_can_lib_update_callback(update_CAN_network, nullptr);
 		CANHardwareInterface::add_raw_can_message_rx_callback(raw_can_glue, nullptr);
@@ -387,7 +391,11 @@ Here's the final code for this example:
 	{
 		CANHardwareInterface::set_number_of_can_channels(1);
 		CANHardwareInterface::assign_can_channel_frame_handler(0, &canDriver);
-		CANHardwareInterface::start();
+
+		if ((!CANHardwareInterface::start()) || (!canDriver.get_is_valid()))
+		{
+			std::cout << "Failed to connect to the socket. The interface might be down." << std::endl;
+		}
 
 		CANHardwareInterface::add_can_lib_update_callback(update_CAN_network, nullptr);
 		CANHardwareInterface::add_raw_can_message_rx_callback(raw_can_glue, nullptr);


### PR DESCRIPTION
Now the examples and tutorials will warn you if the underlying CAN interface is down.
Closes #66 