### PR TITLE
[VT} Automatic object pool version load/store

### DIFF
--- a/examples/vt_version_3_object_pool/main.cpp
+++ b/examples/vt_version_3_object_pool/main.cpp
@@ -141,10 +141,13 @@ void setup()
 		std::cout << "Failed to load object pool from VT3TestPool.iop" << std::endl;
 	}
 
+	// Generate a unique version string for this object pool (this is optional, and is entirely application specific behavior)
+	std::string objectPoolHash = isobus::IOPFileInterface::hash_object_pool_to_version(testPool);
+
 	TestInternalECU = std::make_shared<isobus::InternalControlFunction>(TestDeviceNAME, 0x1C, 0);
 	TestPartnerVT = std::make_shared<isobus ::PartneredControlFunction>(0, vtNameFilters);
 	TestVirtualTerminalClient = std::make_shared<isobus::VirtualTerminalClient>(TestPartnerVT, TestInternalECU);
-	TestVirtualTerminalClient->set_object_pool(0, isobus::VirtualTerminalClient::VTVersion::Version3, testPool.data(), testPool.size());
+	TestVirtualTerminalClient->set_object_pool(0, isobus::VirtualTerminalClient::VTVersion::Version3, testPool.data(), testPool.size(), objectPoolHash);
 	TestVirtualTerminalClient->register_vt_button_event_callback(handleVTButton);
 	TestVirtualTerminalClient->register_vt_soft_key_event_callback(handleVTButton);
 	TestVirtualTerminalClient->initialize(true);

--- a/isobus/include/isobus/isobus/isobus_virtual_terminal_client.hpp
+++ b/isobus/include/isobus/isobus/isobus_virtual_terminal_client.hpp
@@ -185,6 +185,12 @@ namespace isobus
 			WaitForGetTextFontDataResponse, ///< Client is waiting for a response to the "get text font data" message
 			SendGetHardware, ///< Client is sending the "get hardware" message
 			WaitForGetHardwareResponse, ///< Client is waiting for a response to the "get hardware" message
+			SendGetVersions, ///< If a version label was specified, check to see if the VT has that version already
+			WaitForGetVersionsResponse, ///< Client is waiting for a response to the "get versions" message
+			SendStoreVersion, ///< Sending the store version command
+			WaitForStoreVersionResponse, ///< Client is waiting for a response to the store version command
+			SendLoadVersion, ///< Sending the load version command
+			WaitForLoadVersionResponse, ///< Client is waiting for the VT to respond to the "Load Version" command
 			UploadObjectPool, ///< Client is uploading the object pool
 			SendEndOfObjectPool, ///< Client is sending the end of object pool message
 			WaitForEndOfObjectPoolResponse, ///< Client is waiting for the end of object pool response message
@@ -996,14 +1002,14 @@ namespace isobus
 		/// @param[in] poolSupportedVTVersion The VT version of the object pool
 		/// @param[in] pool A pointer to the object pool. Must remain valid until client is connected!
 		/// @param[in] size The object pool size
-		void set_object_pool(std::uint8_t poolIndex, VTVersion poolSupportedVTVersion, const std::uint8_t *pool, std::uint32_t size);
+		void set_object_pool(std::uint8_t poolIndex, VTVersion poolSupportedVTVersion, const std::uint8_t *pool, std::uint32_t size, std::string version = "");
 
 		/// @brief Assigns an object pool to the client using a vector.
 		/// @details This is good for small pools or pools where you have all the data in memory.
 		/// @param[in] poolIndex The index of the pool you are assigning
 		/// @param[in] poolSupportedVTVersion The VT version of the object pool
 		/// @param[in] pool A pointer to the object pool. Must remain valid until client is connected!
-		void set_object_pool(std::uint8_t poolIndex, VTVersion poolSupportedVTVersion, const std::vector<std::uint8_t> *pool);
+		void set_object_pool(std::uint8_t poolIndex, VTVersion poolSupportedVTVersion, const std::vector<std::uint8_t> *pool, std::string version = "");
 
 		/// @brief Assigns an object pool to the client where the client will get data in chunks during upload.
 		/// @details This is probably better for huge pools if you are RAM constrained, or if your
@@ -1148,6 +1154,7 @@ namespace isobus
 			const std::uint8_t *objectPoolDataPointer; ///< A pointer to an object pool
 			const std::vector<std::uint8_t> *objectPoolVectorPointer; ///< A pointer to an object pool (vector format)
 			DataChunkCallback dataCallback; ///< A callback used to get data in chunks as an alternative to loading the whole pool at once
+			std::string versionLabel; ///< An optional version label that will be used to load/store the pool to the VT. 7 character max!
 			std::uint32_t objectPoolSize; ///< The size of the object pool
 			VTVersion version; ///< The version of the object pool. Must be the same for all pools!
 			bool useDataCallback; ///< Determines if the client will use callbacks to get the data in chunks.

--- a/isobus/include/isobus/isobus/isobus_virtual_terminal_client.hpp
+++ b/isobus/include/isobus/isobus/isobus_virtual_terminal_client.hpp
@@ -1002,6 +1002,7 @@ namespace isobus
 		/// @param[in] poolSupportedVTVersion The VT version of the object pool
 		/// @param[in] pool A pointer to the object pool. Must remain valid until client is connected!
 		/// @param[in] size The object pool size
+		/// @param[in] version An optional version string. The stack will automatically store/load your pool from the VT if this is provided.
 		void set_object_pool(std::uint8_t poolIndex, VTVersion poolSupportedVTVersion, const std::uint8_t *pool, std::uint32_t size, std::string version = "");
 
 		/// @brief Assigns an object pool to the client using a vector.
@@ -1009,6 +1010,7 @@ namespace isobus
 		/// @param[in] poolIndex The index of the pool you are assigning
 		/// @param[in] poolSupportedVTVersion The VT version of the object pool
 		/// @param[in] pool A pointer to the object pool. Must remain valid until client is connected!
+		/// @param[in] version An optional version string. The stack will automatically store/load your pool from the VT if this is provided.
 		void set_object_pool(std::uint8_t poolIndex, VTVersion poolSupportedVTVersion, const std::vector<std::uint8_t> *pool, std::string version = "");
 
 		/// @brief Assigns an object pool to the client where the client will get data in chunks during upload.

--- a/utility/include/isobus/utility/iop_file_interface.hpp
+++ b/utility/include/isobus/utility/iop_file_interface.hpp
@@ -19,7 +19,8 @@ namespace isobus
 	//================================================================================================
 	/// @class IOPFileInterface
 	///
-	/// @brief A class that manages reading IOP files
+	/// @brief A class that manages reading IOP files and provides a simple way to generate
+	/// unique versions.
 	/// @details IOP files are the standard format for ISOBUS object pools. This class will read
 	/// an IOP file, and return a vector that represents the object pool stored in the file.
 	//================================================================================================
@@ -30,6 +31,12 @@ namespace isobus
 		/// @param[in] filename A string filepath for the IOP file to read
 		/// @returns A vector with an object pool in it, or an empty vector if reading failed
 		static std::vector<std::uint8_t> read_iop_file(const std::string &filename);
+
+		/// @brief Reads an object pool and generates a string version by hashing it
+		/// @details Credit for the hash algorithm here goes to "see" on stack overflow.
+		/// @param[in] iopData The object pool to hash and generate a version for
+		/// @returns A 7 character string that is probably somewhat unique for this pool
+		static std::string hash_object_pool_to_version(std::vector<std::uint8_t> &iopData);
 	};
 }
 

--- a/utility/src/iop_file_interface.cpp
+++ b/utility/src/iop_file_interface.cpp
@@ -9,7 +9,9 @@
 #include "isobus/utility/iop_file_interface.hpp"
 
 #include <fstream>
+#include <iomanip>
 #include <iterator>
+#include <sstream>
 
 namespace isobus
 {
@@ -35,5 +37,21 @@ namespace isobus
 			retVal.insert(retVal.begin(), std::istream_iterator<std::uint8_t>(file), std::istream_iterator<std::uint8_t>());
 		}
 		return retVal;
+	}
+
+	std::string IOPFileInterface::hash_object_pool_to_version(std::vector<std::uint8_t> &iopData)
+	{
+		std::size_t seed = iopData.size();
+		std::stringstream stream;
+
+		for (auto x : iopData)
+		{
+			x = ((x >> 16) ^ x) * 0x45d9f3b;
+			x = ((x >> 16) ^ x) * 0x45d9f3b;
+			x = (x >> 16) ^ x;
+			seed ^= x + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+		}
+		stream << std::hex << seed;
+		return stream.str();
 	}
 }


### PR DESCRIPTION
## What's New

### Added optional automatic load/store handling for your VT object pools
* Now, if you specify a version label when setting your object pool to the VT client, it will try and store that pool on the VT server so that it can be easily re-activated later without the need to re-transmit the entire thing.
* Added a utility function for generating a somewhat random hash of an object pool to assist in making unique version labels. Use of this is totally optional, and you can label them however you want.
* Note, all object pools for your working set must share a label (this is part of the standard) so only the first object pool is looked at for a version label right now.
* I have plans to automatically delete out-of-date labels in the next VT feature PR.
* Updated VT example program to use a label
Closes #67 