### PR TITLE
[Core]: Change internal control function list to be a vector

### DIFF
--- a/isobus/include/isobus/isobus/can_internal_control_function.hpp
+++ b/isobus/include/isobus/isobus/can_internal_control_function.hpp
@@ -15,7 +15,7 @@
 #include "isobus/isobus/can_badge.hpp"
 #include "isobus/isobus/can_control_function.hpp"
 
-#include <list>
+#include <vector>
 
 namespace isobus
 {
@@ -66,7 +66,7 @@ namespace isobus
 		/// @brief Updates the internal control function, should be called periodically by the network manager
 		void update();
 
-		static std::list<InternalControlFunction *> internalControlFunctionList; ///< A list of all internal control functions that exist
+		static std::vector<InternalControlFunction *> internalControlFunctionList; ///< A list of all internal control functions that exist
 		static bool anyChangedAddress; ///< Lets the network manager know if any ICF changed address since the last update
 		AddressClaimStateMachine stateMachine; ///< The address claimer for this ICF
 		bool objectChangedAddressSinceLastUpdate; ///< Tracks if this object has changed address since the last update

--- a/isobus/include/isobus/isobus/can_network_manager.hpp
+++ b/isobus/include/isobus/isobus/can_network_manager.hpp
@@ -23,6 +23,7 @@
 #include "isobus/isobus/can_transport_protocol.hpp"
 
 #include <array>
+#include <list>
 #include <mutex>
 
 /// @brief This namespace encompases all of the ISO11783 stack's functionality to reduce global namespace pollution

--- a/isobus/src/can_internal_control_function.cpp
+++ b/isobus/src/can_internal_control_function.cpp
@@ -15,7 +15,7 @@
 
 namespace isobus
 {
-	std::list<InternalControlFunction *> InternalControlFunction::internalControlFunctionList;
+	std::vector<InternalControlFunction *> InternalControlFunction::internalControlFunctionList;
 	bool InternalControlFunction::anyChangedAddress = false;
 
 	InternalControlFunction::InternalControlFunction(NAME desiredName, std::uint8_t preferredAddress, std::uint8_t CANPort) :


### PR DESCRIPTION
Changed to avoid a possible segfault while searching a list for nullptr in a static constructor of an ICF.

This was crashing my super secret VT server project on this line:
`auto location = std::find(internalControlFunctionList.begin(), internalControlFunctionList.end(), nullptr);`