### PR TITLE
[#112]: Update VT tutorial with CMake, Fix omissions and a couple outdated function names

### DIFF
--- a/sphinx/source/FAQ.rst
+++ b/sphinx/source/FAQ.rst
@@ -37,7 +37,7 @@ Make sure your CMake links these to your executable:
    set(THREADS_PREFER_PTHREAD_FLAG ON)
    find_package(Threads)
 
-   target_link_libraries(<your executable name> PRIVATE isobus::Isobus isobus::HardwareIntegration ${CMAKE_THREAD_LIBS_INIT})
+   target_link_libraries(<your executable name> PRIVATE isobus::Isobus isobus::HardwareIntegration Threads::Threads)
 
 I have some other issue!
 -------------------------

--- a/sphinx/source/Installation.rst
+++ b/sphinx/source/Installation.rst
@@ -65,7 +65,7 @@ If your project is already using CMake to build your project, or this is a new p
 
    ...
 
-   target_link_libraries(<your target> PRIVATE isobus::Isobus isobus::HardwareIntegration ${CMAKE_THREAD_LIBS_INIT})
+   target_link_libraries(<your target> PRIVATE isobus::Isobus isobus::HardwareIntegration Threads::Threads)
 
 Using CMake has a lot of advantages, such as if the library is updated with additional files, or the file names change, it will not break your compilation.
    

--- a/sphinx/source/Tutorials/The ISOBUS Hello World.rst
+++ b/sphinx/source/Tutorials/The ISOBUS Hello World.rst
@@ -501,7 +501,7 @@ Add the following to a new file called CMakeLists.txt:
    
    add_executable(isobus_hello_world main.cpp)
    
-   target_link_libraries(isobus_hello_world PRIVATE isobus::Isobus isobus::HardwareIntegration ${CMAKE_THREAD_LIBS_INIT})
+   target_link_libraries(isobus_hello_world PRIVATE isobus::Isobus isobus::HardwareIntegration Threads::Threads)
 
 Save and close the file.
 

--- a/sphinx/source/Tutorials/Virtual Terminal Basics.rst
+++ b/sphinx/source/Tutorials/Virtual Terminal Basics.rst
@@ -537,7 +537,7 @@ We can do that with this little handy bit of CMake:
 		TARGET vt_example
 		POST_BUILD
 		COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/VT3TestPool.iop
-		${CMAKE_CURRENT_BINARY_DIR}/VT3TestPool.iop)
+		$<TARGET_FILE_DIR:vt_example>/VT3TestPool.iop)
 
 Now you should be able to build and run the program!
 


### PR DESCRIPTION
* Replaced ${CMAKE_THREAD_LIBS_INIT} with Threads::Threads (See #54)
* Added CMake instructions to VT tutorial
* Fixed `RegisterVTButtonEventCallback` and `RegisterVTSoftKeyEventCallback` should be snake_case
* Clarified use and instructions around `objectPoolObjects.h` and `VT3TestPool.iop`
* Added a section about the other callbacks, like string value events
* Added some more references to the API docs

Closes #112 
Closes #54 