### PR TITLE
[VT]: Fix an out of bounds write when storing object pool version

### DIFF
--- a/isobus/src/isobus_virtual_terminal_client.cpp
+++ b/isobus/src/isobus_virtual_terminal_client.cpp
@@ -1753,7 +1753,6 @@ namespace isobus
 						tempVersionBuffer[4] = ' ';
 						tempVersionBuffer[5] = ' ';
 						tempVersionBuffer[6] = ' ';
-						tempVersionBuffer[7] = ' ';
 
 						for (std::size_t i = 0; ((i < VERSION_LABEL_LENGTH) && (i < objectPools[0].versionLabel.size())); i++)
 						{


### PR DESCRIPTION
This may or may not have caused a crash or assert