### PR TITLE
[Core]: Fix SocketCAN interface unwanted behaviour

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,0 +1,9 @@
+version = 1
+
+[[analyzers]]
+name = "shell"
+enabled = true
+
+[[analyzers]]
+name = "cxx"
+enabled = true

--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,9 +1,0 @@
-version = 1
-
-[[analyzers]]
-name = "shell"
-enabled = true
-
-[[analyzers]]
-name = "cxx"
-enabled = true

--- a/hardware_integration/src/can_hardware_interface.cpp
+++ b/hardware_integration/src/can_hardware_interface.cpp
@@ -476,10 +476,6 @@ void CANHardwareInterface::receive_message_thread_function(uint8_t aCANChannel)
 					threadConditionVariable.notify_all();
 				}
 			}
-			else
-			{
-				pCANHardware->frameHandler->open();
-			}
 		}
 	}
 }

--- a/hardware_integration/src/socket_can_interface.cpp
+++ b/hardware_integration/src/socket_can_interface.cpp
@@ -7,6 +7,7 @@
 /// @copyright 2022 Adrian Del Grosso
 //================================================================================================
 #include "isobus/hardware_integration/socket_can_interface.hpp"
+#include <isobus/isobus/can_warning_logger.hpp>
 #include "isobus/utility/system_timing.hpp"
 
 #include <linux/can.h>
@@ -21,7 +22,6 @@
 #include <cstdint>
 #include <cstring>
 #include <limits>
-#include <isobus/isobus/can_warning_logger.hpp>
 
 SocketCANInterface::SocketCANInterface(const std::string deviceName) :
   pCANDevice(new sockaddr_can),


### PR DESCRIPTION
SocketCAN interface now closes correctly when interface is down. It also logs a warning for this to CANStackLogger. And resolved an issue where the hardware interface keeps reopening the CANHardwarePlugin.