### PR TITLE
[VT]: Disconnection Handling Improvements

### DIFF
--- a/isobus/src/can_extended_transport_protocol.cpp
+++ b/isobus/src/can_extended_transport_protocol.cpp
@@ -638,6 +638,7 @@ namespace isobus
 						{
 							CANStackLogger::CAN_stack_log("[ETP]: Aborting session, T2-3 timeout reached while in RTS state");
 							abort_session(session, ConnectionAbortReason::Timeout);
+							process_session_complete_callback(session, false);
 							close_session(session);
 						}
 					}
@@ -652,6 +653,7 @@ namespace isobus
 					{
 						CANStackLogger::CAN_stack_log("[ETP]: Aborting session, T2-3 timeout reached while waiting for CTS");
 						abort_session(session, ConnectionAbortReason::Timeout);
+						process_session_complete_callback(session, false);
 						close_session(session);
 					}
 				}
@@ -708,6 +710,7 @@ namespace isobus
 									{
 										CANStackLogger::CAN_stack_log("[ETP]: Aborting session, unable to transfer chunk of data (numberBytesLeft=" + to_string(numberBytesLeft) + ")");
 										abort_session(session, ConnectionAbortReason::AnyOtherReason);
+										process_session_complete_callback(session, false);
 										close_session(session);
 										break;
 									}


### PR DESCRIPTION
## What's New
* Now the VT state machine will restart the connection process for disconnects and timeouts that were previously not handled.
* Now we will properly handle a VT server that NACKs our ECU to VT messages by reconnecting. This is somewhat likely to happen while debugging, since status messages stop while you are at a breakpoint, and when we resume the state machine is out of sync with the server, so it may NACK us.
* Added cleanup of VT PGN callback registrations.
* Some VT logging improvements
* Fixed a couple bugs in ETP, where Tx complete callback might not get called for some timeouts.
Closes #64 