### PR TITLE
[Core]: Fix the sonar blocker items

### DIFF
--- a/hardware_integration/src/can_hardware_interface.cpp
+++ b/hardware_integration/src/can_hardware_interface.cpp
@@ -377,7 +377,7 @@ void CANHardwareInterface::can_thread_function()
 
 		if (threadsStarted)
 		{
-			threadConditionVariable.wait(lMutex);
+			threadConditionVariable.wait(lMutex, [] { return true; }); // Always wake up
 
 			for (std::uint32_t i = 0; i < hardwareChannels.size(); i++)
 			{

--- a/isobus/include/isobus/isobus/can_network_manager.hpp
+++ b/isobus/include/isobus/isobus/can_network_manager.hpp
@@ -108,7 +108,7 @@ namespace isobus
 		/// @brief This is the main function used by the stack to receive CAN messages and add them to a queue.
 		/// @details This function is called by the stack itself when you call can_lib_process_rx_message.
 		/// @param[in] message The message to be received
-		void receive_can_message(CANMessage message);
+		void receive_can_message(CANMessage &message);
 
 		/// @brief The main update function for the network manager. Updates all protocols.
 		void update();

--- a/isobus/src/can_network_manager.cpp
+++ b/isobus/src/can_network_manager.cpp
@@ -164,7 +164,7 @@ namespace isobus
 		return retVal;
 	}
 
-	void CANNetworkManager::receive_can_message(CANMessage message)
+	void CANNetworkManager::receive_can_message(CANMessage &message)
 	{
 		if (initialized)
 		{


### PR DESCRIPTION
* Fixed issue in TP similar to the one I fixed in #141 
* Fixed a check where the scanner was worried about class slicing (but no slicing was probably happening?) 
* Add a condition to the can thread's wait. We really just want it to always wake up, as there are tons of things that trigger that thread but guidelines say we should have some condition.

Putting this in as a draft initially to see if I can throw in a few more improvements and to verify that it actually passes the sonar check