### PR TITLE
[#102]: Change how partner and ICF list maintenance is done when members are deleted

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,8 @@ if(BUILD_TESTING)
   if("SocketCAN" IN_LIST CAN_DRIVER)
     add_executable(
       unit_tests test/address_claim_test.cpp test/test_CAN_glue.cpp
-                 test/identifier_tests.cpp test/dm_13_tests.cpp)
+                 test/identifier_tests.cpp test/dm_13_tests.cpp
+                 test/core_network_management_tests.cpp)
     target_link_libraries(
       unit_tests
       PRIVATE GTest::gtest_main ${PROJECT_NAME}::Isobus

--- a/isobus/src/can_internal_control_function.cpp
+++ b/isobus/src/can_internal_control_function.cpp
@@ -24,13 +24,22 @@ namespace isobus
 	  objectChangedAddressSinceLastUpdate(false)
 	{
 		controlFunctionType = Type::Internal;
-		internalControlFunctionList.push_back(this);
+
+		auto location = std::find(internalControlFunctionList.begin(), internalControlFunctionList.end(), nullptr);
+		if (internalControlFunctionList.end() != location)
+		{
+			*location = this; // Use the available space in the list
+		}
+		else
+		{
+			internalControlFunctionList.push_back(this); // Allocate space in the list for this ICF
+		}
 	}
 
 	InternalControlFunction::~InternalControlFunction()
 	{
 		auto thisObject = std::find(internalControlFunctionList.begin(), internalControlFunctionList.end(), this);
-		internalControlFunctionList.erase(thisObject);
+		*thisObject = nullptr; // Don't erase, just null it out. Erase could cause a double free.
 	}
 
 	InternalControlFunction *InternalControlFunction::get_internal_control_function(std::uint32_t index)

--- a/isobus/src/can_network_manager.cpp
+++ b/isobus/src/can_network_manager.cpp
@@ -176,14 +176,16 @@ namespace isobus
 			{
 				InternalControlFunction *currentInternalControlFunction = InternalControlFunction::get_internal_control_function(i);
 
-				if (activeControlFunctions.end() == std::find(activeControlFunctions.begin(), activeControlFunctions.end(), currentInternalControlFunction))
+				if (nullptr != currentInternalControlFunction)
 				{
-					activeControlFunctions.push_back(currentInternalControlFunction);
-				}
-				if ((nullptr != currentInternalControlFunction) &&
-				    (currentInternalControlFunction->get_changed_address_since_last_update({})))
-				{
-					update_address_table(currentInternalControlFunction->get_can_port(), currentInternalControlFunction->get_address());
+					if (activeControlFunctions.end() == std::find(activeControlFunctions.begin(), activeControlFunctions.end(), currentInternalControlFunction))
+					{
+						activeControlFunctions.push_back(currentInternalControlFunction);
+					}
+					if (currentInternalControlFunction->get_changed_address_since_last_update({}))
+					{
+						update_address_table(currentInternalControlFunction->get_can_port(), currentInternalControlFunction->get_address());
+					}
 				}
 			}
 		}
@@ -432,7 +434,8 @@ namespace isobus
 				// If we still haven't found it, it might be a partner. Check the list of partners.
 				for (std::uint32_t i = 0; i < PartneredControlFunction::partneredControlFunctionList.size(); i++)
 				{
-					if (PartneredControlFunction::partneredControlFunctionList[i]->check_matches_name(NAME(claimedNAME)))
+					if ((nullptr != PartneredControlFunction::partneredControlFunctionList[i]) &&
+					    (PartneredControlFunction::partneredControlFunctionList[i]->check_matches_name(NAME(claimedNAME))))
 					{
 						PartneredControlFunction::partneredControlFunctionList[i]->address = CANIdentifier(rxFrame.identifier).get_source_address();
 						PartneredControlFunction::partneredControlFunctionList[i]->controlFunctionNAME = NAME(claimedNAME);

--- a/isobus/src/can_partnered_control_function.cpp
+++ b/isobus/src/can_partnered_control_function.cpp
@@ -21,14 +21,29 @@ namespace isobus
 	  ControlFunction(NAME(0), NULL_CAN_ADDRESS, CANPort),
 	  NAMEFilterList(NAMEFilters)
 	{
+		bool emptyPartnerSlotFound = false;
 		controlFunctionType = Type::Partnered;
-		partneredControlFunctionList.push_back(this);
+
+		for (auto &partner : partneredControlFunctionList)
+		{
+			if (nullptr == partner)
+			{
+				partner = this;
+				emptyPartnerSlotFound = true;
+				break;
+			}
+		}
+
+		if (!emptyPartnerSlotFound)
+		{
+			partneredControlFunctionList.push_back(this);
+		}
 	}
 
 	PartneredControlFunction::~PartneredControlFunction()
 	{
 		auto thisObject = std::find(partneredControlFunctionList.begin(), partneredControlFunctionList.end(), this);
-		partneredControlFunctionList.erase(thisObject);
+		*thisObject = nullptr; // Don't erase, in case the object was already deleted. Just make room for a new partner.
 	}
 
 	void PartneredControlFunction::add_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent)

--- a/test/core_network_management_tests.cpp
+++ b/test/core_network_management_tests.cpp
@@ -1,0 +1,38 @@
+#include <gtest/gtest.h>
+
+#include "isobus/isobus/can_internal_control_function.hpp"
+#include "isobus/isobus/can_partnered_control_function.hpp"
+
+#include <memory>
+
+using namespace isobus;
+
+TEST(CORE_TESTS, TestCreateAndDestroyPartners)
+{
+	std::vector<isobus::NAMEFilter> vtNameFilters;
+	const isobus::NAMEFilter testFilter(isobus::NAME::NAMEParameters::FunctionCode, static_cast<std::uint8_t>(isobus::NAME::Function::VirtualTerminal));
+
+	isobus::PartneredControlFunction TestPartner1(0, vtNameFilters);
+	isobus::PartneredControlFunction *TestPartner2 = new isobus::PartneredControlFunction(0, vtNameFilters);
+	delete TestPartner2;
+	auto TestPartner3 = std::make_shared<isobus::PartneredControlFunction>(0, vtNameFilters);
+}
+
+TEST(CORE_TESTS, TestCreateAndDestroyICFs)
+{
+	isobus::NAME TestDeviceNAME(0);
+	TestDeviceNAME.set_arbitrary_address_capable(true);
+	TestDeviceNAME.set_industry_group(0);
+	TestDeviceNAME.set_device_class(0);
+	TestDeviceNAME.set_function_code(static_cast<std::uint8_t>(isobus::NAME::Function::SteeringControl));
+	TestDeviceNAME.set_identity_number(2);
+	TestDeviceNAME.set_ecu_instance(0);
+	TestDeviceNAME.set_function_instance(0);
+	TestDeviceNAME.set_device_class_instance(0);
+	TestDeviceNAME.set_manufacturer_code(64);
+
+	isobus::InternalControlFunction TestIcf1(TestDeviceNAME, 0x1C, 0);
+	auto TestIcf2 = new isobus::InternalControlFunction(TestDeviceNAME, 0x80, 0);
+	delete TestIcf2;
+	auto TestIcf3 = std::make_shared<isobus::InternalControlFunction>(TestDeviceNAME, 0x81, 0);
+}


### PR DESCRIPTION
When a partner or ICF is deleted, now we will null out its pointer in the list rather than erasing it, which could have caused an exception if the deleted object was a created via smart pointer. Likewise, when a new object is created, we will search first for empty spots in the list before allocating new ones to keep the list as small as possible. Added a trivial unit test to detect exceptions on creation and deletion of ICFs and Partners.

Closes #102 