### PR TITLE
[VT]: Fix accessing a u24 as a u32 when parsing VT NACK

### DIFF
--- a/isobus/include/isobus/isobus/can_message.hpp
+++ b/isobus/include/isobus/isobus/can_message.hpp
@@ -91,6 +91,14 @@ namespace isobus
 		/// @return The 16-bit unsigned integer
 		std::uint16_t get_uint16_at(const std::size_t index, const ByteFormat format = ByteFormat::LittleEndian);
 
+		/// @brief Get a right-aligned 24-bit integer from the buffer (returned as a uint32_t) at a specific index.
+		/// A 24-bit number can hold a value between 0 and 16,777,215.
+		/// @details This function will return the 3 bytes at the specified index in the buffer.
+		/// @param[in] index The index to get the 24-bit unsigned integer from
+		/// @param[in] format The byte format to use when reading the integer
+		/// @return The 24-bit unsigned integer, right aligned into a uint32_t
+		std::uint32_t get_uint24_at(const std::size_t index, const ByteFormat format = ByteFormat::LittleEndian);
+
 		/// @brief Get a 32-bit unsigned integer from the buffer at a specific index.
 		/// A 32-bit unsigned integer can hold a value between 0 and 4294967295.
 		/// @details This function will return the 4 bytes at the specified index in the buffer.

--- a/isobus/src/can_message.cpp
+++ b/isobus/src/can_message.cpp
@@ -84,6 +84,24 @@ namespace isobus
 		return retVal;
 	}
 
+	std::uint32_t CANMessage::get_uint24_at(const std::size_t index, const ByteFormat format)
+	{
+		std::uint32_t retVal;
+		if (ByteFormat::LittleEndian == format)
+		{
+			retVal = data.at(index);
+			retVal |= static_cast<std::uint32_t>(data.at(index + 1)) << 8;
+			retVal |= static_cast<std::uint32_t>(data.at(index + 2)) << 16;
+		}
+		else
+		{
+			retVal = static_cast<std::uint32_t>(data.at(index + 2)) << 16;
+			retVal |= static_cast<std::uint32_t>(data.at(index + 1)) << 8;
+			retVal |= data.at(index + 2);
+		}
+		return retVal;
+	}
+
 	std::uint32_t CANMessage::get_uint32_at(const std::size_t index, const ByteFormat format)
 	{
 		std::uint32_t retVal;

--- a/isobus/src/isobus_virtual_terminal_client.cpp
+++ b/isobus/src/isobus_virtual_terminal_client.cpp
@@ -2586,7 +2586,7 @@ namespace isobus
 				{
 					if (AcknowledgementType::Negative == static_cast<AcknowledgementType>(message->get_uint8_at(0)))
 					{
-						std::uint32_t targetParameterGroupNumber = message->get_uint32_at(5, CANMessage::ByteFormat::BigEndian);
+						std::uint32_t targetParameterGroupNumber = message->get_uint24_at(5);
 						if (static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal) == targetParameterGroupNumber)
 						{
 							CANStackLogger::CAN_stack_log("[VT]: The VT Server is NACK-ing our VT messages. Disconnecting.");


### PR DESCRIPTION
When we were getting NACKs it was causing a crash due to accessing index 8 after converting to the named read functions.