### PR TITLE
Misc. Style Fixes

### DIFF
--- a/isobus/src/can_network_manager.cpp
+++ b/isobus/src/can_network_manager.cpp
@@ -496,7 +496,7 @@ namespace isobus
 			}
 
 			txFrame.channel = portIndex;
-			memcpy((void *)txFrame.data, data, size);
+			memcpy(reinterpret_cast<void *>(txFrame.data), data, size);
 			txFrame.dataLength = size;
 			txFrame.isExtendedFrame = true;
 			txFrame.identifier = identifier & 0x1FFFFFFF;

--- a/isobus/src/isobus_diagnostic_protocol.cpp
+++ b/isobus/src/isobus_diagnostic_protocol.cpp
@@ -753,10 +753,10 @@ namespace isobus
 		if (nullptr != myControlFunction)
 		{
 			std::uint16_t payloadSize = (activeDTCList.size() * DM_PAYLOAD_BYTES_PER_DTC) + 2; // 2 Bytes (0 and 1) are reserved
-			std::vector<std::uint8_t> buffer;
 
 			if (payloadSize <= MAX_PAYLOAD_SIZE_BYTES)
 			{
+				std::vector<std::uint8_t> buffer;
 				buffer.resize(payloadSize);
 
 				if (get_j1939_mode())
@@ -841,10 +841,10 @@ namespace isobus
 		if (nullptr != myControlFunction)
 		{
 			std::uint16_t payloadSize = (inactiveDTCList.size() * DM_PAYLOAD_BYTES_PER_DTC) + 2; // 2 Bytes (0 and 1) are reserved or used for lamp + flash
-			std::vector<std::uint8_t> buffer;
 
 			if (payloadSize <= MAX_PAYLOAD_SIZE_BYTES)
 			{
+				std::vector<std::uint8_t> buffer;
 				buffer.resize(payloadSize);
 
 				if (get_j1939_mode())

--- a/isobus/src/isobus_virtual_terminal_client.cpp
+++ b/isobus/src/isobus_virtual_terminal_client.cpp
@@ -2424,7 +2424,7 @@ namespace isobus
 		    (0 != numberOfBytesNeeded))
 		{
 			VirtualTerminalClient *parentVTClient = reinterpret_cast<VirtualTerminalClient *>(parentPointer);
-			std::uint32_t poolIndex;
+			std::uint32_t poolIndex = std::numeric_limits<std::uint32_t>::max();
 
 			// Need to figure out which pool we're currently uploading
 			for (std::uint32_t i = 0; i < parentVTClient->objectPools.size(); i++)
@@ -2436,7 +2436,9 @@ namespace isobus
 				}
 			}
 
-			if ((bytesOffset + numberOfBytesNeeded) <= parentVTClient->objectPools[poolIndex].objectPoolSize + 1)
+			// If pool index is FFs, something is wrong with the state machine state, return false.
+			if ((std::numeric_limits<std::uint32_t>::max() != poolIndex) &&
+			    (bytesOffset + numberOfBytesNeeded) <= parentVTClient->objectPools[poolIndex].objectPoolSize + 1)
 			{
 				// We've got more data to transfer
 				retVal = true;


### PR DESCRIPTION
Just some small cleanup items:

* Fixed a C style cast
* Reduced the scope of a vector in DM1 and DM2 transmits
* Fixed a situation where we might use an uninitialized variable in VT pool upload