### PR TITLE
Control function maintenance improvements

### DIFF
--- a/isobus/include/isobus/isobus/can_control_function.hpp
+++ b/isobus/include/isobus/isobus/can_control_function.hpp
@@ -12,6 +12,8 @@
 
 #include "isobus/isobus/can_NAME.hpp"
 
+#include <mutex>
+
 namespace isobus
 {
 	//================================================================================================
@@ -61,6 +63,7 @@ namespace isobus
 
 	protected:
 		friend class CANNetworkManager;
+		static std::mutex controlFunctionProcessingMutex; ///< Protects the control function tables
 		NAME controlFunctionNAME; ///< The NAME of the control function
 		Type controlFunctionType; ///< The Type of the control function
 		std::uint8_t address; ///< The address of the control function

--- a/isobus/include/isobus/isobus/can_network_manager.hpp
+++ b/isobus/include/isobus/isobus/can_network_manager.hpp
@@ -181,6 +181,9 @@ namespace isobus
 		/// @param[in] rxFrame Raw frames coming in from the bus
 		void update_control_functions(HardwareInterfaceCANFrame &rxFrame);
 
+		/// @brief Checks if new partners have been created and matches them to existing control functions
+		void update_new_partners();
+
 		/// @brief Builds a CAN frame from a frame's discrete components
 		/// @param[in] portIndex The CAN channel index of the CAN message being processed
 		/// @param[in] sourceAddress The source address to send the CAN message from

--- a/isobus/include/isobus/isobus/can_network_manager.hpp
+++ b/isobus/include/isobus/isobus/can_network_manager.hpp
@@ -29,6 +29,8 @@
 /// @brief This namespace encompases all of the ISO11783 stack's functionality to reduce global namespace pollution
 namespace isobus
 {
+	class PartneredControlFunction;
+
 	//================================================================================================
 	/// @class CANNetworkManager
 	///
@@ -115,6 +117,10 @@ namespace isobus
 		/// @param[in] rxFrame Frame to process
 		/// @param[in] parentClass A generic context variable
 		static void can_lib_process_rx_message(HardwareInterfaceCANFrame &rxFrame, void *parentClass);
+
+		/// @brief Informs the network manager that a partner was deleted so that it can be purged from the address/cf tables
+		/// @param[in] partner Pointer to the partner being deleted
+		void on_partner_deleted(PartneredControlFunction *partner, CANLibBadge<PartneredControlFunction>);
 
 	protected:
 		// Using protected region to allow protocols use of special functions from the network manager

--- a/isobus/include/isobus/isobus/can_partnered_control_function.hpp
+++ b/isobus/include/isobus/isobus/can_partnered_control_function.hpp
@@ -42,7 +42,7 @@ namespace isobus
 		PartneredControlFunction(std::uint8_t CANPort, const std::vector<NAMEFilter> NAMEFilters);
 
 		/// @brief The destructor for PartneredControlFunction
-		~PartneredControlFunction();
+		virtual ~PartneredControlFunction();
 
 		/// @brief This is how you get notified that this control function has sent you a destination specific message.
 		/// @details Add a callback function here to be notified when this device has sent you a message with the specified PGN.
@@ -105,8 +105,10 @@ namespace isobus
 		ParameterGroupNumberCallbackData get_parameter_group_number_callback(std::uint32_t index) const;
 
 		static std::vector<PartneredControlFunction *> partneredControlFunctionList; ///< A list of all created partnered control functions
+		static bool anyPartnerNeedsInitializing; ///< A way for the network manager to know if it needs to parse the partner list to match partners with existing CFs
 		const std::vector<NAMEFilter> NAMEFilterList; ///< A list of NAME parameters that describe this control function's identity
 		std::vector<ParameterGroupNumberCallbackData> parameterGroupNumberCallbacks; ///< A list of all parameter group number callbacks associated with this control function
+		bool initialized; ///< A way to track if the network manager has processed this CF against existing CFs
 	};
 
 } // namespace isobus

--- a/isobus/src/can_control_function.cpp
+++ b/isobus/src/can_control_function.cpp
@@ -13,6 +13,8 @@
 
 namespace isobus
 {
+	std::mutex ControlFunction::controlFunctionProcessingMutex;
+
 	ControlFunction::ControlFunction(NAME NAMEValue, std::uint8_t addressValue, std::uint8_t CANPort) :
 	  controlFunctionNAME(NAMEValue),
 	  controlFunctionType(Type::External),

--- a/isobus/src/can_internal_control_function.cpp
+++ b/isobus/src/can_internal_control_function.cpp
@@ -23,6 +23,7 @@ namespace isobus
 	  stateMachine(preferredAddress, desiredName, CANPort),
 	  objectChangedAddressSinceLastUpdate(false)
 	{
+		const std::lock_guard<std::mutex> lock(ControlFunction::controlFunctionProcessingMutex);
 		controlFunctionType = Type::Internal;
 
 		auto location = std::find(internalControlFunctionList.begin(), internalControlFunctionList.end(), nullptr);
@@ -38,6 +39,7 @@ namespace isobus
 
 	InternalControlFunction::~InternalControlFunction()
 	{
+		const std::lock_guard<std::mutex> lock(ControlFunction::controlFunctionProcessingMutex);
 		auto thisObject = std::find(internalControlFunctionList.begin(), internalControlFunctionList.end(), this);
 		*thisObject = nullptr; // Don't erase, just null it out. Erase could cause a double free.
 	}

--- a/isobus/src/can_network_manager.cpp
+++ b/isobus/src/can_network_manager.cpp
@@ -287,7 +287,7 @@ namespace isobus
 
 	void CANNetworkManager::on_partner_deleted(PartneredControlFunction *partner, CANLibBadge<PartneredControlFunction>)
 	{
-		CANStackLogger::CAN_stack_log("[NM]: A partner was deleted.");
+		CANStackLogger::CAN_stack_log("[NM]: Partner " + isobus::to_string(static_cast<int>(partner->get_address())) + " was deleted.");
 
 		for (auto activeControlFunction = activeControlFunctions.begin(); activeControlFunction != activeControlFunctions.end(); activeControlFunction++)
 		{

--- a/isobus/src/can_partnered_control_function.cpp
+++ b/isobus/src/can_partnered_control_function.cpp
@@ -10,6 +10,7 @@
 #include "isobus/isobus/can_partnered_control_function.hpp"
 
 #include "isobus/isobus/can_constants.hpp"
+#include "isobus/isobus/can_network_manager.hpp"
 
 #include <algorithm>
 
@@ -49,6 +50,7 @@ namespace isobus
 		const std::lock_guard<std::mutex> lock(ControlFunction::controlFunctionProcessingMutex);
 		auto thisObject = std::find(partneredControlFunctionList.begin(), partneredControlFunctionList.end(), this);
 		*thisObject = nullptr; // Don't erase, in case the object was already deleted. Just make room for a new partner.
+		CANNetworkManager::CANNetwork.on_partner_deleted(this, {}); // Tell the network manager to purge this partner from all tables
 	}
 
 	void PartneredControlFunction::add_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent)


### PR DESCRIPTION
## What's new:

Added lots of improvements to control function list/table maintenance.

* Fix issues with mapping a `PartneredControlFunction` with an `ExternalControlFunction` when the partner was created after the stack already had an `ExternalControlFunction` object matching that ECU. In other words, if you made a partner after address claiming was complete, the stack would not resolve that partner to the right ECU. Now it should work no matter when you create a partner.
* Fixed some missing checks for can channel ID.
* Fixed not cleaning up our internal tables if a partner was deleted. Now you can delete partners that were created dynamically and we will automatically either prune it from the appropriate lists or replace the `PartneredControlFunction` with a `ExternalControlFunction`.
* Added a mutex to protect control function tables, that way we can synchronize creation and deletions of partners against the CAN Network Manager's update thread.
* Changed some u32's to `size_t` when they were iterators for an stl container

Closes #130 