### PR TITLE
[Meta]: Small QOL updates to Github actions files

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -2,9 +2,9 @@ name: CMake
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
@@ -18,20 +18,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - name: Configure CMake
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBUILD_EXAMPLES=ON
+      - name: Configure CMake
+        # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+        # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBUILD_EXAMPLES=ON -DBUILD_TESTING=ON -DCAN_DRIVER=SocketCAN
 
-    - name: Build
-      # Build your program with the given configuration
-      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+      - name: Build
+        # Build your program with the given configuration
+        run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
 
-    - name: Test
-      working-directory: ${{github.workspace}}/build
-      # Execute tests defined by the CMake configuration.  
-      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest -C ${{env.BUILD_TYPE}}
-      
+      - name: Test
+        working-directory: ${{github.workspace}}/build
+        # Execute tests defined by the CMake configuration.
+        # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+        run: ctest -C ${{env.BUILD_TYPE}}

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -9,6 +9,11 @@ jobs:
         uses: actions/checkout@v3
       - name: Run clang-format style check for C/C++/Protobuf programs.
         uses: jidicula/clang-format-action@v4.10.1
+        with:
+          # Some files can be excluded from the clang-format style check, like 3rd party driver files,
+          # as their licenses may not allow us to modify them, such as if they are LGPL licensed.
+          # The exclude-regex option can be used to exclude these files from the style check:
+          exclude-regex: ^.*(PCANBasic\.h|libusb\.h)$
   cmake-format:
     name: cmake-format style
     runs-on: ubuntu-latest

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -4,21 +4,11 @@ jobs:
   clang-format:
     name: clang-format style
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        path:
-          - "isobus"
-          - "socket_can"
-          - "examples"
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Run clang-format style check for C/C++/Protobuf programs.
-        uses: jidicula/clang-format-action@v4.9.0
-        with:
-          clang-format-version: "13"
-          check-path: ${{ matrix.path }}
-          fallback-style: "Google" # optional
+        uses: jidicula/clang-format-action@v4.10.1
   cmake-format:
     name: cmake-format style
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -37,8 +37,10 @@ cmake --build build
 
 ## Tests
 
-Tests are run with GTest. They can be invoked through ctest. Once the library is compiled (see above), navigate to the build directory to run tests.
+Tests are run with GTest. They can be invoked through ctest. Once the library is compiled, navigate to the build directory to run tests.
 ```
+cmake -S . -B build -DBUILD_TESTING=ON -DCAN_DRIVER=SocketCAN
+cmake --build build
 cd build
 ctest
 ```


### PR DESCRIPTION
- Updated clang-format linting action:
  - The `socket_can` matrix path is not yet there anymore and resulted into running clang-format in the whole repo instead. But this only took around 50 seconds so it's also acceptable to just run one clang-format linting action for the whole repo as it won't take too long and we wouldn't have the same problem again in the future.
  - Also removed some other properties as they were either default one or optional and wouldn't get used.
  - Bumped the action from 4.9.0 to 4.10.1
- Added `-DBUILD_TESTING=ON` to the cmake build action so the `ctest` job can actually run testing. (Also my vscode wanted to do some formatting on the `cmake.yml` file which I guess is fine as it looks more inline with the other action files now.)