### PR TITLE
[ETP]: Fix ETP Rx message contents not matching the expected content

### DIFF
--- a/isobus/src/can_extended_transport_protocol.cpp
+++ b/isobus/src/can_extended_transport_protocol.cpp
@@ -544,6 +544,11 @@ namespace isobus
 				packetMax = 0xFF;
 			}
 
+			if (packetMax < session->packetCount)
+			{
+				session->packetCount = packetMax; // If we're sending a CTS with less than 0xFF, set the expected packet count to the CTS packet count
+			}
+
 			const std::uint8_t dataBuffer[CAN_DATA_LENGTH] = { EXTENDED_CLEAR_TO_SEND_MULTIPLEXOR,
 				                                                 static_cast<std::uint8_t>(packetMax), /// @todo Make CTS Max user configurable
 				                                                 static_cast<std::uint8_t>((session->processedPacketsThisSession + 1) & 0xFF),

--- a/isobus/src/can_extended_transport_protocol.cpp
+++ b/isobus/src/can_extended_transport_protocol.cpp
@@ -284,16 +284,17 @@ namespace isobus
 			case static_cast<std::uint32_t>(CANLibParameterGroupNumber::ExtendedTransportProtocolDataTransfer):
 			{
 				ExtendedTransportProtocolSession *tempSession = nullptr;
+				auto &messageData = message->get_data();
 
 				if ((CAN_DATA_LENGTH == message->get_data_length()) &&
 				    (get_session(tempSession, message->get_source_control_function(), message->get_destination_control_function())) &&
 				    (StateMachineState::RxDataSession == tempSession->state) &&
-				    (message->get_data()[SEQUENCE_NUMBER_DATA_INDEX] == (tempSession->lastPacketNumber + 1)))
+				    (messageData[SEQUENCE_NUMBER_DATA_INDEX] == (tempSession->lastPacketNumber + 1)))
 				{
-					for (std::uint8_t i = SEQUENCE_NUMBER_DATA_INDEX; i < CAN_DATA_LENGTH; i++)
+					for (std::uint8_t i = SEQUENCE_NUMBER_DATA_INDEX; i < PROTOCOL_BYTES_PER_FRAME; i++)
 					{
-						std::uint32_t currentDataIndex = (CAN_DATA_LENGTH * tempSession->lastPacketNumber) + i;
-						tempSession->sessionMessage.set_data(message->get_data()[SEQUENCE_NUMBER_DATA_INDEX + i], currentDataIndex);
+						std::uint32_t currentDataIndex = (PROTOCOL_BYTES_PER_FRAME * tempSession->processedPacketsThisSession) + i;
+						tempSession->sessionMessage.set_data(messageData[1 + SEQUENCE_NUMBER_DATA_INDEX + i], currentDataIndex);
 					}
 					tempSession->lastPacketNumber++;
 					tempSession->processedPacketsThisSession++;


### PR DESCRIPTION
* Fixed an off by 1 error in parsing the protocol bytes out of each ETP frame
* Fixed the data offset into the resulting message buffer would roll over due to it using the wrong counter
* Fixed an erroneous log message by setting the expected ETP packet count properly when we CTS less than 255 frames, usually at the end of a session.

Closes #121 