### PR TITLE
[ETP/TP/FP]: Fix session complete callback not called sometimes.

### DIFF
--- a/isobus/include/isobus/isobus/can_extended_transport_protocol.hpp
+++ b/isobus/include/isobus/isobus/can_extended_transport_protocol.hpp
@@ -174,7 +174,8 @@ namespace isobus
 
 		/// @brief Gracefully closes a session to prepare for a new session
 		/// @param[in] session The session to close
-		void close_session(ExtendedTransportProtocolSession *session);
+		/// @param[in] successfull True if the session was closed successfully, false if not
+		void close_session(ExtendedTransportProtocolSession *session, bool successfull);
 
 		/// @brief Gets an ETP session from the passed in source and destination combination
 		/// @param[in] source The source control function for the session

--- a/isobus/include/isobus/isobus/can_transport_protocol.hpp
+++ b/isobus/include/isobus/isobus/can_transport_protocol.hpp
@@ -175,7 +175,8 @@ namespace isobus
 
 		/// @brief Gracefully closes a session to prepare for a new session
 		/// @param[in] session The session to close
-		void close_session(TransportProtocolSession *session);
+		/// @param[in] successfull Denotes if the session was successful
+		void close_session(TransportProtocolSession *session, bool successfull);
 
 		/// @brief Processes end of session callbacks
 		/// @param[in] session The session we've just completed

--- a/isobus/include/isobus/isobus/nmea2000_fast_packet_protocol.hpp
+++ b/isobus/include/isobus/isobus/nmea2000_fast_packet_protocol.hpp
@@ -136,7 +136,8 @@ namespace isobus
 
 		/// @brief Ends a session and cleans up the memory associated with its metadata
 		/// @param[in] session The session to close
-		void close_session(FastPacketProtocolSession *session);
+		/// @param[in] successfull `true` if the session was closed successfully, otherwise `false`
+		void close_session(FastPacketProtocolSession *session, bool successfull);
 
 		/// @brief Gets the sequence number to use for a new session based on the history
 		/// @param[in] session The new session we're starting


### PR DESCRIPTION
Moved `process_session_complete_callback` function call to `close_session` to make sure it always gets called when session closes. `process_session_complete_callback` itself checks whether or not a callback is given, which is right now only for transmitting sessions. Though the name "session complete callback" itself doesn't constrain it to transmitting sessions only and so this change also allows receiving sessions to use the callback system if needed.

**Related bug:**
After receiving an abort for a transmitting etp session for an object pool, the callback didn't get called and therefore the VT client never got to reset.
```console
I (366) Main: Starting setup...
I (636) Main: Loaded object pool from vtpooldata.iop
I (636) Main: Setup complete!
I (676) Logger: [NM]: A Partner Has Claimed 38
I (2036) Logger: [ETP]: New ETP Session. Dest: 38
I (3286) Logger: [ETP]: Received an abort for an session with PGN: 59136
I (3286) Logger: [ETP]: Session Closed
```