### PR TITLE
[Core]: Add virtual CAN driver plugin with unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,9 +18,16 @@ if(NOT CMAKE_C_STANDARD)
   set(CMAKE_C_STANDARD 99)
 endif()
 
-# Default to C++11
+# Default to C++14
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
+endif()
+
+# Make CTest available which adds the option BUILD_TESTING
+include(CTest)
+if(BUILD_TESTING)
+  # Set --coverage flag for gcovr (SonarCloud)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
@@ -62,12 +69,7 @@ if(BUILD_EXAMPLES)
   add_subdirectory("examples/vt_aux_n")
 endif()
 
-# Make CTest available which adds the option BUILD_TESTING
-include(CTest)
 if(BUILD_TESTING)
-  # Set --coverage flag for gcovr (SonarCloud)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
-
   find_package(GTest QUIET)
   if(NOT GTest_FOUND)
     # Find GoogleTest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,20 +100,24 @@ if(BUILD_TESTING)
     add_library(GTest::gtest_main ALIAS GTest::Main)
   endif()
 
-  if("SocketCAN" IN_LIST CAN_DRIVER)
-    add_executable(
-      unit_tests
-      test/address_claim_test.cpp test/test_CAN_glue.cpp
-      test/identifier_tests.cpp test/dm_13_tests.cpp
-      test/core_network_management_tests.cpp)
-    target_link_libraries(
-      unit_tests
-      PRIVATE GTest::gtest_main ${PROJECT_NAME}::Isobus
-              ${PROJECT_NAME}::HardwareIntegration ${PROJECT_NAME}::Utility)
+  # Set test source files
+  set(TEST_SRC
+      test/test_CAN_glue.cpp test/identifier_tests.cpp test/dm_13_tests.cpp
+      test/core_network_management_tests.cpp test/virtual_can_plugin_tests.cpp)
 
-    include(GoogleTest)
-    gtest_discover_tests(unit_tests name_tests identifier_tests)
+  # Add SocketCAN specific tests
+  if("SocketCAN" IN_LIST CAN_DRIVER)
+    list(APPEND TEST_SRC test/address_claim_test.cpp)
   endif()
+
+  add_executable(unit_tests ${TEST_SRC})
+  target_link_libraries(
+    unit_tests
+    PRIVATE GTest::gtest_main ${PROJECT_NAME}::Isobus
+            ${PROJECT_NAME}::HardwareIntegration ${PROJECT_NAME}::Utility)
+
+  include(GoogleTest)
+  gtest_discover_tests(unit_tests name_tests identifier_tests)
 endif()
 
 install(

--- a/hardware_integration/CMakeLists.txt
+++ b/hardware_integration/CMakeLists.txt
@@ -20,6 +20,11 @@ if(NOT CAN_DRIVER)
   )
 endif()
 
+if(BUILD_TESTING AND NOT "VirtualCAN" IN_LIST CAN_DRIVER)
+  message(STATUS "Including VirtualCAN driver for testing.")
+  list(APPEND CAN_DRIVER "VirtualCAN")
+endif()
+
 # Set the source files
 set(HARDWARE_INTEGRATION_SRC "can_hardware_interface.cpp")
 
@@ -35,6 +40,10 @@ endif()
 if("WindowsPCANBasic" IN_LIST CAN_DRIVER)
   list(APPEND HARDWARE_INTEGRATION_SRC "pcan_basic_windows_plugin.cpp")
   list(APPEND HARDWARE_INTEGRATION_INCLUDE "pcan_basic_windows_plugin.hpp")
+endif()
+if("VirtualCAN" IN_LIST CAN_DRIVER)
+  list(APPEND HARDWARE_INTEGRATION_SRC "virtual_can_plugin.cpp")
+  list(APPEND HARDWARE_INTEGRATION_INCLUDE "virtual_can_plugin.hpp")
 endif()
 if("TWAI" IN_LIST CAN_DRIVER)
   list(APPEND HARDWARE_INTEGRATION_SRC "twai_plugin.cpp")

--- a/hardware_integration/include/isobus/hardware_integration/virtual_can_plugin.hpp
+++ b/hardware_integration/include/isobus/hardware_integration/virtual_can_plugin.hpp
@@ -1,0 +1,85 @@
+//================================================================================================
+/// @file virtual_can_plugin.hpp
+///
+/// @brief An OS and hardware independent virtual CAN interface driver for testing purposes.
+/// Any instance connecting to the same channel and in the same process will be able to communicate.
+/// @author Daan Steenbergen
+///
+/// @copyright 2023 Adrian Del Grosso
+//================================================================================================
+#ifndef VIRTUAL_CAN_PLUGIN_HPP
+#define VIRTUAL_CAN_PLUGIN_HPP
+
+#include "isobus/hardware_integration/can_hardware_plugin.hpp"
+#include "isobus/isobus/can_frame.hpp"
+#include "isobus/isobus/can_hardware_abstraction.hpp"
+
+#include <condition_variable>
+#include <deque>
+#include <map>
+#include <mutex>
+#include <string>
+#include <vector>
+
+//================================================================================================
+/// @class VirtualCANPlugin
+///
+/// @brief An OS and hardware independent virtual CAN interface driver for testing purposes.
+/// @details Any instance connecting to the same channel and in the same process can communicate.
+/// However, this plugin does not implement rate limiting or any other CAN bus specific features,
+/// like prioritization under heavy load.
+//================================================================================================
+class VirtualCANPlugin : public CANHardwarePlugin
+{
+public:
+	/// @brief Constructor for the virtual CAN driver
+	/// @param[in] channel The virtual channel name to use. Free to choose.
+	/// @param[in] receiveOwnMessages If `true`, the driver will receive its own messages.
+	VirtualCANPlugin(const std::string channel = "", const bool receiveOwnMessages = false);
+
+	/// @brief Returns if the socket connection is valid
+	/// @returns `true` if connected, `false` if not connected
+	bool get_is_valid() const override;
+
+	/// @brief Returns the assigned virtual channel name
+	/// @returns The virtual channel name the bus is assigned to
+	std::string get_channel_name() const;
+
+	/// @brief Closes the socket
+	void close() override;
+
+	/// @brief Connects to the socket
+	void open() override;
+
+	/// @brief Returns a frame from the hardware (synchronous), or `false` if no frame can be read.
+	/// @param[in, out] canFrame The CAN frame that was read
+	/// @returns `true` if a CAN frame was read, otherwise `false`
+	bool read_frame(isobus::HardwareInterfaceCANFrame &canFrame) override;
+
+	/// @brief Writes a frame to the bus (synchronous)
+	/// @param[in] canFrame The frame to write to the bus
+	/// @returns `true` if the frame was written, otherwise `false`
+	bool write_frame(const isobus::HardwareInterfaceCANFrame &canFrame) override;
+
+private:
+	/// @brief A struct holding information about a virtual CAN device
+	struct VirtualDevice
+	{
+		std::deque<isobus::HardwareInterfaceCANFrame> queue; ///< A queue of CAN frames
+		VirtualCANPlugin *owner; ///< A pointer to the owner of this device
+	};
+
+	static constexpr size_t MAX_QUEUE_SIZE = 1000; ///< The maximum size of the queue, mostly arbitrary
+
+	static std::mutex mutex; ///< Mutex to access channels and queues for thread safety
+	static std::map<std::string, std::vector<VirtualDevice>> channels; ///< A channel is a vector of devices
+
+	const std::string channel; ///< The virtual channel name
+	const bool receiveOwnMessages; ///< If `true`, the driver will receive its own messages
+
+	std::condition_variable condition; ///< A condition variable to wake us up when a frame is received
+	VirtualDevice *ourDevice; ///< A pointer to the virtual device of this instance
+	bool running; ///< If `true`, the driver is running
+};
+
+#endif // VIRTUAL_CAN_PLUGIN_HPP

--- a/hardware_integration/src/virtual_can_plugin.cpp
+++ b/hardware_integration/src/virtual_can_plugin.cpp
@@ -1,0 +1,73 @@
+//================================================================================================
+/// @file virtual_can_plugin.cpp
+///
+/// @brief A driver for a virtual CAN bus that can be used for (automated) testing.
+/// @author Daan Steenbergen
+///
+/// @copyright 2023 Adrian Del Grosso
+//================================================================================================
+#include "isobus/hardware_integration/virtual_can_plugin.hpp"
+
+std::mutex VirtualCANPlugin::mutex;
+std::map<std::string, std::vector<VirtualCANPlugin::VirtualDevice>> VirtualCANPlugin::channels;
+
+VirtualCANPlugin::VirtualCANPlugin(const std::string channel, const bool receiveOwnMessages) :
+  channel(channel),
+  receiveOwnMessages(receiveOwnMessages)
+{
+	const std::lock_guard<std::mutex> lock(mutex);
+	channels[channel].push_back({ {}, this });
+	ourDevice = &channels[channel].back();
+}
+
+bool VirtualCANPlugin::get_is_valid() const
+{
+	return true;
+}
+
+std::string VirtualCANPlugin::get_channel_name() const
+{
+	return channel;
+}
+
+void VirtualCANPlugin::open()
+{
+	running = true;
+}
+
+void VirtualCANPlugin::close()
+{
+	running = false;
+}
+
+bool VirtualCANPlugin::write_frame(const isobus::HardwareInterfaceCANFrame &canFrame)
+{
+	bool retVal = false;
+	const std::lock_guard<std::mutex> lock(mutex);
+	for (VirtualDevice &device : channels[channel])
+	{
+		if (device.queue.size() < MAX_QUEUE_SIZE)
+		{
+			if (receiveOwnMessages || device.owner != this)
+			{
+				device.queue.push_back(canFrame);
+				device.owner->condition.notify_one();
+				retVal = true;
+			}
+		}
+	}
+	return retVal;
+}
+
+bool VirtualCANPlugin::read_frame(isobus::HardwareInterfaceCANFrame &canFrame)
+{
+	std::unique_lock<std::mutex> lock(mutex);
+	condition.wait(lock, [this] { return !running || !ourDevice->queue.empty(); });
+	if (!ourDevice->queue.empty())
+	{
+		canFrame = ourDevice->queue.front();
+		ourDevice->queue.pop_front();
+		return true;
+	}
+	return false;
+}

--- a/test/virtual_can_plugin_tests.cpp
+++ b/test/virtual_can_plugin_tests.cpp
@@ -1,0 +1,72 @@
+#include <gtest/gtest.h>
+
+#include "isobus/hardware_integration/virtual_can_plugin.hpp"
+
+using namespace isobus;
+
+TEST(VIRTUAL_CAN_PLUGIN_TESTS, ReceivesOwnMessages)
+{
+	VirtualCANPlugin testPlugin("", true);
+
+	HardwareInterfaceCANFrame sentFrame;
+	sentFrame.identifier = 0x18FFA227;
+	sentFrame.isExtendedFrame = true;
+	sentFrame.data[0] = 0x01;
+	sentFrame.data[1] = 0x02;
+	sentFrame.data[2] = 0x03;
+	sentFrame.data[3] = 0x04;
+	sentFrame.data[4] = 0x05;
+	sentFrame.data[5] = 0x06;
+	sentFrame.data[6] = 0x07;
+	sentFrame.data[7] = 0x08;
+	sentFrame.dataLength = 8;
+	testPlugin.write_frame(sentFrame);
+
+	HardwareInterfaceCANFrame receiveFrame;
+	EXPECT_TRUE(testPlugin.read_frame(receiveFrame));
+	EXPECT_EQ(receiveFrame.identifier, 0x18FFA227);
+	EXPECT_EQ(receiveFrame.isExtendedFrame, true);
+	EXPECT_EQ(receiveFrame.data[0], 0x01);
+	EXPECT_EQ(receiveFrame.data[1], 0x02);
+	EXPECT_EQ(receiveFrame.data[2], 0x03);
+	EXPECT_EQ(receiveFrame.data[3], 0x04);
+	EXPECT_EQ(receiveFrame.data[4], 0x05);
+	EXPECT_EQ(receiveFrame.data[5], 0x06);
+	EXPECT_EQ(receiveFrame.data[6], 0x07);
+	EXPECT_EQ(receiveFrame.data[7], 0x08);
+	EXPECT_EQ(receiveFrame.dataLength, 8);
+}
+
+TEST(VIRTUAL_CAN_PLUGIN_TESTS, OtherReceivesMessage)
+{
+	VirtualCANPlugin testPlugin;
+	VirtualCANPlugin otherPlugin;
+
+	HardwareInterfaceCANFrame sentFrame;
+	sentFrame.identifier = 0x18FFA227;
+	sentFrame.isExtendedFrame = true;
+	sentFrame.data[0] = 0x01;
+	sentFrame.data[1] = 0x02;
+	sentFrame.data[2] = 0x03;
+	sentFrame.data[3] = 0x04;
+	sentFrame.data[4] = 0x05;
+	sentFrame.data[5] = 0x06;
+	sentFrame.data[6] = 0x07;
+	sentFrame.data[7] = 0x08;
+	sentFrame.dataLength = 8;
+	testPlugin.write_frame(sentFrame);
+
+	HardwareInterfaceCANFrame receiveFrame;
+	EXPECT_TRUE(otherPlugin.read_frame(receiveFrame));
+	EXPECT_EQ(receiveFrame.identifier, 0x18FFA227);
+	EXPECT_EQ(receiveFrame.isExtendedFrame, true);
+	EXPECT_EQ(receiveFrame.data[0], 0x01);
+	EXPECT_EQ(receiveFrame.data[1], 0x02);
+	EXPECT_EQ(receiveFrame.data[2], 0x03);
+	EXPECT_EQ(receiveFrame.data[3], 0x04);
+	EXPECT_EQ(receiveFrame.data[4], 0x05);
+	EXPECT_EQ(receiveFrame.data[5], 0x06);
+	EXPECT_EQ(receiveFrame.data[6], 0x07);
+	EXPECT_EQ(receiveFrame.data[7], 0x08);
+	EXPECT_EQ(receiveFrame.dataLength, 8);
+}


### PR DESCRIPTION
### What's new:
- Added VirtualCANPlugin to communicate with ourself in testing environments.
- Some basic unit tests for the VirtualCANPlugin.
- Modified building of GTest such that it will still compile the tests that don't rely on SocketCAN when SocketCAN is not available.
- Moved setting of `--coverage` flag to CXX compiler up so SonerCloud will hopefully now track the other files for code coverage as well.

TLDR: I just wrote my first C++ unit test 😄 