### PR TITLE
[Core]: Added a way to register for a PGN callback for any CF

### DIFF
--- a/isobus/include/isobus/isobus/can_network_manager.hpp
+++ b/isobus/include/isobus/isobus/can_network_manager.hpp
@@ -165,15 +165,6 @@ namespace isobus
 		std::vector<CANLibProtocol *> protocolList; ///< A list of all created protocol classes
 
 	private:
-		/// @brief A structure to hold PGN callback data to provide parent back to the reigistrar of the callback
-		struct CANLibProtocolPGNCallbackInfo
-		{
-			bool operator==(const CANLibProtocolPGNCallbackInfo &obj); ///< A function to compare the other structure member variables
-			CANLibCallback callback; ///< The callback itself
-			void *parent; ///< A generic context variable that helps identify what object the callback was destined for
-			std::uint32_t parameterGroupNumber; ///< The PGN associated with the callback
-		};
-
 		/// @brief Constructor for the network manager. Sets default values for members
 		CANNetworkManager();
 
@@ -265,7 +256,7 @@ namespace isobus
 		std::array<std::array<ControlFunction *, 256>, CAN_PORT_MAXIMUM> controlFunctionTable; ///< Table to maintain address to NAME mappings
 		std::vector<ControlFunction *> activeControlFunctions; ///< A list of active control function used to track connected devices
 		std::vector<ControlFunction *> inactiveControlFunctions; ///< A list of inactive control functions, used to track disconnected devices
-		std::list<CANLibProtocolPGNCallbackInfo> protocolPGNCallbacks; ///< A list of PGN callback registered by CAN protocols
+		std::list<ParameterGroupNumberCallbackData> protocolPGNCallbacks; ///< A list of PGN callback registered by CAN protocols
 		std::list<CANMessage> receiveMessageList; ///< A queue of Rx messages to process
 		std::vector<ParameterGroupNumberCallbackData> globalParameterGroupNumberCallbacks; ///< A list of all global PGN callbacks
 		std::vector<ParameterGroupNumberCallbackData> anyControlFunctionParameterGroupNumberCallbacks; ///< A list of all global PGN callbacks

--- a/isobus/include/isobus/isobus/can_network_manager.hpp
+++ b/isobus/include/isobus/isobus/can_network_manager.hpp
@@ -213,9 +213,26 @@ namespace isobus
 		/// @returns A control function matching the address and CAN port passed in
 		ControlFunction *get_control_function(std::uint8_t CANPort, std::uint8_t CFAddress) const;
 
+		/// @brief Gets a message from the Rx Queue.
+		/// @note This will only ever get an 8 byte message. Long messages are handled elsewhere.
+		/// @returns The can message that was at the front of the buffer
+		CANMessage get_next_can_message_from_rx_queue();
+
+		/// @brief Returns the number of messages in the rx queue that need to be processed
+		/// @returns The number of messages in the rx queue that need to be processed
+		std::size_t get_number_can_messages_in_rx_queue();
+
+		/// @brief Processes a can message for callbacks added with add_any_control_function_parameter_group_number_callback
+		/// @param[in] currentMessage The message to process
+		void process_any_control_function_pgn_callbacks(CANMessage &currentMessage);
+
+		/// @brief Processes a can message for callbacks added with add_protocol_parameter_group_number_callback
+		/// @param[in] currentMessage The message to process
+		void process_protocol_pgn_callbacks(CANMessage &currentMessage);
+
 		/// @brief Matches a CAN message to any matching PGN callback, and calls that callback
 		/// @param[in] message A pointer to a CAN message to be processed
-		void process_can_message_for_callbacks(CANMessage *message);
+		void process_can_message_for_global_and_partner_callbacks(CANMessage *message);
 
 		/// @brief Processes the internal receive message queue
 		void process_rx_messages();

--- a/isobus/include/isobus/isobus/can_network_manager.hpp
+++ b/isobus/include/isobus/isobus/can_network_manager.hpp
@@ -71,6 +71,18 @@ namespace isobus
 		/// @returns The number of global PGN callbacks that have been registered with the network manager
 		std::uint32_t get_number_global_parameter_group_number_callbacks() const;
 
+		/// @brief Registers a callback for ANY control function sending the associated PGN
+		/// @param[in] parameterGroupNumber The PGN you want to register for
+		/// @param[in] callback The callback that will be called when parameterGroupNumber is recieved from any control function
+		/// @param[in] parent A generic context variable that helps identify what object the callback is destined for. Can be nullptr if you don't want to use it.
+		void add_any_control_function_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent);
+
+		/// @brief This is how you remove a callback added with add_any_control_function_parameter_group_number_callback
+		/// @param[in] parameterGroupNumber The PGN of the callback to remove
+		/// @param[in] callback The callback that will be removed
+		/// @param[in] parent A generic context variable that helps identify what object the callback was destined for
+		void remove_any_control_function_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent);
+
 		/// @brief Returns an internal control function if the passed-in control function is an internal type
 		/// @returns An internal control function casted from the passed in control function
 		InternalControlFunction *get_internal_control_function(ControlFunction *controlFunction);
@@ -162,6 +174,9 @@ namespace isobus
 			std::uint32_t parameterGroupNumber; ///< The PGN associated with the callback
 		};
 
+		/// @brief Constructor for the network manager. Sets default values for members
+		CANNetworkManager();
+
 		/// @brief Updates the internal address table based on a received CAN message
 		/// @param[in] message A message being received by the stack
 		void update_address_table(CANMessage &message);
@@ -236,8 +251,10 @@ namespace isobus
 		std::list<CANLibProtocolPGNCallbackInfo> protocolPGNCallbacks; ///< A list of PGN callback registered by CAN protocols
 		std::list<CANMessage> receiveMessageList; ///< A queue of Rx messages to process
 		std::vector<ParameterGroupNumberCallbackData> globalParameterGroupNumberCallbacks; ///< A list of all global PGN callbacks
+		std::vector<ParameterGroupNumberCallbackData> anyControlFunctionParameterGroupNumberCallbacks; ///< A list of all global PGN callbacks
 		std::mutex receiveMessageMutex; ///< A mutex for receive messages thread safety
 		std::mutex protocolPGNCallbacksMutex; ///< A mutex for PGN callback thread safety
+		std::mutex anyControlFunctionCallbacksMutex; ///< Mutex to protect the "any CF" callbacks
 		std::uint32_t updateTimestamp_ms; ///< Keeps track of the last time the CAN stack was update in milliseconds
 		bool initialized; ///< True if the network manager has been initialized by the update function
 	};

--- a/isobus/src/can_network_manager.cpp
+++ b/isobus/src/can_network_manager.cpp
@@ -69,14 +69,14 @@ namespace isobus
 
 	void CANNetworkManager::add_any_control_function_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent)
 	{
-		std::unique_lock<std::mutex> lock(anyControlFunctionCallbacksMutex);
+		std::lock_guard<std::mutex> lock(anyControlFunctionCallbacksMutex);
 		anyControlFunctionParameterGroupNumberCallbacks.push_back(ParameterGroupNumberCallbackData(parameterGroupNumber, callback, parent));
 	}
 
 	void CANNetworkManager::remove_any_control_function_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent)
 	{
 		ParameterGroupNumberCallbackData tempObject(parameterGroupNumber, callback, parent);
-		std::unique_lock<std::mutex> lock(anyControlFunctionCallbacksMutex);
+		std::lock_guard<std::mutex> lock(anyControlFunctionCallbacksMutex);
 		auto callbackLocation = std::find(anyControlFunctionParameterGroupNumberCallbacks.begin(), anyControlFunctionParameterGroupNumberCallbacks.end(), tempObject);
 		if (anyControlFunctionParameterGroupNumberCallbacks.end() != callbackLocation)
 		{
@@ -284,35 +284,28 @@ namespace isobus
 	bool CANNetworkManager::add_protocol_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parentPointer)
 	{
 		bool retVal = false;
-		CANLibProtocolPGNCallbackInfo callbackInfo;
+		CANLibProtocolPGNCallbackInfo callbackInfo{
+			callback, parentPointer, parameterGroupNumber
+		};
 
-		callbackInfo.callback = callback;
-		callbackInfo.parent = parentPointer;
-		callbackInfo.parameterGroupNumber = parameterGroupNumber;
-
-		protocolPGNCallbacksMutex.lock();
+		const std::lock_guard<std::mutex> lock(protocolPGNCallbacksMutex);
 
 		if ((nullptr != callback) && (protocolPGNCallbacks.end() == find(protocolPGNCallbacks.begin(), protocolPGNCallbacks.end(), callbackInfo)))
 		{
 			protocolPGNCallbacks.push_back(callbackInfo);
 			retVal = true;
 		}
-
-		protocolPGNCallbacksMutex.unlock();
-
 		return retVal;
 	}
 
 	bool CANNetworkManager::remove_protocol_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parentPointer)
 	{
 		bool retVal = false;
-		CANLibProtocolPGNCallbackInfo callbackInfo;
+		CANLibProtocolPGNCallbackInfo callbackInfo{
+			callback, parentPointer, parameterGroupNumber
+		};
 
-		callbackInfo.callback = callback;
-		callbackInfo.parent = parentPointer;
-		callbackInfo.parameterGroupNumber = parameterGroupNumber;
-
-		protocolPGNCallbacksMutex.lock();
+		const std::lock_guard<std::mutex> lock(protocolPGNCallbacksMutex);
 
 		if (nullptr != callback)
 		{
@@ -325,9 +318,6 @@ namespace isobus
 				retVal = true;
 			}
 		}
-
-		protocolPGNCallbacksMutex.unlock();
-
 		return retVal;
 	}
 
@@ -553,7 +543,45 @@ namespace isobus
 		return retVal;
 	}
 
-	void CANNetworkManager::process_can_message_for_callbacks(CANMessage *message)
+	CANMessage CANNetworkManager::get_next_can_message_from_rx_queue()
+	{
+		std::lock_guard<std::mutex> lock(receiveMessageMutex);
+		CANMessage retVal = receiveMessageList.front();
+		receiveMessageList.pop_front();
+		return retVal;
+	}
+
+	std::size_t CANNetworkManager::get_number_can_messages_in_rx_queue()
+	{
+		std::lock_guard<std::mutex> lock(receiveMessageMutex);
+		return receiveMessageList.size();
+	}
+
+	void CANNetworkManager::process_any_control_function_pgn_callbacks(CANMessage &currentMessage)
+	{
+		const std::lock_guard<std::mutex> lock(anyControlFunctionCallbacksMutex);
+		for (auto &currentCallback : anyControlFunctionParameterGroupNumberCallbacks)
+		{
+			if (currentCallback.get_parameter_group_number() == currentMessage.get_identifier().get_parameter_group_number())
+			{
+				currentCallback.get_callback()(&currentMessage, currentCallback.get_parent());
+			}
+		}
+	}
+
+	void CANNetworkManager::process_protocol_pgn_callbacks(CANMessage &currentMessage)
+	{
+		const std::lock_guard<std::mutex> lock(protocolPGNCallbacksMutex);
+		for (auto &currentCallback : protocolPGNCallbacks)
+		{
+			if (currentCallback.parameterGroupNumber == currentMessage.get_identifier().get_parameter_group_number())
+			{
+				currentCallback.callback(&currentMessage, currentCallback.parent);
+			}
+		}
+	}
+
+	void CANNetworkManager::process_can_message_for_global_and_partner_callbacks(CANMessage *message)
 	{
 		if (nullptr != message)
 		{
@@ -609,44 +637,18 @@ namespace isobus
 
 	void CANNetworkManager::process_rx_messages()
 	{
-		// Move this to a function
-		receiveMessageMutex.lock();
-		bool processNextMessage = (!receiveMessageList.empty());
-		receiveMessageMutex.unlock();
-
-		while (processNextMessage)
+		while (0 != get_number_can_messages_in_rx_queue())
 		{
-			receiveMessageMutex.lock();
-			CANMessage currentMessage = receiveMessageList.front();
-			receiveMessageList.pop_front();
-			processNextMessage = (!receiveMessageList.empty());
-			receiveMessageMutex.unlock();
+			CANMessage currentMessage = get_next_can_message_from_rx_queue();
 
 			update_address_table(currentMessage);
 
-			// Update Protocols
-			protocolPGNCallbacksMutex.lock();
-			for (auto &currentCallback : protocolPGNCallbacks)
-			{
-				if (currentCallback.parameterGroupNumber == currentMessage.get_identifier().get_parameter_group_number())
-				{
-					currentCallback.callback(&currentMessage, currentCallback.parent);
-				}
-			}
-			protocolPGNCallbacksMutex.unlock();
-
-			anyControlFunctionCallbacksMutex.lock();
-			for (auto &currentCallback : anyControlFunctionParameterGroupNumberCallbacks)
-			{
-				if (currentCallback.get_parameter_group_number() == currentMessage.get_identifier().get_parameter_group_number())
-				{
-					currentCallback.get_callback()(&currentMessage, currentCallback.get_parent());
-				}
-			}
-			anyControlFunctionCallbacksMutex.unlock();
+			// Update Special Callbacks, like protocols and non-cf specific ones
+			process_protocol_pgn_callbacks(currentMessage);
+			process_any_control_function_pgn_callbacks(currentMessage);
 
 			// Update Others
-			process_can_message_for_callbacks(&currentMessage);
+			process_can_message_for_global_and_partner_callbacks(&currentMessage);
 		}
 	}
 
@@ -665,7 +667,7 @@ namespace isobus
 
 	void CANNetworkManager::protocol_message_callback(CANMessage *protocolMessage)
 	{
-		process_can_message_for_callbacks(protocolMessage);
+		process_can_message_for_global_and_partner_callbacks(protocolMessage);
 	}
 
 } // namespace isobus


### PR DESCRIPTION
This is is essentially a way to register for PGN callbacks from anybody. This should really only be used when the other registration method doesn't work for your use case, but for some server applications (VT and File Server come to mind) it seems like it would be beneficial to have a way to get all messages with a specific PGN without registering specific partners.