### PR TITLE
Update README with install and CAN driver instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,19 @@ Check out the [tutorial website](https://delgrossoengineering.com/isobus-tutoria
 
 ## Compilation
 
-This library is compiled with CMake. Currently, I am testing on Ubuntu 20.04 and RHEL 9, and the built in Socket CAN integration (if you choose to use it) only works on Linux.
+This library is compiled with CMake.
+
 ```
 cmake -S . -B build
 cmake --build build
 ```
+
+A default CAN driver plug-in will be selected for you based on your OS, but when compiling you can explicitly choose to use one of the natively supported CAN drivers by supplying the `CAN_DRIVER` variable.
+
+* `-DCAN_DRIVER=SocketCAN` Will compile with Socket CAN support (This is the default for Linux)
+* `-DCAN_DRIVER=WindowsPCANBasic` Will compile with windows support for the PEAK PCAN drivers (This is the default for Windows)
+
+If your target hardware is not listed above, you can easily integrate your own hardware by [implementing a few simple functions](https://github.com/ad3154/ISO11783-CAN-Stack/tree/main/hardware_integration#writing-a-new-can-driver-for-the-stack).
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,24 @@ target_link_libraries(<your executable name> PRIVATE isobus::Isobus isobus::Hard
 
 A full example CMakeLists.txt file can be found on the tutorial website.
 
+### Installing The Library
+
+You can also install the library if you want.
+
+For a local install:
+
+```
+cmake --install build --prefix install
+```
+
+For a system-wide install:
+
+```
+sudo cmake --install build
+```
+
+Then, use a call to find_package() to find this package.
+
 ## Documentation
 
 You can view the pre-compiled doxygen here https://delgrossoengineering.com/isobus-docs

--- a/hardware_integration/CMakeLists.txt
+++ b/hardware_integration/CMakeLists.txt
@@ -12,7 +12,12 @@ if(NOT CAN_DRIVER)
     AUTHOR_WARNING
       "No CAN driver specified, choosing Linux socket CAN by default. Use -DCAN_DRIVER=\"SocketCAN\" to specify another driver. or -DCAN_DRIVER=\"SocketCAN;WindowsPCANBasic\" to specify multiple drivers."
   )
-  set(CAN_DRIVER "SocketCAN")
+
+  if (WIN32)
+    set(CAN_DRIVER "WindowsPCANBasic")
+  else()
+    set(CAN_DRIVER "SocketCAN")
+  endif()
 endif()
 
 # Set the source files


### PR DESCRIPTION
* Added a short section to the readme file about installing the library
* Added mentions to the main README for how to set the CAN driver plugin
* Added a trivial check to not choose socket CAN by default on Windows and instead choose the PEAK driver