### PR TITLE
[Meta]: Rename library SystemTiming to Utility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,7 @@ if(BUILD_TESTING)
       unit_tests
       PRIVATE GTest::gtest_main ${PROJECT_NAME}::Isobus
               ${PROJECT_NAME}::HardwareIntegration
-              ${PROJECT_NAME}::SystemTiming)
+              ${PROJECT_NAME}::Utility)
 
     include(GoogleTest)
     gtest_discover_tests(unit_tests name_tests identifier_tests)
@@ -110,7 +110,7 @@ if(BUILD_TESTING)
 endif()
 
 install(
-  TARGETS Isobus SystemTiming HardwareIntegration
+  TARGETS Isobus Utility HardwareIntegration
   EXPORT isobusTargets
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib

--- a/examples/diagnostic_protocol/CMakeLists.txt
+++ b/examples/diagnostic_protocol/CMakeLists.txt
@@ -11,4 +11,4 @@ add_executable(DiagnosticProtocolExampleTarget main.cpp)
 target_link_libraries(
   DiagnosticProtocolExampleTarget
   PRIVATE isobus::Isobus isobus::HardwareIntegration Threads::Threads
-          isobus::SystemTiming)
+          isobus::Utility)

--- a/examples/nmea2000/CMakeLists.txt
+++ b/examples/nmea2000/CMakeLists.txt
@@ -10,4 +10,4 @@ add_executable(NMEA2KExampleTarget main.cpp)
 
 target_link_libraries(
   NMEA2KExampleTarget PRIVATE isobus::Isobus isobus::HardwareIntegration
-                              Threads::Threads isobus::SystemTiming)
+                              Threads::Threads isobus::Utility)

--- a/examples/pgn_requests/CMakeLists.txt
+++ b/examples/pgn_requests/CMakeLists.txt
@@ -10,4 +10,4 @@ find_package(Threads REQUIRED)
 add_executable(PGNRequestExampleTarget main.cpp)
 target_link_libraries(
   PGNRequestExampleTarget PRIVATE isobus::Isobus isobus::HardwareIntegration
-                                  Threads::Threads isobus::SystemTiming)
+                                  Threads::Threads isobus::Utility)

--- a/examples/transport_layer/CMakeLists.txt
+++ b/examples/transport_layer/CMakeLists.txt
@@ -11,4 +11,4 @@ add_executable(TransportLayerExampleTarget main.cpp)
 target_link_libraries(
   TransportLayerExampleTarget
   PRIVATE isobus::Isobus isobus::HardwareIntegration Threads::Threads
-          isobus::SystemTiming)
+          isobus::Utility)

--- a/examples/vt_aux_n/CMakeLists.txt
+++ b/examples/vt_aux_n/CMakeLists.txt
@@ -10,7 +10,7 @@ find_package(Threads REQUIRED)
 add_executable(VTAuxNExample main.cpp object_pool_ids.h)
 target_link_libraries(
   VTAuxNExample PRIVATE isobus::Isobus isobus::HardwareIntegration
-                           Threads::Threads isobus::SystemTiming)
+                           Threads::Threads isobus::Utility)
 
 add_custom_command(
   TARGET VTAuxNExample

--- a/examples/vt_version_3_object_pool/CMakeLists.txt
+++ b/examples/vt_version_3_object_pool/CMakeLists.txt
@@ -10,7 +10,7 @@ find_package(Threads REQUIRED)
 add_executable(VT3ExampleTarget main.cpp objectPoolObjects.h)
 target_link_libraries(
   VT3ExampleTarget PRIVATE isobus::Isobus isobus::HardwareIntegration
-                           Threads::Threads isobus::SystemTiming)
+                           Threads::Threads isobus::Utility)
 
 add_custom_command(
   TARGET VT3ExampleTarget

--- a/hardware_integration/CMakeLists.txt
+++ b/hardware_integration/CMakeLists.txt
@@ -61,7 +61,7 @@ prepend(HARDWARE_INTEGRATION_INCLUDE ${HARDWARE_INTEGRATION_INCLUDE_DIR}
 add_library(HardwareIntegration ${HARDWARE_INTEGRATION_SRC}
                                 ${HARDWARE_INTEGRATION_INCLUDE})
 add_library(${PROJECT_NAME}::HardwareIntegration ALIAS HardwareIntegration)
-target_link_libraries(HardwareIntegration PRIVATE ${PROJECT_NAME}::SystemTiming
+target_link_libraries(HardwareIntegration PRIVATE ${PROJECT_NAME}::Utility
                                                   ${PROJECT_NAME}::Isobus)
 
 if("WindowsPCANBasic" IN_LIST CAN_DRIVER)

--- a/isobus/CMakeLists.txt
+++ b/isobus/CMakeLists.txt
@@ -73,7 +73,7 @@ target_include_directories(
   Isobus PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
                 $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
-target_link_libraries(Isobus PRIVATE ${PROJECT_NAME}::SystemTiming)
+target_link_libraries(Isobus PRIVATE ${PROJECT_NAME}::Utility)
 
 install(
   TARGETS Isobus

--- a/sphinx/source/Tutorials/Virtual Terminal Basics.rst
+++ b/sphinx/source/Tutorials/Virtual Terminal Basics.rst
@@ -200,7 +200,7 @@ This can be used to read from some external device if needed in segments or just
 
 .. note::
 
-    Since we are now using a function in the "isobus/utility" folder to load this IOP file, we will also need to link to the CAN stack's utility library in our CMakeLists.txt file. You can do this by adding :code:`isobus::SystemTiming` to your :code:`target_link_libraries` statement. We'll also need to add some CMake to move the IOP file to the binary location, so that when the program is compiled, the IOP will end up in a location accessable to your program.
+    Since we are now using a function in the "isobus/utility" folder to load this IOP file, we will also need to link to the CAN stack's utility library in our CMakeLists.txt file. You can do this by adding :code:`isobus::Utility` to your :code:`target_link_libraries` statement. We'll also need to add some CMake to move the IOP file to the binary location, so that when the program is compiled, the IOP will end up in a location accessable to your program.
 
 	We'll go over the full CMake closer to the end of this tutorial.
 
@@ -522,11 +522,11 @@ Looking "ISOBUS Hello World" we had this next:
 
 	target_link_libraries(isobus_hello_world PRIVATE isobus::Isobus isobus::HardwareIntegration Threads::Threads)
 
-But like we mentioned earlier, we're now using a function (the IOP file reader) in the isobus utility library called "SystemTiming", so we need to link that too:
+But like we mentioned earlier, we're now using a function (the IOP file reader) in the isobus utility library called "Utility", so we need to link that too:
 
 .. code-block:: c++
 
-	target_link_libraries(isobus_hello_world PRIVATE isobus::Isobus isobus::HardwareIntegration isobus::SystemTiming Threads::Threads)
+	target_link_libraries(isobus_hello_world PRIVATE isobus::Isobus isobus::HardwareIntegration isobus::Utility Threads::Threads)
 
 We also want to move our IOP file to be in the same folder as the executable after it's built, so that it can locate it.
 We can do that with this little handy bit of CMake:

--- a/utility/CMakeLists.txt
+++ b/utility/CMakeLists.txt
@@ -4,37 +4,37 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Set source and include directories
-set(SYSTEM_TIMING_SRC_DIR "src")
-set(SYSTEM_TIMING_INCLUDE_DIR "include/isobus/utility")
+set(UTILITY_SRC_DIR "src")
+set(UTILITY_INCLUDE_DIR "include/isobus/utility")
 
 # Set source files
-set(SYSTEM_TIMING_SRC "system_timing.cpp" "processing_flags.cpp"
+set(UTILITY_SRC "system_timing.cpp" "processing_flags.cpp"
                       "iop_file_interface.cpp")
 
 # Prepend the source directory path to all the source files
-prepend(SYSTEM_TIMING_SRC ${SYSTEM_TIMING_SRC_DIR} ${SYSTEM_TIMING_SRC})
+prepend(UTILITY_SRC ${UTILITY_SRC_DIR} ${UTILITY_SRC})
 
 # Set the include files
-set(SYSTEM_TIMING_INCLUDE "system_timing.hpp" "processing_flags.hpp"
+set(UTILITY_INCLUDE "system_timing.hpp" "processing_flags.hpp"
                           "iop_file_interface.hpp" "to_string.hpp")
 
 # Prepend the include directory path to all the include files
-prepend(SYSTEM_TIMING_INCLUDE ${SYSTEM_TIMING_INCLUDE_DIR}
-        ${SYSTEM_TIMING_INCLUDE})
+prepend(UTILITY_INCLUDE ${UTILITY_INCLUDE_DIR}
+        ${UTILITY_INCLUDE})
 
 # Create the library from the source and include files
-add_library(SystemTiming ${SYSTEM_TIMING_SRC} ${SYSTEM_TIMING_INCLUDE})
-add_library(${PROJECT_NAME}::SystemTiming ALIAS SystemTiming)
+add_library(Utility ${UTILITY_SRC} ${UTILITY_INCLUDE})
+add_library(${PROJECT_NAME}::Utility ALIAS Utility)
 
 # Specify the include directory to be exported for other moduels to use. The
 # PUBLIC keyword here allows other libraries or exectuables to link to this
 # library and use its functionality.
 target_include_directories(
-  SystemTiming PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  Utility PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
                       $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
 install(
-  TARGETS SystemTiming
+  TARGETS Utility
   EXPORT IsobusTargets
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib


### PR DESCRIPTION
This breaks all current applications importing the current "isobus::SystemTiming". Their fix would be to change it to "isobus::Utility".

I feel like this change would otherwise be due sooner or later, since the current library "SystemTiming" already includes more than only the system timing, but change the naming leads to breaking applications so I think we should do this before any release.

I'm also open for other name suggestions like "SystemUtility", etc