### PR TITLE
[Meta]: Add missing tests directory parameter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,9 @@ endif()
 # Make CTest available which adds the option BUILD_TESTING
 include(CTest)
 if(BUILD_TESTING)
+  # Set --coverage flag for gcovr (SonarCloud)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
+
   find_package(GTest QUIET)
   if(NOT GTest_FOUND)
     # Find GoogleTest

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,6 +7,7 @@ sonar.organization=isobus-plusplus
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=isobus,examples,hardware_integration,utility
+sonar.tests=test
 
 # Exclude some files from the analysis.
 sonar.exclusions=**/PCANBasic.h


### PR DESCRIPTION
I missed this parameter in #155 I'm afraid. There were no coverage results in [this action](https://github.com/ad3154/ISO11783-CAN-Stack/runs/10912856878). And I guess we won't find out if this fixes the missing coverage results either without merging it... Or is there any other way I'm missing here?