### PR TITLE
[Core]: Changed protocol list to be non-static to remove the need for "whole-archive"

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,10 @@ find_package(Threads)
 
 add_subdirectory(<path to this submodule>)
 
-target_link_libraries(<your executable name> PRIVATE -Wl,--whole-archive isobus::Isobus -Wl,--no-whole-archive isobus::HardwareIntegration isobus::SocketCANInterface)
+target_link_libraries(<your executable name> PRIVATE isobus::Isobus isobus::HardwareIntegration isobus::SocketCANInterface)
 ```
 
 A full example CMakeLists.txt file can be found on the tutorial website.
-
-`-Wl,--whole-archive` is required to ensure that some static singleton objects, such as the `TransportProtocolManager` don't get optimized out of your executable by your linker.
 
 ## Documentation
 

--- a/examples/diagnostic_protocol/CMakeLists.txt
+++ b/examples/diagnostic_protocol/CMakeLists.txt
@@ -8,9 +8,7 @@ find_package(Threads REQUIRED)
 add_executable(DiagnosticProtocolExampleTarget main.cpp)
 
 target_link_libraries(DiagnosticProtocolExampleTarget PRIVATE 
-	-Wl,--whole-archive
 	isobus::Isobus
-	-Wl,--no-whole-archive
 	isobus::HardwareIntegration
 	Threads::Threads
 	isobus::SystemTiming

--- a/examples/nmea2000/CMakeLists.txt
+++ b/examples/nmea2000/CMakeLists.txt
@@ -8,9 +8,7 @@ find_package(Threads REQUIRED)
 add_executable(NMEA2KExampleTarget main.cpp)
 
 target_link_libraries(NMEA2KExampleTarget PRIVATE 
-	-Wl,--whole-archive
 	isobus::Isobus
-	-Wl,--no-whole-archive
 	isobus::HardwareIntegration
 	Threads::Threads
 	isobus::SystemTiming

--- a/examples/pgn_requests/CMakeLists.txt
+++ b/examples/pgn_requests/CMakeLists.txt
@@ -8,9 +8,7 @@ find_package(Threads REQUIRED)
 
 add_executable(PGNRequestExampleTarget main.cpp)
 target_link_libraries(PGNRequestExampleTarget PRIVATE
-	-Wl,--whole-archive
 	isobus::Isobus
-	-Wl,--no-whole-archive
 	isobus::HardwareIntegration
 	Threads::Threads
 	isobus::SystemTiming

--- a/examples/transport_layer/CMakeLists.txt
+++ b/examples/transport_layer/CMakeLists.txt
@@ -8,9 +8,7 @@ find_package(Threads REQUIRED)
 
 add_executable(TransportLayerExampleTarget main.cpp)
 target_link_libraries(TransportLayerExampleTarget PRIVATE 
-	-Wl,--whole-archive
 	isobus::Isobus
-	-Wl,--no-whole-archive
 	isobus::HardwareIntegration
 	Threads::Threads
 	isobus::SystemTiming

--- a/examples/vt_version_3_object_pool/CMakeLists.txt
+++ b/examples/vt_version_3_object_pool/CMakeLists.txt
@@ -8,9 +8,7 @@ find_package(Threads REQUIRED)
 
 add_executable(VT3ExampleTarget main.cpp objectPoolObjects.h)
 target_link_libraries(VT3ExampleTarget PRIVATE 
-    -Wl,--whole-archive
     isobus::Isobus
-    -Wl,--no-whole-archive
     isobus::HardwareIntegration
     Threads::Threads
     isobus::SystemTiming

--- a/isobus/include/isobus/isobus/can_extended_transport_protocol.hpp
+++ b/isobus/include/isobus/isobus/can_extended_transport_protocol.hpp
@@ -14,7 +14,6 @@
 #include "isobus/isobus/can_badge.hpp"
 #include "isobus/isobus/can_control_function.hpp"
 #include "isobus/isobus/can_managed_message.hpp"
-#include "isobus/isobus/can_network_manager.hpp"
 #include "isobus/isobus/can_protocol.hpp"
 
 namespace isobus
@@ -111,8 +110,6 @@ namespace isobus
 
 		/// @brief The destructor for the TransportProtocolManager
 		virtual ~ExtendedTransportProtocolManager();
-
-		static ExtendedTransportProtocolManager Protocol; ///< Static instance of the protocol manager
 
 		/// @brief The protocol's initializer function
 		void initialize(CANLibBadge<CANNetworkManager>) override;

--- a/isobus/include/isobus/isobus/can_network_manager.hpp
+++ b/isobus/include/isobus/isobus/can_network_manager.hpp
@@ -15,10 +15,12 @@
 #include "isobus/isobus/can_badge.hpp"
 #include "isobus/isobus/can_callbacks.hpp"
 #include "isobus/isobus/can_constants.hpp"
+#include "isobus/isobus/can_extended_transport_protocol.hpp"
 #include "isobus/isobus/can_frame.hpp"
 #include "isobus/isobus/can_identifier.hpp"
 #include "isobus/isobus/can_internal_control_function.hpp"
 #include "isobus/isobus/can_message.hpp"
+#include "isobus/isobus/can_transport_protocol.hpp"
 
 #include <array>
 #include <mutex>
@@ -109,6 +111,7 @@ namespace isobus
 		friend class DiagnosticProtocol; ///< Allows the diagnostic protocol to access the protected functions on the network manager
 		friend class ParameterGroupNumberRequestProtocol; ///< Allows the PGN request protocol to access the network manager protected functions
 		friend class FastPacketProtocol; ///< Allows the FP protocol to access the network manager protected functions
+		friend class CANLibProtocol;
 
 		/// @brief Adds a PGN callback for a protocol class
 		/// @param[in] parameterGroupNumber The PGN to register for
@@ -145,6 +148,8 @@ namespace isobus
 		/// @brief Processes completed protocol messages. Causes PGN callbacks to trigger.
 		/// @param[in] protocolMessage The completed protocol message
 		void protocol_message_callback(CANMessage *protocolMessage);
+
+		std::vector<CANLibProtocol *> protocolList; ///< A list of all created protocol classes
 
 	private:
 		/// @brief A structure to hold PGN callback data to provide parent back to the reigistrar of the callback
@@ -220,6 +225,9 @@ namespace isobus
 		/// @param[in] index The index of the callback to get
 		/// @returns A structure containing the global PGN callback data
 		ParameterGroupNumberCallbackData get_global_parameter_group_number_callback(std::uint32_t index) const;
+
+		ExtendedTransportProtocolManager extendedTransportProtocol; ///< Static instance of the protocol manager
+		TransportProtocolManager transportProtocol; ///< Static instance of the transport protocol manager
 
 		std::array<std::array<ControlFunction *, 256>, CAN_PORT_MAXIMUM> controlFunctionTable; ///< Table to maintain address to NAME mappings
 		std::vector<ControlFunction *> activeControlFunctions; ///< A list of active control function used to track connected devices

--- a/isobus/include/isobus/isobus/can_protocol.hpp
+++ b/isobus/include/isobus/isobus/can_protocol.hpp
@@ -84,8 +84,6 @@ namespace isobus
 		virtual void update(CANLibBadge<CANNetworkManager>) = 0;
 
 	protected:
-		static std::vector<CANLibProtocol *> protocolList; ///< A list of all created protocol classes
-
 		bool initialized; ///< Keeps track of if the protocol has been initialized by the network manager
 	};
 

--- a/isobus/include/isobus/isobus/can_transport_protocol.hpp
+++ b/isobus/include/isobus/isobus/can_transport_protocol.hpp
@@ -14,7 +14,6 @@
 #include "isobus/isobus/can_badge.hpp"
 #include "isobus/isobus/can_control_function.hpp"
 #include "isobus/isobus/can_managed_message.hpp"
-#include "isobus/isobus/can_network_manager.hpp"
 #include "isobus/isobus/can_protocol.hpp"
 
 namespace isobus
@@ -34,6 +33,7 @@ namespace isobus
 	//================================================================================================
 	class TransportProtocolManager : public CANLibProtocol
 	{
+	public:
 		/// @brief The states that a TP session could be in. Used for the internal state machine.
 		enum class StateMachineState
 		{
@@ -123,8 +123,6 @@ namespace isobus
 
 		/// @brief The destructor for the TransportProtocolManager
 		virtual ~TransportProtocolManager();
-
-		static TransportProtocolManager Protocol; ///< Static instance of the protocol manager
 
 		/// @brief The protocol's initializer function
 		void initialize(CANLibBadge<CANNetworkManager>) override;

--- a/isobus/src/can_extended_transport_protocol.cpp
+++ b/isobus/src/can_extended_transport_protocol.cpp
@@ -11,6 +11,7 @@
 
 #include "isobus/isobus/can_general_parameter_group_numbers.hpp"
 #include "isobus/isobus/can_network_configuration.hpp"
+#include "isobus/isobus/can_network_manager.hpp"
 #include "isobus/isobus/can_warning_logger.hpp"
 #include "isobus/utility/system_timing.hpp"
 #include "isobus/utility/to_string.hpp"
@@ -19,8 +20,6 @@
 
 namespace isobus
 {
-	ExtendedTransportProtocolManager ExtendedTransportProtocolManager::Protocol;
-
 	ExtendedTransportProtocolManager::ExtendedTransportProtocolSession::ExtendedTransportProtocolSession(Direction sessionDirection, std::uint8_t canPortIndex) :
 	  state(StateMachineState::None),
 	  sessionMessage(canPortIndex),
@@ -51,11 +50,8 @@ namespace isobus
 
 	ExtendedTransportProtocolManager ::~ExtendedTransportProtocolManager()
 	{
-		if (initialized)
-		{
-			CANNetworkManager::CANNetwork.remove_protocol_parameter_group_number_callback(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ExtendedTransportProtocolDataTransfer), process_message, this);
-			CANNetworkManager::CANNetwork.remove_protocol_parameter_group_number_callback(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ExtendedTransportProtocolConnectionManagement), process_message, this);
-		}
+		// No need to clean up, as this object is a member of the network manager
+		// so its callbacks will be cleared at destruction time
 	}
 
 	void ExtendedTransportProtocolManager::initialize(CANLibBadge<CANNetworkManager>)

--- a/isobus/src/can_network_manager.cpp
+++ b/isobus/src/can_network_manager.cpp
@@ -30,6 +30,8 @@ namespace isobus
 	{
 		receiveMessageList.clear();
 		initialized = true;
+		transportProtocol.initialize({});
+		extendedTransportProtocol.initialize({});
 	}
 
 	ControlFunction *CANNetworkManager::get_control_function(std::uint8_t CANPort, std::uint8_t CFAddress, CANLibBadge<AddressClaimStateMachine>) const

--- a/isobus/src/can_protocol.cpp
+++ b/isobus/src/can_protocol.cpp
@@ -9,25 +9,25 @@
 //================================================================================================
 #include "isobus/isobus/can_protocol.hpp"
 
+#include "isobus/isobus/can_network_manager.hpp"
+
 #include <algorithm>
 
 namespace isobus
 {
-	std::vector<CANLibProtocol *> CANLibProtocol::protocolList;
-
 	CANLibProtocol::CANLibProtocol() :
 	  initialized(false)
 	{
-		protocolList.push_back(this);
+		CANNetworkManager::CANNetwork.protocolList.push_back(this);
 	}
 
 	CANLibProtocol::~CANLibProtocol()
 	{
-		auto protocolLocation = find(protocolList.begin(), protocolList.end(), this);
+		auto protocolLocation = find(CANNetworkManager::CANNetwork.protocolList.begin(), CANNetworkManager::CANNetwork.protocolList.end(), this);
 
-		if (protocolList.end() != protocolLocation)
+		if (CANNetworkManager::CANNetwork.protocolList.end() != protocolLocation)
 		{
-			protocolList.erase(protocolLocation);
+			CANNetworkManager::CANNetwork.protocolList.erase(protocolLocation);
 		}
 	}
 
@@ -40,16 +40,16 @@ namespace isobus
 	{
 		returnedProtocol = nullptr;
 
-		if (index < protocolList.size())
+		if (index < CANNetworkManager::CANNetwork.protocolList.size())
 		{
-			returnedProtocol = protocolList[index];
+			returnedProtocol = CANNetworkManager::CANNetwork.protocolList[index];
 		}
 		return (nullptr != returnedProtocol);
 	}
 
 	std::uint32_t CANLibProtocol::get_number_protocols()
 	{
-		return protocolList.size();
+		return CANNetworkManager::CANNetwork.protocolList.size();
 	}
 
 	void CANLibProtocol::initialize(CANLibBadge<CANNetworkManager>)

--- a/isobus/src/can_transport_protocol.cpp
+++ b/isobus/src/can_transport_protocol.cpp
@@ -12,6 +12,7 @@
 
 #include "isobus/isobus/can_general_parameter_group_numbers.hpp"
 #include "isobus/isobus/can_network_configuration.hpp"
+#include "isobus/isobus/can_network_manager.hpp"
 #include "isobus/isobus/can_warning_logger.hpp"
 #include "isobus/utility/system_timing.hpp"
 #include "isobus/utility/to_string.hpp"
@@ -20,8 +21,6 @@
 
 namespace isobus
 {
-	TransportProtocolManager TransportProtocolManager::Protocol;
-
 	TransportProtocolManager::TransportProtocolSession::TransportProtocolSession(Direction sessionDirection, std::uint8_t canPortIndex) :
 	  state(StateMachineState::None),
 	  sessionMessage(canPortIndex),
@@ -53,11 +52,8 @@ namespace isobus
 
 	TransportProtocolManager::~TransportProtocolManager()
 	{
-		if (initialized)
-		{
-			CANNetworkManager::CANNetwork.remove_protocol_parameter_group_number_callback(static_cast<std::uint32_t>(CANLibParameterGroupNumber::TransportProtocolCommand), process_message, this);
-			CANNetworkManager::CANNetwork.remove_protocol_parameter_group_number_callback(static_cast<std::uint32_t>(CANLibParameterGroupNumber::TransportProtocolData), process_message, this);
-		}
+		// No need to clean up, as this object is a member of the network manager
+		// so its callbacks will be cleared at destruction time
 	}
 
 	void TransportProtocolManager::initialize(CANLibBadge<CANNetworkManager>)

--- a/sphinx/source/FAQ.rst
+++ b/sphinx/source/FAQ.rst
@@ -37,7 +37,7 @@ Make sure your CMake links these to your executable:
    set(THREADS_PREFER_PTHREAD_FLAG ON)
    find_package(Threads)
 
-   target_link_libraries(<your executable name> PRIVATE -Wl,--whole-archive isobus::Isobus -Wl,--no-whole-archive isobus::HardwareIntegration ${CMAKE_THREAD_LIBS_INIT})
+   target_link_libraries(<your executable name> PRIVATE isobus::Isobus isobus::HardwareIntegration ${CMAKE_THREAD_LIBS_INIT})
 
 I have some other issue!
 -------------------------

--- a/sphinx/source/Installation.rst
+++ b/sphinx/source/Installation.rst
@@ -65,9 +65,7 @@ If your project is already using CMake to build your project, or this is a new p
 
    ...
 
-   target_link_libraries(<your target> PRIVATE -Wl,--whole-archive isobus::Isobus -Wl,--no-whole-archive isobus::HardwareIntegration ${CMAKE_THREAD_LIBS_INIT})
-
-:code:`-Wl,--whole-archive` is required to ensure that some static singleton objects, such as the :code:`TransportProtocolManager` don't get optimized out of your executable by your linker.
+   target_link_libraries(<your target> PRIVATE isobus::Isobus isobus::HardwareIntegration ${CMAKE_THREAD_LIBS_INIT})
 
 Using CMake has a lot of advantages, such as if the library is updated with additional files, or the file names change, it will not break your compilation.
    

--- a/sphinx/source/Tutorials/The ISOBUS Hello World.rst
+++ b/sphinx/source/Tutorials/The ISOBUS Hello World.rst
@@ -501,7 +501,7 @@ Add the following to a new file called CMakeLists.txt:
    
    add_executable(isobus_hello_world main.cpp)
    
-   target_link_libraries(isobus_hello_world PRIVATE -Wl,--whole-archive isobus::Isobus -Wl,--no-whole-archive isobus::HardwareIntegration ${CMAKE_THREAD_LIBS_INIT})
+   target_link_libraries(isobus_hello_world PRIVATE isobus::Isobus isobus::HardwareIntegration ${CMAKE_THREAD_LIBS_INIT})
 
 Save and close the file.
 


### PR DESCRIPTION
Dealing with the "whole-archive" behavior between compilers was very annoying, so I made the affected objects non-static members of the network manager. Now they will not be removed by your linker erroneously. Updated readme and tutorial docs to match this change.