### PR TITLE
[Core]: Add basic named reading of byte buffer

### DIFF
--- a/isobus/include/isobus/isobus/can_message.hpp
+++ b/isobus/include/isobus/isobus/can_message.hpp
@@ -33,6 +33,13 @@ namespace isobus
 			Internal ///< Message is being used internally as data storage for a protocol
 		};
 
+		/// @brief The different byte formats that can be used when reading bytes from the buffer.
+		enum class ByteFormat
+		{
+			LittleEndian,
+			BigEndian
+		};
+
 		/// @brief Constructor for a CAN message
 		/// @param[in] CANPort The can channel index the message uses
 		CANMessage(std::uint8_t CANPort);
@@ -68,6 +75,45 @@ namespace isobus
 		/// @brief Returns the CAN channel index associated with the message
 		/// @returns The CAN channel index associated with the message
 		std::uint8_t get_can_port_index() const;
+
+		/// @brief Get a 8-bit unsigned byte from the buffer at a specific index.
+		/// A 8-bit unsigned byte can hold a value between 0 and 255.
+		/// @details This function will return the byte at the specified index in the buffer.
+		/// @param[in] index The index to get the byte from
+		/// @return The 8-bit unsigned byte
+		std::uint8_t get_uint8_at(const std::size_t index);
+
+		/// @brief Get a 16-bit unsigned integer from the buffer at a specific index.
+		/// A 16-bit unsigned integer can hold a value between 0 and 65535.
+		/// @details This function will return the 2 bytes at the specified index in the buffer.
+		/// @param[in] index The index to get the 16-bit unsigned integer from
+		/// @param[in] format The byte format to use when reading the integer
+		/// @return The 16-bit unsigned integer
+		std::uint16_t get_uint16_at(const std::size_t index, const ByteFormat format = ByteFormat::LittleEndian);
+
+		/// @brief Get a 32-bit unsigned integer from the buffer at a specific index.
+		/// A 32-bit unsigned integer can hold a value between 0 and 4294967295.
+		/// @details This function will return the 4 bytes at the specified index in the buffer.
+		/// @param[in] index The index to get the 32-bit unsigned integer from
+		/// @param[in] format The byte format to use when reading the integer
+		/// @return The 32-bit unsigned integer
+		std::uint32_t get_uint32_at(const std::size_t index, const ByteFormat format = ByteFormat::LittleEndian);
+
+		/// @brief Get a 64-bit unsigned integer from the buffer at a specific index.
+		/// A 64-bit unsigned integer can hold a value between 0 and 18446744073709551615.
+		/// @details This function will return the 8 bytes at the specified index in the buffer.
+		/// @param[in] index The index to get the 64-bit unsigned integer from
+		/// @param[in] format The byte format to use when reading the integer
+		/// @return The 64-bit unsigned integer
+		std::uint64_t get_uint64_at(const std::size_t index, const ByteFormat format = ByteFormat::LittleEndian);
+
+		/// @brief Get a bit-boolean from the buffer at a specific index.
+		/// @details This function will return whether the bit(s) at the specified index in the buffer is/are (all) equal to 1.
+		/// @param[in] byteIndex The byte index to start reading the boolean from
+		/// @param[in] bitIndex The bit index to start reading the boolean from, ranging from 0 to 7
+		/// @param[in] length The number of bits to read, maximum of (8 - bitIndex)
+		/// @return True if (all) the bit(s) are set, false otherwise
+		bool get_bool_at(const std::size_t byteIndex, const std::uint8_t bitIndex, const std::uint8_t length = 1);
 
 		/// @brief ISO11783-3 defines this: The maximum number of packets that can be sent in a single connection
 		/// with extended transport protocol is restricted by the extended data packet offset (3 bytes).

--- a/isobus/src/can_message.cpp
+++ b/isobus/src/can_message.cpp
@@ -7,6 +7,7 @@
 /// @copyright 2022 Adrian Del Grosso
 //================================================================================================
 #include "isobus/isobus/can_message.hpp"
+#include <cassert>
 
 namespace isobus
 {
@@ -64,95 +65,77 @@ namespace isobus
 
 	std::uint8_t CANMessage::get_uint8_at(const std::size_t index)
 	{
-		std::uint8_t retVal = 0;
-		if (index + 1 <= get_data_length())
-		{
-			retVal = data[index];
-		}
-		return retVal;
+		return data.at(index);
 	}
 
 	std::uint16_t CANMessage::get_uint16_at(const std::size_t index, const ByteFormat format)
 	{
-		std::uint16_t retVal = 0;
-		if (index + 2 <= get_data_length())
+		std::uint16_t retVal;
+		if (ByteFormat::LittleEndian == format)
 		{
-			if (ByteFormat::LittleEndian == format)
-			{
-				retVal = data[index];
-				retVal |= static_cast<std::uint16_t>(data[index + 1]) << 8;
-			}
-			else
-			{
-				retVal = static_cast<std::uint16_t>(data[index]) << 8;
-				retVal |= data[index + 1];
-			}
+			retVal = data.at(index);
+			retVal |= static_cast<std::uint16_t>(data.at(index + 1)) << 8;
+		}
+		else
+		{
+			retVal = static_cast<std::uint16_t>(data.at(index)) << 8;
+			retVal |= data.at(index + 1);
 		}
 		return retVal;
 	}
 
 	std::uint32_t CANMessage::get_uint32_at(const std::size_t index, const ByteFormat format)
 	{
-		std::uint32_t retVal = 0;
-		if (index + 4 <= get_data_length())
+		std::uint32_t retVal;
+		if (ByteFormat::LittleEndian == format)
 		{
-			if (ByteFormat::LittleEndian == format)
-			{
-				retVal = data[index];
-				retVal |= static_cast<std::uint32_t>(data[index + 1]) << 8;
-				retVal |= static_cast<std::uint32_t>(data[index + 2]) << 16;
-				retVal |= static_cast<std::uint32_t>(data[index + 3]) << 24;
-			}
-			else
-			{
-				retVal = static_cast<std::uint32_t>(data[index]) << 24;
-				retVal |= static_cast<std::uint32_t>(data[index + 1]) << 16;
-				retVal |= static_cast<std::uint32_t>(data[index + 2]) << 8;
-				retVal |= data[index + 3];
-			}
+			retVal = data.at(index);
+			retVal |= static_cast<std::uint32_t>(data.at(index + 1)) << 8;
+			retVal |= static_cast<std::uint32_t>(data.at(index + 2)) << 16;
+			retVal |= static_cast<std::uint32_t>(data.at(index + 3)) << 24;
+		}
+		else
+		{
+			retVal = static_cast<std::uint32_t>(data.at(index)) << 24;
+			retVal |= static_cast<std::uint32_t>(data.at(index + 1)) << 16;
+			retVal |= static_cast<std::uint32_t>(data.at(index + 2)) << 8;
+			retVal |= data.at(index + 3);
 		}
 		return retVal;
 	}
 
 	std::uint64_t CANMessage::get_uint64_at(const std::size_t index, const ByteFormat format)
 	{
-		std::uint64_t retVal = 0;
-		if (index + 8 <= get_data_length())
+		std::uint64_t retVal;
+		if (ByteFormat::LittleEndian == format)
 		{
-			if (ByteFormat::LittleEndian == format)
-			{
-				retVal = data[index];
-				retVal |= static_cast<std::uint64_t>(data[index + 1]) << 8;
-				retVal |= static_cast<std::uint64_t>(data[index + 2]) << 16;
-				retVal |= static_cast<std::uint64_t>(data[index + 3]) << 24;
-				retVal |= static_cast<std::uint64_t>(data[index + 4]) << 32;
-				retVal |= static_cast<std::uint64_t>(data[index + 5]) << 40;
-				retVal |= static_cast<std::uint64_t>(data[index + 6]) << 48;
-				retVal |= static_cast<std::uint64_t>(data[index + 7]) << 56;
-			}
-			else
-			{
-				retVal = static_cast<std::uint64_t>(data[index]) << 56;
-				retVal |= static_cast<std::uint64_t>(data[index + 1]) << 48;
-				retVal |= static_cast<std::uint64_t>(data[index + 2]) << 40;
-				retVal |= static_cast<std::uint64_t>(data[index + 3]) << 32;
-				retVal |= static_cast<std::uint64_t>(data[index + 4]) << 24;
-				retVal |= static_cast<std::uint64_t>(data[index + 5]) << 16;
-				retVal |= static_cast<std::uint64_t>(data[index + 6]) << 8;
-				retVal |= data[index + 7];
-			}
+			retVal = data.at(index);
+			retVal |= static_cast<std::uint64_t>(data.at(index + 1)) << 8;
+			retVal |= static_cast<std::uint64_t>(data.at(index + 2)) << 16;
+			retVal |= static_cast<std::uint64_t>(data.at(index + 3)) << 24;
+			retVal |= static_cast<std::uint64_t>(data.at(index + 4)) << 32;
+			retVal |= static_cast<std::uint64_t>(data.at(index + 5)) << 40;
+			retVal |= static_cast<std::uint64_t>(data.at(index + 6)) << 48;
+			retVal |= static_cast<std::uint64_t>(data.at(index + 7)) << 56;
+		}
+		else
+		{
+			retVal = static_cast<std::uint64_t>(data.at(index)) << 56;
+			retVal |= static_cast<std::uint64_t>(data.at(index + 1)) << 48;
+			retVal |= static_cast<std::uint64_t>(data.at(index + 2)) << 40;
+			retVal |= static_cast<std::uint64_t>(data.at(index + 3)) << 32;
+			retVal |= static_cast<std::uint64_t>(data.at(index + 4)) << 24;
+			retVal |= static_cast<std::uint64_t>(data.at(index + 5)) << 16;
+			retVal |= static_cast<std::uint64_t>(data.at(index + 6)) << 8;
+			retVal |= data.at(index + 7);
 		}
 		return retVal;
 	}
 	bool isobus::CANMessage::get_bool_at(const std::size_t byteIndex, const std::uint8_t bitIndex, const std::uint8_t length)
 	{
-		bool retVal = false;
-		if (length <= 8 - bitIndex)
-		{
-			uint8_t mask = ((1 << length) - 1) << bitIndex;
-			retVal = (get_uint8_at(byteIndex) & mask) == mask;
-		}
-		return retVal;
+		assert(length <= 8 - bitIndex && "length must be less than or equal to 8 - bitIndex");
+		std::uint8_t mask = ((1 << length) - 1) << bitIndex;
+		return (get_uint8_at(byteIndex) & mask) == mask;
 	}
 
 } // namespace isobus

--- a/isobus/src/can_message.cpp
+++ b/isobus/src/can_message.cpp
@@ -62,4 +62,97 @@ namespace isobus
 		return CANPortIndex;
 	}
 
+	std::uint8_t CANMessage::get_uint8_at(const std::size_t index)
+	{
+		std::uint8_t retVal = 0;
+		if (index + 1 <= get_data_length())
+		{
+			retVal = data[index];
+		}
+		return retVal;
+	}
+
+	std::uint16_t CANMessage::get_uint16_at(const std::size_t index, const ByteFormat format)
+	{
+		std::uint16_t retVal = 0;
+		if (index + 2 <= get_data_length())
+		{
+			if (ByteFormat::LittleEndian == format)
+			{
+				retVal = data[index];
+				retVal |= static_cast<std::uint16_t>(data[index + 1]) << 8;
+			}
+			else
+			{
+				retVal = static_cast<std::uint16_t>(data[index]) << 8;
+				retVal |= data[index + 1];
+			}
+		}
+		return retVal;
+	}
+
+	std::uint32_t CANMessage::get_uint32_at(const std::size_t index, const ByteFormat format)
+	{
+		std::uint32_t retVal = 0;
+		if (index + 4 <= get_data_length())
+		{
+			if (ByteFormat::LittleEndian == format)
+			{
+				retVal = data[index];
+				retVal |= static_cast<std::uint32_t>(data[index + 1]) << 8;
+				retVal |= static_cast<std::uint32_t>(data[index + 2]) << 16;
+				retVal |= static_cast<std::uint32_t>(data[index + 3]) << 24;
+			}
+			else
+			{
+				retVal = static_cast<std::uint32_t>(data[index]) << 24;
+				retVal |= static_cast<std::uint32_t>(data[index + 1]) << 16;
+				retVal |= static_cast<std::uint32_t>(data[index + 2]) << 8;
+				retVal |= data[index + 3];
+			}
+		}
+		return retVal;
+	}
+
+	std::uint64_t CANMessage::get_uint64_at(const std::size_t index, const ByteFormat format)
+	{
+		std::uint64_t retVal = 0;
+		if (index + 8 <= get_data_length())
+		{
+			if (ByteFormat::LittleEndian == format)
+			{
+				retVal = data[index];
+				retVal |= static_cast<std::uint64_t>(data[index + 1]) << 8;
+				retVal |= static_cast<std::uint64_t>(data[index + 2]) << 16;
+				retVal |= static_cast<std::uint64_t>(data[index + 3]) << 24;
+				retVal |= static_cast<std::uint64_t>(data[index + 4]) << 32;
+				retVal |= static_cast<std::uint64_t>(data[index + 5]) << 40;
+				retVal |= static_cast<std::uint64_t>(data[index + 6]) << 48;
+				retVal |= static_cast<std::uint64_t>(data[index + 7]) << 56;
+			}
+			else
+			{
+				retVal = static_cast<std::uint64_t>(data[index]) << 56;
+				retVal |= static_cast<std::uint64_t>(data[index + 1]) << 48;
+				retVal |= static_cast<std::uint64_t>(data[index + 2]) << 40;
+				retVal |= static_cast<std::uint64_t>(data[index + 3]) << 32;
+				retVal |= static_cast<std::uint64_t>(data[index + 4]) << 24;
+				retVal |= static_cast<std::uint64_t>(data[index + 5]) << 16;
+				retVal |= static_cast<std::uint64_t>(data[index + 6]) << 8;
+				retVal |= data[index + 7];
+			}
+		}
+		return retVal;
+	}
+	bool isobus::CANMessage::get_bool_at(const std::size_t byteIndex, const std::uint8_t bitIndex, const std::uint8_t length)
+	{
+		bool retVal = false;
+		if (length <= 8 - bitIndex)
+		{
+			uint8_t mask = ((1 << length) - 1) << bitIndex;
+			retVal = (get_uint8_at(byteIndex) & mask) == mask;
+		}
+		return retVal;
+	}
+
 } // namespace isobus


### PR DESCRIPTION
Allows reading of the following types directly from `CANMessage` object using dedicated functions:
- uint8_t 
- uint16_t
- uint32_t
- uint64_t
- bool

Also adjusted the `process_rx_message` in `VirtualTerminalClient` to use these functions already.

Closes #137 