### PR TITLE
[Meta]: Examples with automatic driver selection and less global variables

### DIFF
--- a/examples/diagnostic_protocol/CMakeLists.txt
+++ b/examples/diagnostic_protocol/CMakeLists.txt
@@ -1,7 +1,9 @@
 cmake_minimum_required(VERSION 3.16)
 project(diagnostic_protocol_example)
+
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 if(NOT BUILD_EXAMPLES)
   find_package(isobus REQUIRED)
 endif()

--- a/examples/diagnostic_protocol/main.cpp
+++ b/examples/diagnostic_protocol/main.cpp
@@ -12,7 +12,7 @@
 
 using namespace std;
 
-void signal_handler(int signum)
+void signal_handler(int)
 {
 	isobus::DiagnosticProtocol::deassign_all_diagnostic_protocol_to_internal_control_functions();
 	CANHardwareInterface::stop();

--- a/examples/diagnostic_protocol/main.cpp
+++ b/examples/diagnostic_protocol/main.cpp
@@ -53,7 +53,7 @@ int main()
 
 	if ((!CANHardwareInterface::start()) || (!canDriver->get_is_valid()))
 	{
-		std::cout << "Failed to start hardware interface. A CAN driver might be invalid." << std::endl;
+		std::cout << "Failed to start hardware interface. The CAN driver might be invalid." << std::endl;
 		return -2;
 	}
 

--- a/examples/diagnostic_protocol/main.cpp
+++ b/examples/diagnostic_protocol/main.cpp
@@ -1,3 +1,4 @@
+#include "isobus/hardware_integration/available_can_drivers.hpp"
 #include "isobus/hardware_integration/can_hardware_interface.hpp"
 #include "isobus/hardware_integration/socket_can_interface.hpp"
 #include "isobus/isobus/can_general_parameter_group_numbers.hpp"
@@ -8,14 +9,6 @@
 #include <iostream>
 #include <iterator>
 #include <memory>
-
-#ifdef WIN32
-#include "isobus/hardware_integration/pcan_basic_windows_plugin.hpp"
-static PCANBasicWindowsPlugin canDriver(PCAN_USBBUS1);
-#else
-#include "isobus/hardware_integration/socket_can_interface.hpp"
-static SocketCANInterface canDriver("can0");
-#endif
 
 static std::shared_ptr<isobus::InternalControlFunction> TestInternalECU = nullptr;
 
@@ -38,14 +31,32 @@ void raw_can_glue(isobus::HardwareInterfaceCANFrame &rawFrame, void *parentPoint
 	isobus::CANNetworkManager::CANNetwork.can_lib_process_rx_message(rawFrame, parentPointer);
 }
 
-void setup()
+int main()
 {
-	CANHardwareInterface::set_number_of_can_channels(1);
-	CANHardwareInterface::assign_can_channel_frame_handler(0, &canDriver);
+	std::signal(SIGINT, signal_handler);
 
-	if ((!CANHardwareInterface::start()) || (!canDriver.get_is_valid()))
+	std::shared_ptr<CANHardwarePlugin> canDriver = nullptr;
+#if defined(ISOBUS_SOCKETCAN_AVAILABLE)
+	canDriver = std::make_shared<SocketCANInterface>("can0");
+#elif defined(ISOBUS_WINDOWSPCANBASIC_AVAILABLE)
+	canDriver = std::make_shared<PCANBasicWindowsPlugin>(PCAN_USBBUS1);
+#elif defined(ISOBUS_WINDOWSINNOMAKERUSB2CAN_AVAILABLE)
+	canDriver = std::make_shared<InnoMakerUSB2CANWindowsPlugin>(0); // CAN0
+#endif
+	if (nullptr == canDriver)
+	{
+		std::cout << "Unable to find a CAN driver. Please make sure you have one of the above drivers installed with the library." << std::endl;
+		std::cout << "If you want to use a different driver, please add it to the list above." << std::endl;
+		return -1;
+	}
+
+	CANHardwareInterface::set_number_of_can_channels(1);
+	CANHardwareInterface::assign_can_channel_frame_handler(0, canDriver);
+
+	if ((!CANHardwareInterface::start()) || (!canDriver->get_is_valid()))
 	{
 		std::cout << "Failed to connect to the socket. The interface might be down." << std::endl;
+		return -2;
 	}
 
 	CANHardwareInterface::add_can_lib_update_callback(update_CAN_network, nullptr);
@@ -71,16 +82,7 @@ void setup()
 
 	isobus::DiagnosticProtocol::assign_diagnostic_protocol_to_internal_control_function(TestInternalECU);
 
-	std::signal(SIGINT, signal_handler);
-}
-
-int main()
-{
-	isobus::DiagnosticProtocol *diagnosticProtocol;
-
-	setup();
-
-	diagnosticProtocol = isobus::DiagnosticProtocol::get_diagnostic_protocol_by_internal_control_function(TestInternalECU);
+	isobus::DiagnosticProtocol *diagnosticProtocol = isobus::DiagnosticProtocol::get_diagnostic_protocol_by_internal_control_function(TestInternalECU);
 
 	// Make a few test DTCs
 	isobus::DiagnosticProtocol::DiagnosticTroubleCode testDTC1(1234, isobus::DiagnosticProtocol::FailureModeIdentifier::ConditionExists, isobus::DiagnosticProtocol::LampStatus::None);

--- a/examples/nmea2000/CMakeLists.txt
+++ b/examples/nmea2000/CMakeLists.txt
@@ -1,7 +1,9 @@
 cmake_minimum_required(VERSION 3.16)
 project(nmea2000_example)
+
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 if(NOT BUILD_EXAMPLES)
   find_package(isobus REQUIRED)
 endif()

--- a/examples/nmea2000/main.cpp
+++ b/examples/nmea2000/main.cpp
@@ -34,7 +34,7 @@ void nmea2k_transmit_complete_callback(std::uint32_t parameterGroupNumber,
 	}
 }
 
-void signal_handler(int signum)
+void signal_handler(int)
 {
 	CANHardwareInterface::stop();
 	isobus::FastPacketProtocol::Protocol.remove_multipacket_message_callback(0x1F001, nmea2k_callback, nullptr);

--- a/examples/nmea2000/main.cpp
+++ b/examples/nmea2000/main.cpp
@@ -1,3 +1,4 @@
+#include "isobus/hardware_integration/available_can_drivers.hpp"
 #include "isobus/hardware_integration/can_hardware_interface.hpp"
 #include "isobus/hardware_integration/socket_can_interface.hpp"
 #include "isobus/isobus/can_general_parameter_group_numbers.hpp"
@@ -8,14 +9,6 @@
 #include <iostream>
 #include <iterator>
 #include <memory>
-
-#ifdef WIN32
-#include "isobus/hardware_integration/pcan_basic_windows_plugin.hpp"
-static PCANBasicWindowsPlugin canDriver(PCAN_USBBUS1);
-#else
-#include "isobus/hardware_integration/socket_can_interface.hpp"
-static SocketCANInterface canDriver("can0");
-#endif
 
 static std::shared_ptr<isobus::InternalControlFunction> TestInternalECU = nullptr;
 
@@ -60,16 +53,33 @@ void raw_can_glue(isobus::HardwareInterfaceCANFrame &rawFrame, void *parentPoint
 	isobus::CANNetworkManager::CANNetwork.can_lib_process_rx_message(rawFrame, parentPointer);
 }
 
-void setup()
+int main()
 {
-	CANHardwareInterface::set_number_of_can_channels(1);
-	CANHardwareInterface::assign_can_channel_frame_handler(0, &canDriver);
+	std::signal(SIGINT, signal_handler);
 
-	if ((!CANHardwareInterface::start()) || (!canDriver.get_is_valid()))
+	std::shared_ptr<CANHardwarePlugin> canDriver = nullptr;
+#if defined(ISOBUS_SOCKETCAN_AVAILABLE)
+	canDriver = std::make_shared<SocketCANInterface>("can0");
+#elif defined(ISOBUS_WINDOWSPCANBASIC_AVAILABLE)
+	canDriver = std::make_shared<PCANBasicWindowsPlugin>(PCAN_USBBUS1);
+#elif defined(ISOBUS_WINDOWSINNOMAKERUSB2CAN_AVAILABLE)
+	canDriver = std::make_shared<InnoMakerUSB2CANWindowsPlugin>(0); // CAN0
+#endif
+	if (nullptr == canDriver)
 	{
-		std::cout << "Failed to connect to the socket. The interface might be down." << std::endl;
+		std::cout << "Unable to find a CAN driver. Please make sure you have one of the above drivers installed with the library." << std::endl;
+		std::cout << "If you want to use a different driver, please add it to the list above." << std::endl;
+		return -1;
 	}
 
+	CANHardwareInterface::set_number_of_can_channels(1);
+	CANHardwareInterface::assign_can_channel_frame_handler(0, canDriver);
+
+	if ((!CANHardwareInterface::start()) || (!canDriver->get_is_valid()))
+	{
+		std::cout << "Failed to connect to the socket. The interface might be down." << std::endl;
+		return -2;
+	}
 	CANHardwareInterface::add_can_lib_update_callback(update_CAN_network, nullptr);
 	CANHardwareInterface::add_raw_can_message_rx_callback(raw_can_glue, nullptr);
 
@@ -95,11 +105,6 @@ void setup()
 
 	std::this_thread::sleep_for(std::chrono::milliseconds(250)); // Wait to make sure our address was claimed
 
-	std::signal(SIGINT, signal_handler);
-}
-
-int main()
-{
 	constexpr std::uint8_t TEST_MESSAGE_LENGTH = 100;
 	std::uint8_t testMessageData[TEST_MESSAGE_LENGTH];
 
@@ -108,8 +113,6 @@ int main()
 	{
 		testMessageData[i] = i;
 	}
-
-	setup();
 
 	while (true)
 	{

--- a/examples/pgn_requests/CMakeLists.txt
+++ b/examples/pgn_requests/CMakeLists.txt
@@ -3,6 +3,7 @@ project(pgn_requests_example)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 if(NOT BUILD_EXAMPLES)
   find_package(isobus REQUIRED)
 endif()

--- a/examples/pgn_requests/main.cpp
+++ b/examples/pgn_requests/main.cpp
@@ -114,7 +114,7 @@ int main()
 
 	if ((!CANHardwareInterface::start()) || (!canDriver->get_is_valid()))
 	{
-		std::cout << "Failed to start hardware interface. A CAN driver might be invalid" << std::endl;
+		std::cout << "Failed to start hardware interface. The CAN driver might be invalid" << std::endl;
 		return -2;
 	}
 

--- a/examples/pgn_requests/main.cpp
+++ b/examples/pgn_requests/main.cpp
@@ -16,7 +16,7 @@ static isobus::ControlFunction *repetitionRateRequestor = nullptr;
 
 using namespace std;
 
-void signal_handler(int signum)
+void signal_handler(int)
 {
 	CANHardwareInterface::stop();
 	_exit(EXIT_FAILURE);

--- a/examples/transport_layer/CMakeLists.txt
+++ b/examples/transport_layer/CMakeLists.txt
@@ -3,6 +3,7 @@ project(transport_layer_example)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 if(NOT BUILD_EXAMPLES)
   find_package(isobus REQUIRED)
 endif()

--- a/examples/transport_layer/README.md
+++ b/examples/transport_layer/README.md
@@ -91,8 +91,9 @@ void raw_can_glue(isobus::HardwareInterfaceCANFrame &rawFrame, void *parentPoint
 	isobus::CANNetworkManager::CANNetwork.can_lib_process_rx_message(rawFrame, parentPointer);
 }
 
+std::shared_ptr<SocketCANInterface> canDriver = std::make_shared<SocketCANInterface>("can0");
 CANHardwareInterface::set_number_of_can_channels(1);
-CANHardwareInterface::assign_can_channel_frame_handler(0, "can0");
+CANHardwareInterface::assign_can_channel_frame_handler(0, canDriver);
 CANHardwareInterface::start();
 
 CANHardwareInterface::add_can_lib_update_callback(update_CAN_network, nullptr);

--- a/examples/transport_layer/main.cpp
+++ b/examples/transport_layer/main.cpp
@@ -17,7 +17,7 @@ static constexpr std::uint32_t ETP_TEST_SIZE = 2048;
 
 using namespace std;
 
-void signal_handler(int signum)
+void signal_handler(int)
 {
 	CANHardwareInterface::stop();
 	_exit(EXIT_FAILURE);

--- a/examples/transport_layer/main.cpp
+++ b/examples/transport_layer/main.cpp
@@ -12,10 +12,8 @@
 #include <iterator>
 #include <memory>
 
-std::uint8_t *TPTestBuffer = nullptr;
-std::uint8_t *ETPTestBuffer = nullptr;
-constexpr std::uint16_t MAX_TP_SIZE_BYTES = 1785;
-constexpr std::uint32_t ETP_TEST_SIZE = 2048;
+static constexpr std::uint16_t MAX_TP_SIZE_BYTES = 1785;
+static constexpr std::uint32_t ETP_TEST_SIZE = 2048;
 
 using namespace std;
 
@@ -59,7 +57,7 @@ int main()
 
 	if ((!CANHardwareInterface::start()) || (!canDriver->get_is_valid()))
 	{
-		std::cout << "Failed to start hardware interface. A CAN driver might be invalid." << std::endl;
+		std::cout << "Failed to start hardware interface. The CAN driver might be invalid." << std::endl;
 		return -2;
 	}
 

--- a/examples/vt_aux_n/CMakeLists.txt
+++ b/examples/vt_aux_n/CMakeLists.txt
@@ -3,6 +3,7 @@ project(vt_aux_n_example)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 if(NOT BUILD_EXAMPLES)
   find_package(isobus REQUIRED)
 endif()

--- a/examples/vt_aux_n/CMakeLists.txt
+++ b/examples/vt_aux_n/CMakeLists.txt
@@ -8,7 +8,7 @@ if(NOT BUILD_EXAMPLES)
 endif()
 find_package(Threads REQUIRED)
 
-add_executable(VTAuxNExample main.cpp object_pool_ids.h)
+add_executable(VTAuxNExample main.cpp console_logger.cpp object_pool_ids.h)
 target_link_libraries(
   VTAuxNExample PRIVATE isobus::Isobus isobus::HardwareIntegration
                         Threads::Threads isobus::Utility)

--- a/examples/vt_aux_n/console_logger.cpp
+++ b/examples/vt_aux_n/console_logger.cpp
@@ -1,0 +1,67 @@
+#include "isobus/isobus/can_stack_logger.hpp"
+
+#include <iostream>
+
+// A log sink for the CAN stack
+class CustomLogger : public isobus::CANStackLogger
+{
+public:
+	void sink_CAN_stack_log(CANStackLogger::LoggingLevel level, const std::string &text) override
+	{
+		switch (level)
+		{
+			case LoggingLevel::Debug:
+			{
+				std::cout << "["
+				          << "\033[1;36m"
+				          << "Debug"
+				          << "\033[0m"
+				          << "]";
+			}
+			break;
+
+			case LoggingLevel::Info:
+			{
+				std::cout << "["
+				          << "\033[1;32m"
+				          << "Info"
+				          << "\033[0m"
+				          << "]";
+			}
+			break;
+
+			case LoggingLevel::Warning:
+			{
+				std::cout << "["
+				          << "\033[1;33m"
+				          << "Warn"
+				          << "\033[0m"
+				          << "]";
+			}
+			break;
+
+			case LoggingLevel::Error:
+			{
+				std::cout << "["
+				          << "\033[1;31m"
+				          << "Error"
+				          << "\033[0m"
+				          << "]";
+			}
+			break;
+
+			case LoggingLevel::Critical:
+			{
+				std::cout << "["
+				          << "\033[1;35m"
+				          << "Critical"
+				          << "\033[0m"
+				          << "]";
+			}
+			break;
+		}
+		std::cout << text << std::endl; // Write the text to stdout
+	}
+};
+
+static CustomLogger logger;

--- a/examples/vt_aux_n/main.cpp
+++ b/examples/vt_aux_n/main.cpp
@@ -71,7 +71,7 @@ int main()
 
 	if ((!CANHardwareInterface::start()) || (!canDriver->get_is_valid()))
 	{
-		std::cout << "Failed to start hardware interface. A CAN driver might be invalid." << std::endl;
+		std::cout << "Failed to start hardware interface. The CAN driver might be invalid." << std::endl;
 		return -2;
 	}
 

--- a/examples/vt_aux_n/main.cpp
+++ b/examples/vt_aux_n/main.cpp
@@ -5,6 +5,8 @@
 #include "isobus/isobus/can_stack_logger.hpp"
 #include "isobus/isobus/isobus_virtual_terminal_client.hpp"
 #include "isobus/utility/iop_file_interface.hpp"
+
+#include "console_logger.cpp"
 #include "object_pool_ids.h"
 
 #ifdef WIN32
@@ -27,70 +29,6 @@ const isobus::NAMEFilter testFilter(isobus::NAME::NAMEParameters::FunctionCode, 
 static std::vector<std::uint8_t> testPool;
 
 using namespace std;
-
-// A log sink for the CAN stack
-class CustomLogger : public isobus::CANStackLogger
-{
-public:
-	void sink_CAN_stack_log(CANStackLogger::LoggingLevel level, const std::string &text) override
-	{
-		switch (level)
-		{
-			case LoggingLevel::Debug:
-			{
-				std::cout << "["
-				          << "\033[1;36m"
-				          << "Debug"
-				          << "]"
-				          << "\033[0m";
-			}
-			break;
-
-			case LoggingLevel::Info:
-			{
-				std::cout << "["
-				          << "\033[1;32m"
-				          << "Info"
-				          << "]"
-				          << "\033[0m";
-			}
-			break;
-
-			case LoggingLevel::Warning:
-			{
-				std::cout << "["
-				          << "\033[1;33m"
-				          << "Warn"
-				          << "]"
-				          << "\033[0m";
-			}
-			break;
-
-			case LoggingLevel::Error:
-			{
-				std::cout << "["
-				          << "\033[1;31m"
-				          << "Debug"
-				          << "]"
-				          << "\033[0m";
-			}
-			break;
-
-			case LoggingLevel::Critical:
-			{
-				std::cout << "["
-				          << "\033[1;35m"
-				          << "Debug"
-				          << "]"
-				          << "\033[0m";
-			}
-			break;
-		}
-		std::cout << text << std::endl; // Write the text to stdout
-	}
-};
-
-static CustomLogger logger;
 
 void signal_handler(int signum)
 {
@@ -121,6 +59,7 @@ void handle_aux_input(isobus::VirtualTerminalClient::AssignedAuxiliaryFunction f
 void setup()
 {
 	isobus::CANStackLogger::set_can_stack_logger_sink(&logger);
+	isobus::CANStackLogger::set_log_level(isobus::CANStackLogger::LoggingLevel::Info); // Change this to Debug to see more information
 	CANHardwareInterface::set_number_of_can_channels(1);
 	CANHardwareInterface::assign_can_channel_frame_handler(0, &canDriver);
 

--- a/examples/vt_aux_n/main.cpp
+++ b/examples/vt_aux_n/main.cpp
@@ -14,12 +14,8 @@
 #include <iostream>
 #include <memory>
 
-static std::shared_ptr<isobus::InternalControlFunction> TestInternalECU = nullptr;
-static std::shared_ptr<isobus::PartneredControlFunction> TestPartnerVT = nullptr;
+//! It is discouraged to use global variables, but it is done here for simplicity.
 static std::shared_ptr<isobus::VirtualTerminalClient> TestVirtualTerminalClient = nullptr;
-std::vector<isobus::NAMEFilter> vtNameFilters;
-const isobus::NAMEFilter testFilter(isobus::NAME::NAMEParameters::FunctionCode, static_cast<std::uint8_t>(isobus::NAME::Function::VirtualTerminal));
-static std::vector<std::uint8_t> testPool;
 
 using namespace std;
 
@@ -30,7 +26,7 @@ void signal_handler(int signum)
 	{
 		TestVirtualTerminalClient->terminate();
 	}
-	exit(signum);
+	_exit(EXIT_FAILURE);
 }
 
 void update_CAN_network()
@@ -75,7 +71,7 @@ int main()
 
 	if ((!CANHardwareInterface::start()) || (!canDriver->get_is_valid()))
 	{
-		std::cout << "Failed to connect to the socket. The interface might be down." << std::endl;
+		std::cout << "Failed to start hardware interface. A CAN driver might be invalid." << std::endl;
 		return -2;
 	}
 
@@ -86,8 +82,8 @@ int main()
 
 	isobus::NAME TestDeviceNAME(0);
 
-	// Make sure you change these for your device!!!!
-	// This is an example device that is using a manufacturer code that is currently unused at time of writing
+	//! Make sure you change these for your device!!!!
+	//! This is an example device that is using a manufacturer code that is currently unused at time of writing
 	TestDeviceNAME.set_arbitrary_address_capable(true);
 	TestDeviceNAME.set_industry_group(1);
 	TestDeviceNAME.set_device_class(0);
@@ -97,9 +93,8 @@ int main()
 	TestDeviceNAME.set_function_instance(0);
 	TestDeviceNAME.set_device_class_instance(0);
 	TestDeviceNAME.set_manufacturer_code(64);
-	vtNameFilters.push_back(testFilter);
 
-	testPool = isobus::IOPFileInterface::read_iop_file("vtpooldata.iop");
+	std::vector<std::uint8_t> testPool = isobus::IOPFileInterface::read_iop_file("vtpooldata.iop");
 
 	if (0 != testPool.size())
 	{
@@ -108,13 +103,17 @@ int main()
 	else
 	{
 		std::cout << "Failed to load object pool from vtpooldata.iop" << std::endl;
+		return -3;
 	}
 
 	// Generate a unique version string for this object pool (this is optional, and is entirely application specific behavior)
 	std::string objectPoolHash = isobus::IOPFileInterface::hash_object_pool_to_version(testPool);
 
-	TestInternalECU = std::make_shared<isobus::InternalControlFunction>(TestDeviceNAME, 0x1C, 0);
-	TestPartnerVT = std::make_shared<isobus ::PartneredControlFunction>(0, vtNameFilters);
+	const isobus::NAMEFilter filterVirtualTerminal(isobus::NAME::NAMEParameters::FunctionCode, static_cast<std::uint8_t>(isobus::NAME::Function::VirtualTerminal));
+	const std::vector<isobus::NAMEFilter> vtNameFilters = { filterVirtualTerminal };
+	std::shared_ptr<isobus::InternalControlFunction> TestInternalECU = std::make_shared<isobus::InternalControlFunction>(TestDeviceNAME, 0x1C, 0);
+	std::shared_ptr<isobus::PartneredControlFunction> TestPartnerVT = std::make_shared<isobus::PartneredControlFunction>(0, vtNameFilters);
+
 	TestVirtualTerminalClient = std::make_shared<isobus::VirtualTerminalClient>(TestPartnerVT, TestInternalECU);
 	TestVirtualTerminalClient->set_object_pool(0, isobus::VirtualTerminalClient::VTVersion::Version3, testPool.data(), testPool.size(), objectPoolHash);
 	TestVirtualTerminalClient->register_auxiliary_input_event_callback(handle_aux_input);

--- a/examples/vt_aux_n/main.cpp
+++ b/examples/vt_aux_n/main.cpp
@@ -1,3 +1,4 @@
+#include "isobus/hardware_integration/available_can_drivers.hpp"
 #include "isobus/hardware_integration/can_hardware_interface.hpp"
 #include "isobus/isobus/can_general_parameter_group_numbers.hpp"
 #include "isobus/isobus/can_network_manager.hpp"
@@ -8,14 +9,6 @@
 
 #include "console_logger.cpp"
 #include "object_pool_ids.h"
-
-#ifdef WIN32
-#include "isobus/hardware_integration/pcan_basic_windows_plugin.hpp"
-static PCANBasicWindowsPlugin canDriver(PCAN_USBBUS1);
-#else
-#include "isobus/hardware_integration/socket_can_interface.hpp"
-static SocketCANInterface canDriver("can0");
-#endif
 
 #include <csignal>
 #include <iostream>
@@ -56,16 +49,34 @@ void handle_aux_input(isobus::VirtualTerminalClient::AssignedAuxiliaryFunction f
 	std::cout << "Auxiliary input received: (" << function.functionObjectID << ", " << function.inputObjectID << ", " << static_cast<int>(function.functionType) << "), value1: " << value1 << ", value2: " << value2 << std::endl;
 }
 
-void setup()
+int main()
 {
+	std::signal(SIGINT, signal_handler);
+
+	std::shared_ptr<CANHardwarePlugin> canDriver = nullptr;
+#if defined(ISOBUS_SOCKETCAN_AVAILABLE)
+	canDriver = std::make_shared<SocketCANInterface>("can0");
+#elif defined(ISOBUS_WINDOWSPCANBASIC_AVAILABLE)
+	canDriver = std::make_shared<PCANBasicWindowsPlugin>(PCAN_USBBUS1);
+#elif defined(ISOBUS_WINDOWSINNOMAKERUSB2CAN_AVAILABLE)
+	canDriver = std::make_shared<InnoMakerUSB2CANWindowsPlugin>(0); // CAN0
+#endif
+	if (nullptr == canDriver)
+	{
+		std::cout << "Unable to find a CAN driver. Please make sure you have one of the above drivers installed with the library." << std::endl;
+		std::cout << "If you want to use a different driver, please add it to the list above." << std::endl;
+		return -1;
+	}
+
 	isobus::CANStackLogger::set_can_stack_logger_sink(&logger);
 	isobus::CANStackLogger::set_log_level(isobus::CANStackLogger::LoggingLevel::Info); // Change this to Debug to see more information
 	CANHardwareInterface::set_number_of_can_channels(1);
-	CANHardwareInterface::assign_can_channel_frame_handler(0, &canDriver);
+	CANHardwareInterface::assign_can_channel_frame_handler(0, canDriver);
 
-	if ((!CANHardwareInterface::start()) || (!canDriver.get_is_valid()))
+	if ((!CANHardwareInterface::start()) || (!canDriver->get_is_valid()))
 	{
 		std::cout << "Failed to connect to the socket. The interface might be down." << std::endl;
+		return -2;
 	}
 
 	CANHardwareInterface::add_can_lib_update_callback(update_CAN_network, nullptr);
@@ -108,12 +119,6 @@ void setup()
 	TestVirtualTerminalClient->set_object_pool(0, isobus::VirtualTerminalClient::VTVersion::Version3, testPool.data(), testPool.size(), objectPoolHash);
 	TestVirtualTerminalClient->register_auxiliary_input_event_callback(handle_aux_input);
 	TestVirtualTerminalClient->initialize(true);
-	std::signal(SIGINT, signal_handler);
-}
-
-int main()
-{
-	setup();
 
 	while (true)
 	{

--- a/examples/vt_aux_n/main.cpp
+++ b/examples/vt_aux_n/main.cpp
@@ -19,7 +19,7 @@ static std::shared_ptr<isobus::VirtualTerminalClient> TestVirtualTerminalClient 
 
 using namespace std;
 
-void signal_handler(int signum)
+void signal_handler(int)
 {
 	CANHardwareInterface::stop();
 	if (nullptr != TestVirtualTerminalClient)

--- a/examples/vt_version_3_object_pool/CMakeLists.txt
+++ b/examples/vt_version_3_object_pool/CMakeLists.txt
@@ -3,6 +3,7 @@ project(vt3_version_3_object_pool_example)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 if(NOT BUILD_EXAMPLES)
   find_package(isobus REQUIRED)
 endif()
@@ -18,4 +19,4 @@ add_custom_command(
   POST_BUILD
   COMMENT "Copying VT3TestPool.iop to build directory"
   COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/VT3TestPool.iop
-          ${CMAKE_CURRENT_BINARY_DIR}/VT3TestPool.iop)
+          $<TARGET_FILE_DIR:VT3ExampleTarget>/VT3TestPool.iop)

--- a/examples/vt_version_3_object_pool/CMakeLists.txt
+++ b/examples/vt_version_3_object_pool/CMakeLists.txt
@@ -8,7 +8,7 @@ if(NOT BUILD_EXAMPLES)
 endif()
 find_package(Threads REQUIRED)
 
-add_executable(VT3ExampleTarget main.cpp objectPoolObjects.h)
+add_executable(VT3ExampleTarget main.cpp console_logger.cpp objectPoolObjects.h)
 target_link_libraries(
   VT3ExampleTarget PRIVATE isobus::Isobus isobus::HardwareIntegration
                            Threads::Threads isobus::Utility)

--- a/examples/vt_version_3_object_pool/console_logger.cpp
+++ b/examples/vt_version_3_object_pool/console_logger.cpp
@@ -1,0 +1,67 @@
+#include "isobus/isobus/can_stack_logger.hpp"
+
+#include <iostream>
+
+// A log sink for the CAN stack
+class CustomLogger : public isobus::CANStackLogger
+{
+public:
+	void sink_CAN_stack_log(CANStackLogger::LoggingLevel level, const std::string &text) override
+	{
+		switch (level)
+		{
+			case LoggingLevel::Debug:
+			{
+				std::cout << "["
+				          << "\033[1;36m"
+				          << "Debug"
+				          << "\033[0m"
+				          << "]";
+			}
+			break;
+
+			case LoggingLevel::Info:
+			{
+				std::cout << "["
+				          << "\033[1;32m"
+				          << "Info"
+				          << "\033[0m"
+				          << "]";
+			}
+			break;
+
+			case LoggingLevel::Warning:
+			{
+				std::cout << "["
+				          << "\033[1;33m"
+				          << "Warn"
+				          << "\033[0m"
+				          << "]";
+			}
+			break;
+
+			case LoggingLevel::Error:
+			{
+				std::cout << "["
+				          << "\033[1;31m"
+				          << "Error"
+				          << "\033[0m"
+				          << "]";
+			}
+			break;
+
+			case LoggingLevel::Critical:
+			{
+				std::cout << "["
+				          << "\033[1;35m"
+				          << "Critical"
+				          << "\033[0m"
+				          << "]";
+			}
+			break;
+		}
+		std::cout << text << std::endl; // Write the text to stdout
+	}
+};
+
+static CustomLogger logger;

--- a/examples/vt_version_3_object_pool/main.cpp
+++ b/examples/vt_version_3_object_pool/main.cpp
@@ -110,7 +110,7 @@ int main()
 
 	if ((!CANHardwareInterface::start()) || (!canDriver->get_is_valid()))
 	{
-		std::cout << "Failed to start hardware interface. A CAN driver might be invalid." << std::endl;
+		std::cout << "Failed to start hardware interface. The CAN driver might be invalid." << std::endl;
 		return -2;
 	}
 

--- a/examples/vt_version_3_object_pool/main.cpp
+++ b/examples/vt_version_3_object_pool/main.cpp
@@ -5,6 +5,8 @@
 #include "isobus/isobus/can_stack_logger.hpp"
 #include "isobus/isobus/isobus_virtual_terminal_client.hpp"
 #include "isobus/utility/iop_file_interface.hpp"
+
+#include "console_logger.cpp"
 #include "objectPoolObjects.h"
 
 #ifdef WIN32
@@ -27,70 +29,6 @@ const isobus::NAMEFilter testFilter(isobus::NAME::NAMEParameters::FunctionCode, 
 static std::vector<std::uint8_t> testPool;
 
 using namespace std;
-
-// A log sink for the CAN stack
-class CustomLogger : public isobus::CANStackLogger
-{
-public:
-	void sink_CAN_stack_log(CANStackLogger::LoggingLevel level, const std::string &text) override
-	{
-		switch (level)
-		{
-			case LoggingLevel::Debug:
-			{
-				std::cout << "["
-				          << "\033[1;36m"
-				          << "Debug"
-				          << "\033[0m"
-				          << "]";
-			}
-			break;
-
-			case LoggingLevel::Info:
-			{
-				std::cout << "["
-				          << "\033[1;32m"
-				          << "Info"
-				          << "\033[0m"
-				          << "]";
-			}
-			break;
-
-			case LoggingLevel::Warning:
-			{
-				std::cout << "["
-				          << "\033[1;33m"
-				          << "Warn"
-				          << "\033[0m"
-				          << "]";
-			}
-			break;
-
-			case LoggingLevel::Error:
-			{
-				std::cout << "["
-				          << "\033[1;31m"
-				          << "Error"
-				          << "\033[0m"
-				          << "]";
-			}
-			break;
-
-			case LoggingLevel::Critical:
-			{
-				std::cout << "["
-				          << "\033[1;35m"
-				          << "Debug"
-				          << "\033[0m"
-				          << "]";
-			}
-			break;
-		}
-		std::cout << text << std::endl; // Write the text to stdout
-	}
-};
-
-static CustomLogger logger;
 
 void signal_handler(int signum)
 {
@@ -160,6 +98,7 @@ void handleVTButton(isobus::VirtualTerminalClient::KeyActivationCode keyEvent, s
 void setup()
 {
 	isobus::CANStackLogger::set_can_stack_logger_sink(&logger);
+	isobus::CANStackLogger::set_log_level(isobus::CANStackLogger::LoggingLevel::Info); // Change this to Debug to see more information
 	CANHardwareInterface::set_number_of_can_channels(1);
 	CANHardwareInterface::assign_can_channel_frame_handler(0, &canDriver);
 

--- a/examples/vt_version_3_object_pool/main.cpp
+++ b/examples/vt_version_3_object_pool/main.cpp
@@ -19,7 +19,7 @@ static std::shared_ptr<isobus::VirtualTerminalClient> TestVirtualTerminalClient 
 
 using namespace std;
 
-void signal_handler(int signum)
+void signal_handler(int)
 {
 	CANHardwareInterface::stop();
 	if (nullptr != TestVirtualTerminalClient)

--- a/hardware_integration/CMakeLists.txt
+++ b/hardware_integration/CMakeLists.txt
@@ -29,8 +29,9 @@ endif()
 set(HARDWARE_INTEGRATION_SRC "can_hardware_interface.cpp")
 
 # Set the include files
-set(HARDWARE_INTEGRATION_INCLUDE "can_hardware_interface.hpp"
-                                 "can_hardware_plugin.hpp")
+set(HARDWARE_INTEGRATION_INCLUDE
+    "can_hardware_interface.hpp" "can_hardware_plugin.hpp"
+    "available_can_drivers.hpp")
 
 # Add the source/include files based on the CAN driver chosen
 if("SocketCAN" IN_LIST CAN_DRIVER)
@@ -168,6 +169,15 @@ if("WindowsInnoMakerUSB2CAN" IN_LIST CAN_DRIVER)
     )
   endif()
 endif()
+
+# Mark the compiled CAN drivers available to other modules. In the form:
+# `ISOBUS_<uppercase CAN_DRIVER>_AVAILABLE` as a preprocessor definition.
+foreach(AVAILABLE_DRIVER ${CAN_DRIVER})
+  string(TOUPPER ${AVAILABLE_DRIVER} AVAILABLE_DRIVER)
+  string(PREPEND AVAILABLE_DRIVER "ISOBUS_")
+  string(APPEND AVAILABLE_DRIVER "_AVAILABLE")
+  target_compile_definitions(HardwareIntegration PUBLIC ${AVAILABLE_DRIVER})
+endforeach()
 
 # Specify the include directory to be exported for other moduels to use. The
 # PUBLIC keyword here allows other libraries or exectuables to link to this

--- a/hardware_integration/CMakeLists.txt
+++ b/hardware_integration/CMakeLists.txt
@@ -172,11 +172,11 @@ endif()
 
 # Mark the compiled CAN drivers available to other modules. In the form:
 # `ISOBUS_<uppercase CAN_DRIVER>_AVAILABLE` as a preprocessor definition.
-foreach(AVAILABLE_DRIVER ${CAN_DRIVER})
-  string(TOUPPER ${AVAILABLE_DRIVER} AVAILABLE_DRIVER)
-  string(PREPEND AVAILABLE_DRIVER "ISOBUS_")
-  string(APPEND AVAILABLE_DRIVER "_AVAILABLE")
-  target_compile_definitions(HardwareIntegration PUBLIC ${AVAILABLE_DRIVER})
+foreach(available_driver ${CAN_DRIVER})
+  string(TOUPPER ${available_driver} available_driver)
+  string(PREPEND available_driver "ISOBUS_")
+  string(APPEND available_driver "_AVAILABLE")
+  target_compile_definitions(HardwareIntegration PUBLIC ${available_driver})
 endforeach()
 
 # Specify the include directory to be exported for other moduels to use. The

--- a/hardware_integration/include/isobus/hardware_integration/available_can_drivers.hpp
+++ b/hardware_integration/include/isobus/hardware_integration/available_can_drivers.hpp
@@ -1,0 +1,37 @@
+//================================================================================================
+/// @file available_can_drivers.hpp
+///
+/// @brief A utility to include all of the available CAN drivers. Should mainly be
+/// used for testing purposes.
+/// @author Daan Steenbergen
+///
+/// @copyright 2023 Adrian Del Grosso
+//================================================================================================
+#ifndef AVAILABLE_CAN_DRIVERS_HPP
+#define AVAILABLE_CAN_DRIVERS_HPP
+
+#ifdef ISOBUS_SOCKETCAN_AVAILABLE
+#include "isobus/hardware_integration/socket_can_interface.hpp"
+#endif
+
+#ifdef ISOBUS_WINDOWSPCANBASIC_AVAILABLE
+#include "isobus/hardware_integration/pcan_basic_windows_plugin.hpp"
+#endif
+
+#ifdef ISOBUS_VIRTUALCAN_AVAILABLE
+#include "isobus/hardware_integration/virtual_can_plugin.hpp"
+#endif
+
+#ifdef ISOBUS_TWAI_AVAILABLE
+#include "isobus/hardware_integration/twai_plugin.hpp"
+#endif
+
+#ifdef ISOBUS_MCP2515_AVAILABLE
+#include "isobus/hardware_integration/mcp2515_can_interface.hpp"
+#endif
+
+#ifdef ISOBUS_WINDOWSINNOMAKERUSB2CAN_AVAILABLE
+#include "isobus/hardware_integration/innomaker_usb2can_windows_plugin.hpp"
+#endif
+
+#endif // AVAILABLE_CAN_DRIVERS_HPP

--- a/hardware_integration/include/isobus/hardware_integration/can_hardware_interface.hpp
+++ b/hardware_integration/include/isobus/hardware_integration/can_hardware_interface.hpp
@@ -84,7 +84,7 @@ public:
 	/// @param[in] canDriver The driver to assign to the channel
 	/// @note All changes to driver assignment will be ignored if `start` has been called and the threads are running
 	/// @returns `true` if the driver was assigned to the channel, otherwise `false`
-	static bool assign_can_channel_frame_handler(std::uint8_t aCANChannel, CANHardwarePlugin *canDriver);
+	static bool assign_can_channel_frame_handler(std::uint8_t aCANChannel, std::shared_ptr<CANHardwarePlugin> canDriver);
 
 	/// @brief Starts the threads for managing the CAN stack and CAN drivers
 	/// @returns `true` if the threads were started, otherwise false (perhaps they are already running)
@@ -146,7 +146,7 @@ private:
 
 		std::thread *receiveMessageThread; ///< Thread to manage getting messages from a CAN channel
 
-		CANHardwarePlugin *frameHandler; ///< The CAN driver to use for a CAN channel
+		std::shared_ptr<CANHardwarePlugin> frameHandler; ///< The CAN driver to use for a CAN channel
 	};
 
 	/// @brief The default update interval for the CAN stack. Mostly arbitrary

--- a/hardware_integration/src/can_hardware_interface.cpp
+++ b/hardware_integration/src/can_hardware_interface.cpp
@@ -66,7 +66,7 @@ CANHardwareInterface::~CANHardwareInterface()
 	set_number_of_can_channels(0);
 }
 
-bool CANHardwareInterface::assign_can_channel_frame_handler(std::uint8_t aCANChannel, CANHardwarePlugin *driver)
+bool CANHardwareInterface::assign_can_channel_frame_handler(std::uint8_t aCANChannel, std::shared_ptr<CANHardwarePlugin> driver)
 {
 	bool retVal = false;
 

--- a/hardware_integration/src/innomaker_usb2can_windows_plugin.cpp
+++ b/hardware_integration/src/innomaker_usb2can_windows_plugin.cpp
@@ -307,7 +307,7 @@ bool InnoMakerUSB2CANWindowsPlugin::write_frame(const isobus::HardwareInterfaceC
 	InnoMakerUsb2CanLib::innomaker_tx_context *txc = driverInstance->innomaker_alloc_tx_context(txContexts.get());
 	if (0xFF == txc->echo_id)
 	{
-		isobus::CANStackLogger::warn("[InnoMaker-Windows] No free transmission context");
+		isobus::CANStackLogger::debug("[InnoMaker-Windows] No free transmission context");
 		return false;
 	}
 

--- a/isobus/include/isobus/isobus/isobus_diagnostic_protocol.hpp
+++ b/isobus/include/isobus/isobus/isobus_diagnostic_protocol.hpp
@@ -214,6 +214,10 @@ namespace isobus
 		/// @returns `true` If the protocol instance was deleted OK according to the passed in ICF
 		static bool deassign_diagnostic_protocol_to_internal_control_function(std::shared_ptr<InternalControlFunction> internalControlFunction);
 
+		/// @brief Used to tell the CAN stack that diagnostic messages should no longer be sent from any internal control function
+		/// @details This will delete all instances of this protocol and may delete associated but unused instances of the PGN request protocol.
+		static void deassign_all_diagnostic_protocol_to_internal_control_functions();
+
 		/// @brief Retuns the diagnostic protocol assigned to an internal control function, if any
 		/// @param internalControlFunction The internal control function to search against
 		/// @returns The protocol object associated to the passed in ICF, or `nullptr` if none found that match the passed in ICF

--- a/isobus/src/can_NAME.cpp
+++ b/isobus/src/can_NAME.cpp
@@ -84,10 +84,6 @@ namespace isobus
 
 	void NAME::set_function_code(std::uint8_t value)
 	{
-		if (value > 0xFF)
-		{
-			CANStackLogger::error("[NAME]: Function code out of range, must be between 0 and 255");
-		}
 		rawName &= ~static_cast<std::uint64_t>(0xFF0000000000);
 		rawName |= (static_cast<std::uint64_t>(value & 0xFF) << 40);
 	}

--- a/isobus/src/isobus_diagnostic_protocol.cpp
+++ b/isobus/src/isobus_diagnostic_protocol.cpp
@@ -168,6 +168,16 @@ namespace isobus
 		return retVal;
 	}
 
+	void DiagnosticProtocol::deassign_all_diagnostic_protocol_to_internal_control_functions()
+	{
+		for (isobus::DiagnosticProtocol *protocol : diagnosticProtocolList)
+		{
+			// First, remove callbacks from PGN requests
+			protocol->deregister_all_pgns();
+			delete protocol;
+		}
+	}
+
 	DiagnosticProtocol *DiagnosticProtocol::get_diagnostic_protocol_by_internal_control_function(std::shared_ptr<InternalControlFunction> internalControlFunction)
 	{
 		DiagnosticProtocol *retVal = nullptr;

--- a/sphinx/README.md
+++ b/sphinx/README.md
@@ -14,7 +14,7 @@ pip install sphinx-rtd-theme
 ## Build the Tutorial
 
 ```
-make html
+./make html
 ```
 
 Then, you can view the documentation at build\html\index.html in your web browser.

--- a/sphinx/source/Tutorials/Adding a Destination.rst
+++ b/sphinx/source/Tutorials/Adding a Destination.rst
@@ -101,7 +101,7 @@ The final program for this tutorial (including the code from the previous Hello 
    #include <memory>
    #include <csignal>
 
-   void signal_handler(int signum)
+   void signal_handler(int)
    {
       CANHardwareInterface::stop(); // Clean up the threads
 		_exit(EXIT_FAILURE);

--- a/sphinx/source/Tutorials/Debug Logging.rst
+++ b/sphinx/source/Tutorials/Debug Logging.rst
@@ -43,6 +43,9 @@ Now, we just need to create a static instance of this logger, and tell the CAN s
 
 	isobus::CANStackLogger::set_can_stack_logger_sink(&logger);
 
+	// If you want to change the logging level, you can do so as followed; the default level is INFO.
+	isobus::CANStackLogger::set_log_level(isobus::CANStackLogger::LoggingLevel::DEBUG);
+
 The logger must be static or otherwise not go out of scope, as the CAN stack saves a reference to that logger object!
 
 That's all there is to it! Now, when you run your program you should see some logging messages are written to your console.

--- a/sphinx/source/Tutorials/Receiving Messages.rst
+++ b/sphinx/source/Tutorials/Receiving Messages.rst
@@ -28,10 +28,10 @@ In this example, we'll define a function that will process all received propriet
 
    void propa_callback(isobus::CANMessage *CANMessage, void *parent)
    {
-   	 if (nullptr != CANMessage)
-     {
-      std::cout << CANMessage->get_data_length() << std::endl;
-     }
+      if (nullptr != CANMessage)
+      {
+         std::cout << CANMessage->get_data_length() << std::endl;
+      }
    }
 
 This callback isn't particularly useful, but it does illustrate how to use the callback system.
@@ -60,8 +60,8 @@ Our example program has to stay running for us to receive messages, so if we wan
 
    while (true)
    {
-    // CAN stack runs in other threads. Do nothing forever.
-    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+      // CAN stack runs in other threads. Do nothing forever.
+      std::this_thread::sleep_for(std::chrono::milliseconds(1000));
    }
 
 So, our updated tutorial program now should look like this:
@@ -79,95 +79,98 @@ So, our updated tutorial program now should look like this:
 
    void signal_handler(int signum)
    {
-        CANHardwareInterface::stop(); // Clean up the threads
-        exit(signum);
+      CANHardwareInterface::stop(); // Clean up the threads
+		_exit(EXIT_FAILURE);
    }
 
    void update_CAN_network()
    {
-        isobus::CANNetworkManager::CANNetwork.update();
+      isobus::CANNetworkManager::CANNetwork.update();
    }
 
    void raw_can_glue(isobus::HardwareInterfaceCANFrame &rawFrame, void *parentPointer)
    {
-        isobus::CANNetworkManager::CANNetwork.can_lib_process_rx_message(rawFrame, parentPointer);
+      isobus::CANNetworkManager::CANNetwork.can_lib_process_rx_message(rawFrame, parentPointer);
    }
 
    void propa_callback(isobus::CANMessage *CANMessage, void *parent)
    {
-         if (nullptr != CANMessage)
-     {
-       std::cout << CANMessage->get_data_length() << std::endl;
-     }
+      if (nullptr != CANMessage)
+      {
+         std::cout << CANMessage->get_data_length() << std::endl;
+      }
    }
 
    int main()
    {
-    isobus::NAME myNAME(0); // Create an empty NAME
-    std::shared_ptr<isobus::InternalControlFunction> myECU = nullptr; // A pointer to hold our InternalControlFunction
-    std::shared_ptr<isobus::PartneredControlFunction> myPartner = nullptr; // A pointer to hold a partner
-    SocketCANInterface canDriver("can0"); // The CAN driver to use for this program. In this case, we're using socket CAN.
+      isobus::NAME myNAME(0); // Create an empty NAME
 
-    // Define a NAME filter for our partner
-    std::vector<isobus::NAMEFilter> myPartnerFilter;
-    const isobus::NAMEFilter virtualTerminalFilter(isobus::NAME::NAMEParameters::FunctionCode, static_cast<std::uint8_t>(isobus::NAME::Function::VirtualTerminal));
-    myPartnerFilter.push_back(virtualTerminalFilter);
+      std::shared_ptr<isobus::InternalControlFunction> myECU = nullptr; // A pointer to hold our InternalControlFunction
+      std::shared_ptr<isobus::PartneredControlFunction> myPartner = nullptr; // A pointer to hold a partner
 
-    // Set up the hardware layer to use "can0"
-    CANHardwareInterface::set_number_of_can_channels(1);
-    CANHardwareInterface::assign_can_channel_frame_handler(0, &canDriver);
-    
-    if ((!CANHardwareInterface::start()) || (!canDriver.get_is_valid()))
-    {
-	    std::cout << "Failed to connect to the socket. The interface might be down." << std::endl;
-    }
+      // Set up the hardware layer to use SocketCAN interface on channel "can0"
+      std::shared_ptr<SocketCANInterface> canDriver = std::make_shared<SocketCANInterface>("can0");
+      CANHardwareInterface::set_number_of_can_channels(1);
+      CANHardwareInterface::assign_can_channel_frame_handler(0, canDriver);
 
-    // Handle control+c
-    std::signal(SIGINT, signal_handler);
+      if ((!CANHardwareInterface::start()) || (!canDriver->get_is_valid()))
+      {
+         std::cout << "Failed to start hardware interface. The CAN driver might be invalid." << std::endl;
+         return -1;
+      }
 
-    CANHardwareInterface::add_can_lib_update_callback(update_CAN_network, nullptr);
-    CANHardwareInterface::add_raw_can_message_rx_callback(raw_can_glue, nullptr);
+      // Handle control+c
+      std::signal(SIGINT, signal_handler);
 
-    // Set up NAME fields
-    myNAME.set_arbitrary_address_capable(true);
-    myNAME.set_industry_group(1);
-    myNAME.set_device_class(0);
-    myNAME.set_function_code(static_cast<std::uint8_t>(isobus::NAME::Function::SteeringControl));
-    myNAME.set_identity_number(2);
-    myNAME.set_ecu_instance(0);
-    myNAME.set_function_instance(0);
-    myNAME.set_device_class_instance(0);
-    myNAME.set_manufacturer_code(64);
+      CANHardwareInterface::add_can_lib_update_callback(update_CAN_network, nullptr);
+      CANHardwareInterface::add_raw_can_message_rx_callback(raw_can_glue, nullptr);
 
-    // Create our InternalControlFunction
-    myECU = std::make_shared<isobus::InternalControlFunction>(myNAME, 0x1C, 0);
+      //! Make sure you change these for your device!!!!
+      //! This is an example device that is using a manufacturer code that is currently unused at time of writing
+      myNAME.set_arbitrary_address_capable(true);
+      myNAME.set_industry_group(1);
+      myNAME.set_device_class(0);
+      myNAME.set_function_code(static_cast<std::uint8_t>(isobus::NAME::Function::SteeringControl));
+      myNAME.set_identity_number(2);
+      myNAME.set_ecu_instance(0);
+      myNAME.set_function_instance(0);
+      myNAME.set_device_class_instance(0);
+      myNAME.set_manufacturer_code(64);
 
-    // Register to receive broadcast PROPA messages
-    isobus::CANNetworkManager::CANNetwork.add_global_parameter_group_number_callback(0xEF00, propa_callback, nullptr);
+      // Create our InternalControlFunction
+      myECU = std::make_shared<isobus::InternalControlFunction>(myNAME, 0x1C, 0);
 
-    // Create our PartneredControlFunction
-    myPartner = std::make_shared<isobus::PartneredControlFunction>(0, myPartnerFilter);
+      // Define a NAME filter for our partner
+      std::vector<isobus::NAMEFilter> myPartnerFilter;
+      const isobus::NAMEFilter virtualTerminalFilter(isobus::NAME::NAMEParameters::FunctionCode, static_cast<std::uint8_t>(isobus::NAME::Function::VirtualTerminal));
+      myPartnerFilter.push_back(virtualTerminalFilter);
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+      // Register to receive broadcast PROPA messages
+      isobus::CANNetworkManager::CANNetwork.add_global_parameter_group_number_callback(0xEF00, propa_callback, nullptr);
 
-    std::array<std::uint8_t, isobus::CAN_DATA_LENGTH> messageData = {0}; // Data is just all zeros
+      // Create our PartneredControlFunction
+      myPartner = std::make_shared<isobus::PartneredControlFunction>(0, myPartnerFilter);
 
-    // Send a message to the broadcast address
-    isobus::CANNetworkManager::CANNetwork.send_can_message(0xEF00, messageData.data(), isobus::CAN_DATA_LENGTH, myECU.get());
+      std::this_thread::sleep_for(std::chrono::milliseconds(1000));
 
-    // Send a message to our partner (if it is present)
-    isobus::CANNetworkManager::CANNetwork.send_can_message(0xEF00, messageData.data(), isobus::CAN_DATA_LENGTH, myECU.get(), myPartner.get());
+      std::array<std::uint8_t, isobus::CAN_DATA_LENGTH> messageData = {0}; // Data is just all zeros
 
-    while (true)
-    {
-     // CAN stack runs in other threads. Do nothing forever.
-     std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-    }
+      // Send a message to the broadcast address
+      isobus::CANNetworkManager::CANNetwork.send_can_message(0xEF00, messageData.data(), isobus::CAN_DATA_LENGTH, myECU.get());
 
-    // Clean up the threads
-    CANHardwareInterface::stop();
+      // Send a message to our partner (if it is present)
+      isobus::CANNetworkManager::CANNetwork.send_can_message(0xEF00, messageData.data(), isobus::CAN_DATA_LENGTH, myECU.get(), myPartner.get());
 
-    return 0;
+      while (true)
+      {
+         // CAN stack runs in other threads. Do nothing forever.
+         std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+      }
+
+      // Clean up the threads
+      CANHardwareInterface::stop();
+
+      return 0;
    }
 
 This will be tricky to test, as you would need another valid ISO 11783 device on the bus *that has properly address claimed* and is also sending this message in order for the stack to receive it and pass it to your callback.

--- a/sphinx/source/Tutorials/Receiving Messages.rst
+++ b/sphinx/source/Tutorials/Receiving Messages.rst
@@ -77,7 +77,7 @@ So, our updated tutorial program now should look like this:
    #include <csignal>
    #include <iostream>
 
-   void signal_handler(int signum)
+   void signal_handler(int)
    {
       CANHardwareInterface::stop(); // Clean up the threads
 		_exit(EXIT_FAILURE);

--- a/sphinx/source/Tutorials/The ISOBUS Hello World.rst
+++ b/sphinx/source/Tutorials/The ISOBUS Hello World.rst
@@ -126,7 +126,8 @@ In this example, I'll use a shared_ptr to store my InternalControlFunction, but 
     isobus::NAME myNAME(0); // Create an empty NAME
     std::shared_ptr<isobus::InternalControlFunction> myECU = nullptr; // A pointer to hold our InternalControlFunction
 
-    // Set up NAME fields
+    //! Make sure you change these for your device!!!!
+    //! This is an example device that is using a manufacturer code that is currently unused at time of writing
     myNAME.set_arbitrary_address_capable(true);
     myNAME.set_industry_group(1);
     myNAME.set_device_class(0);
@@ -175,22 +176,25 @@ There are a few lines we'll need to add:
 
 .. code-block:: c++
 
-   SocketCANInterface canDriver("can0");
+   std::shared_ptr<SocketCANInterface> canDriver = std::make_shared<SocketCANInterface>("can0");
    CANHardwareInterface::set_number_of_can_channels(1);
-   CANHardwareInterface::assign_can_channel_frame_handler(0, &canDriver);
+   CANHardwareInterface::assign_can_channel_frame_handler(0, canDriver);
 
-   if ((!CANHardwareInterface::start()) || (!canDriver.get_is_valid()))
+   if ((!CANHardwareInterface::start()) || (!canDriver->get_is_valid()))
    {
-	   std::cout << "Failed to connect to the socket. The interface might be down." << std::endl;
+      std::cout << "Failed to start hardware interface. The CAN driver might be invalid." << std::endl;
+      return -1;
    }
 
 The "CANHardwareInterface" is an independent component that is not actually directly tied to the CAN stack. It serves as a way for the stack to abstract away whatever hardware is being used.
 
 So, lets talk about what's happening here.
 
+:code:`std::shared_ptr<SocketCANInterface> canDriver = std::make_shared<SocketCANInterface>("can0");` Creates a new SocketCANInterface object, and stores it in a shared_ptr. This is the object that will be used to interface with the socket CAN driver.
+
 :code:`CANHardwareInterface::set_number_of_can_channels(1)` Is telling the hardware layer (socket CAN in our case) that we will use 1 CAN adapter.
 
-:code:`CANHardwareInterface::assign_can_channel_frame_handler(0, "can0");` Tells the hardware layer to use "can0" for CAN channel 0.
+:code:`CANHardwareInterface::assign_can_channel_frame_handler(0, canDriver);` Tells the hardware layer that we want to use the SocketCANInterface object we just created as the handler for CAN channel 0.
 
 :code:`CANHardwareInterface::start();` Kicks off a number of threads that will manage the socket and issue callbacks for when messages are received. It also provides callbacks to 'tick' the stack cyclically.
 Checking its return value and :code:`get_is_valid` will tell you if the underlying CAN driver is connected to the hardware. In this case, since we're using socket CAN, it tells us if we bound to the socket.
@@ -240,47 +244,49 @@ Let's see what we've got so far:
 
    void update_CAN_network()
    {
-   	isobus::CANNetworkManager::CANNetwork.update();
+      isobus::CANNetworkManager::CANNetwork.update();
    }
-   
+
    void raw_can_glue(isobus::HardwareInterfaceCANFrame &rawFrame, void *parentPointer)
    {
-   	isobus::CANNetworkManager::CANNetwork.can_lib_process_rx_message(rawFrame, parentPointer);
+      isobus::CANNetworkManager::CANNetwork.can_lib_process_rx_message(rawFrame, parentPointer);
    }
-   
+
    int main()
    {
-    isobus::NAME myNAME(0); // Create an empty NAME
-    std::shared_ptr<isobus::InternalControlFunction> myECU = nullptr; // A pointer to hold our InternalControlFunction
+      isobus::NAME myNAME(0); // Create an empty NAME
+      std::shared_ptr<isobus::InternalControlFunction> myECU = nullptr; // A pointer to hold our InternalControlFunction
 
-    // Set up the hardware layer to use "can0"
-    SocketCANInterface canDriver("can0");
-    CANHardwareInterface::set_number_of_can_channels(1);
-    CANHardwareInterface::assign_can_channel_frame_handler(0, &canDriver);
-    
-    if ((!CANHardwareInterface::start()) || (!canDriver.get_is_valid()))
-	{
-		std::cout << "Failed to connect to the socket. The interface might be down." << std::endl;
-	}
+      // Set up the hardware layer to use SocketCAN interface on channel "can0"
+      std::shared_ptr<SocketCANInterface> canDriver = std::make_shared<SocketCANInterface>("can0");
+      CANHardwareInterface::set_number_of_can_channels(1);
+      CANHardwareInterface::assign_can_channel_frame_handler(0, canDriver);
 
-    CANHardwareInterface::add_can_lib_update_callback(update_CAN_network, nullptr);
-    CANHardwareInterface::add_raw_can_message_rx_callback(raw_can_glue, nullptr);
+      if ((!CANHardwareInterface::start()) || (!canDriver->get_is_valid()))
+      {
+         std::cout << "Failed to start hardware interface. The CAN driver might be invalid." << std::endl;
+         return -2;
+      }
 
-    // Set up NAME fields
-    myNAME.set_arbitrary_address_capable(true);
-    myNAME.set_industry_group(1);
-    myNAME.set_device_class(0);
-    myNAME.set_function_code(static_cast<std::uint8_t>(isobus::NAME::Function::SteeringControl));
-    myNAME.set_identity_number(2);
-    myNAME.set_ecu_instance(0);
-    myNAME.set_function_instance(0);
-    myNAME.set_device_class_instance(0);
-    myNAME.set_manufacturer_code(64);
+      CANHardwareInterface::add_can_lib_update_callback(update_CAN_network, nullptr);
+      CANHardwareInterface::add_raw_can_message_rx_callback(raw_can_glue, nullptr);
 
-    // Create our InternalControlFunction
-    myECU = std::make_shared<isobus::InternalControlFunction>(myNAME, 0x1C, 0);
+      //! Make sure you change these for your device!!!!
+      //! This is an example device that is using a manufacturer code that is currently unused at time of writing
+      myNAME.set_arbitrary_address_capable(true);
+      myNAME.set_industry_group(1);
+      myNAME.set_device_class(0);
+      myNAME.set_function_code(static_cast<std::uint8_t>(isobus::NAME::Function::SteeringControl));
+      myNAME.set_identity_number(2);
+      myNAME.set_ecu_instance(0);
+      myNAME.set_function_instance(0);
+      myNAME.set_device_class_instance(0);
+      myNAME.set_manufacturer_code(64);
 
-    return 0;
+      // Create our InternalControlFunction
+      myECU = std::make_shared<isobus::InternalControlFunction>(myNAME, 0x1C, 0);
+
+      return 0;
    }
 
 Sweet! We're almost ready to send a message. Let's just add a few more things to make sure we gracefully stop the CAN stack when the program is done. This helps prevent memory leaks and crashing when exiting.
@@ -307,59 +313,61 @@ Make sure to include `csignal`.
 
    void signal_handler(int signum)
    {
-   	CANHardwareInterface::stop(); // Clean up the threads
-   	exit(signum);
+      CANHardwareInterface::stop(); // Clean up the threads
+		_exit(EXIT_FAILURE);
    }
 
    void update_CAN_network()
    {
-   	isobus::CANNetworkManager::CANNetwork.update();
+      isobus::CANNetworkManager::CANNetwork.update();
    }
-   
+
    void raw_can_glue(isobus::HardwareInterfaceCANFrame &rawFrame, void *parentPointer)
    {
-   	isobus::CANNetworkManager::CANNetwork.can_lib_process_rx_message(rawFrame, parentPointer);
+      isobus::CANNetworkManager::CANNetwork.can_lib_process_rx_message(rawFrame, parentPointer);
    }
-   
+
    int main()
    {
-    isobus::NAME myNAME(0); // Create an empty NAME
-    std::shared_ptr<isobus::InternalControlFunction> myECU = nullptr; // A pointer to hold our InternalControlFunction
+      isobus::NAME myNAME(0); // Create an empty NAME
+      std::shared_ptr<isobus::InternalControlFunction> myECU = nullptr; // A pointer to hold our InternalControlFunction
 
-    // Set up the hardware layer to use "can0"
-    SocketCANInterface canDriver("can0");
-    CANHardwareInterface::set_number_of_can_channels(1);
-    CANHardwareInterface::assign_can_channel_frame_handler(0, &canDriver);
+      // Set up the hardware layer to use SocketCAN interface on channel "can0"
+      std::shared_ptr<SocketCANInterface> canDriver = std::make_shared<SocketCANInterface>("can0");
+      CANHardwareInterface::set_number_of_can_channels(1);
+      CANHardwareInterface::assign_can_channel_frame_handler(0, canDriver);
 
-    if ((!CANHardwareInterface::start()) || (!canDriver.get_is_valid()))
-	{
-		std::cout << "Failed to connect to the socket. The interface might be down." << std::endl;
-	}
+      if ((!CANHardwareInterface::start()) || (!canDriver->get_is_valid()))
+      {
+         std::cout << "Failed to start hardware interface. The CAN driver might be invalid." << std::endl;
+         return -2;
+      }
 
-    // Handle control+c
-    std::signal(SIGINT, signal_handler);
+      // Handle control+c
+      std::signal(SIGINT, signal_handler);
 
-    CANHardwareInterface::add_can_lib_update_callback(update_CAN_network, nullptr);
-    CANHardwareInterface::add_raw_can_message_rx_callback(raw_can_glue, nullptr);
+      CANHardwareInterface::add_can_lib_update_callback(update_CAN_network, nullptr);
+      CANHardwareInterface::add_raw_can_message_rx_callback(raw_can_glue, nullptr);
 
-    // Set up NAME fields
-    myNAME.set_arbitrary_address_capable(true);
-    myNAME.set_industry_group(1);
-    myNAME.set_device_class(0);
-    myNAME.set_function_code(static_cast<std::uint8_t>(isobus::NAME::Function::SteeringControl));
-    myNAME.set_identity_number(2);
-    myNAME.set_ecu_instance(0);
-    myNAME.set_function_instance(0);
-    myNAME.set_device_class_instance(0);
-    myNAME.set_manufacturer_code(64);
+      //! Make sure you change these for your device!!!!
+      //! This is an example device that is using a manufacturer code that is currently unused at time of writing
+      myNAME.set_arbitrary_address_capable(true);
+      myNAME.set_industry_group(1);
+      myNAME.set_device_class(0);
+      myNAME.set_function_code(static_cast<std::uint8_t>(isobus::NAME::Function::SteeringControl));
+      myNAME.set_identity_number(2);
+      myNAME.set_ecu_instance(0);
+      myNAME.set_function_instance(0);
+      myNAME.set_device_class_instance(0);
+      myNAME.set_manufacturer_code(64);
 
-    // Create our InternalControlFunction
-    myECU = std::make_shared<isobus::InternalControlFunction>(myNAME, 0x1C, 0);
+      // Create our InternalControlFunction
+      myECU = std::make_shared<isobus::InternalControlFunction>(myNAME, 0x1C, 0);
 
-    // Clean up the threads
-    CANHardwareInterface::stop();
+      // Clean up the threads
+      CANHardwareInterface::stop();
 
-    return 0;
+      return 0;
    }
 
 Hurry Up And Wait
@@ -387,7 +395,7 @@ The total result:
    void signal_handler(int signum)
    {
    	CANHardwareInterface::stop(); // Clean up the threads
-   	exit(signum);
+		_exit(EXIT_FAILURE);
    }
 
    void update_CAN_network()
@@ -405,15 +413,16 @@ The total result:
     isobus::NAME myNAME(0); // Create an empty NAME
     std::shared_ptr<isobus::InternalControlFunction> myECU = nullptr; // A pointer to hold our InternalControlFunction
 
-    // Set up the hardware layer to use "can0"
-    SocketCANInterface canDriver("can0");
+    // Set up the hardware layer to use SocketCAN interface on channel "can0"
+    std::shared_ptr<SocketCANInterface> canDriver = std::make_shared<SocketCANInterface>("can0");
     CANHardwareInterface::set_number_of_can_channels(1);
-    CANHardwareInterface::assign_can_channel_frame_handler(0, &canDriver);
-    
-    if ((!CANHardwareInterface::start()) || (!canDriver.get_is_valid()))
-	{
-		std::cout << "Failed to connect to the socket. The interface might be down." << std::endl;
-	}
+    CANHardwareInterface::assign_can_channel_frame_handler(0, canDriver);
+
+    if ((!CANHardwareInterface::start()) || (!canDriver->get_is_valid()))
+    {
+    	 std::cout << "Failed to start hardware interface. The CAN driver might be invalid." << std::endl;
+    	 return -2;
+    }
 
     // Handle control+c
     std::signal(SIGINT, signal_handler);
@@ -421,7 +430,8 @@ The total result:
     CANHardwareInterface::add_can_lib_update_callback(update_CAN_network, nullptr);
     CANHardwareInterface::add_raw_can_message_rx_callback(raw_can_glue, nullptr);
 
-    // Set up NAME fields
+    //! Make sure you change these for your device!!!!
+    //! This is an example device that is using a manufacturer code that is currently unused at time of writing
     myNAME.set_arbitrary_address_capable(true);
     myNAME.set_industry_group(1);
     myNAME.set_device_class(0);

--- a/sphinx/source/Tutorials/The ISOBUS Hello World.rst
+++ b/sphinx/source/Tutorials/The ISOBUS Hello World.rst
@@ -311,7 +311,7 @@ Make sure to include `csignal`.
    #include <csignal>
    #include <iostream>
 
-   void signal_handler(int signum)
+   void signal_handler(int)
    {
       CANHardwareInterface::stop(); // Clean up the threads
 		_exit(EXIT_FAILURE);
@@ -392,7 +392,7 @@ The total result:
    #include <csignal>
    #include <iostream>
 
-   void signal_handler(int signum)
+   void signal_handler(int)
    {
    	CANHardwareInterface::stop(); // Clean up the threads
 		_exit(EXIT_FAILURE);

--- a/sphinx/source/Tutorials/Transport Layer.rst
+++ b/sphinx/source/Tutorials/Transport Layer.rst
@@ -25,7 +25,7 @@ To send a message of more than 8 bytes, simply send a message like normal, but w
 
 .. code-block:: c++
 
-   longMessage = std::uint8_t[2000] = {0};
+   std::uint8_t longMessage[2000] = {0};
 
    isobus::CANNetworkManager::CANNetwork.send_can_message(0xEF00, longMessage, 2000, myECU.get(), myPartner.get());
 
@@ -61,7 +61,7 @@ Here's an example:
 
 .. code-block:: c++
 
-	std::uint8_t testMessageData[100];
+	std::uint8_t testMessageData[100] = {0};
 
 	isobus::FastPacketProtocol::Protocol.send_multipacket_message(0x1F001, testMessageData, 100, someInternalControlFunction, nullptr, isobus::CANIdentifier::PriorityLowest7, nullptr);
 

--- a/sphinx/source/Tutorials/Virtual Terminal Basics.rst
+++ b/sphinx/source/Tutorials/Virtual Terminal Basics.rst
@@ -48,7 +48,7 @@ Create the file `main.cpp` as shown below inside that folder with the requisite 
 
 	using namespace std;
 
-	void signal_handler(int signum)
+	void signal_handler(int)
 	{
 		CANHardwareInterface::stop();
 		_exit(EXIT_FAILURE);
@@ -354,7 +354,7 @@ Here's the final code for this example:
 
 	using namespace std;
 
-	void signal_handler(int signum)
+	void signal_handler(int)
 	{
 		CANHardwareInterface::stop();
 		if (nullptr != TestVirtualTerminalClient)

--- a/test/address_claim_tests.cpp
+++ b/test/address_claim_tests.cpp
@@ -15,11 +15,11 @@ using namespace isobus;
 
 TEST(ADDRESS_CLAIM_TESTS, PartneredClaim)
 {
-	VirtualCANPlugin firstDevice;
-	VirtualCANPlugin secondDevice;
+	std::shared_ptr<VirtualCANPlugin> firstDevice = std::make_shared<VirtualCANPlugin>();
+	std::shared_ptr<VirtualCANPlugin> secondDevice = std::make_shared<VirtualCANPlugin>();
 	CANHardwareInterface::set_number_of_can_channels(2);
-	CANHardwareInterface::assign_can_channel_frame_handler(0, &firstDevice);
-	CANHardwareInterface::assign_can_channel_frame_handler(1, &secondDevice);
+	CANHardwareInterface::assign_can_channel_frame_handler(0, firstDevice);
+	CANHardwareInterface::assign_can_channel_frame_handler(1, secondDevice);
 	CANHardwareInterface::start();
 
 	CANHardwareInterface::add_can_lib_update_callback(

--- a/test/can_name_tests.cpp
+++ b/test/can_name_tests.cpp
@@ -30,7 +30,7 @@ TEST(CAN_NAME_TESTS, NAMEProperties)
 	EXPECT_EQ(TestDeviceNAME.get_function_instance(), 6);
 	EXPECT_EQ(TestDeviceNAME.get_device_class_instance(), 7);
 	EXPECT_EQ(TestDeviceNAME.get_manufacturer_code(), 8);
-	EXPECT_EQ(TestDeviceNAME.get_full_name(), 10881826125818888196);
+	EXPECT_EQ(TestDeviceNAME.get_full_name(), 10881826125818888196U);
 }
 
 TEST(CAN_NAME_TESTS, NAMEPropertiesOutOfRange)
@@ -39,26 +39,24 @@ TEST(CAN_NAME_TESTS, NAMEPropertiesOutOfRange)
 	TestDeviceNAME.set_industry_group(8);
 	TestDeviceNAME.set_device_class_instance(16);
 	TestDeviceNAME.set_device_class(128);
-	TestDeviceNAME.set_function_code(256);
 	TestDeviceNAME.set_identity_number(2097152);
-	TestDeviceNAME.set_ecu_instance(256);
-	TestDeviceNAME.set_function_instance(256);
-	TestDeviceNAME.set_manufacturer_code(65536);
+	TestDeviceNAME.set_ecu_instance(8);
+	TestDeviceNAME.set_function_instance(32);
+	TestDeviceNAME.set_manufacturer_code(2048);
 
 	EXPECT_NE(TestDeviceNAME.get_industry_group(), 8);
 	EXPECT_NE(TestDeviceNAME.get_device_class_instance(), 16);
 	EXPECT_NE(TestDeviceNAME.get_device_class(), 128);
-	EXPECT_NE(TestDeviceNAME.get_function_code(), 256);
-	EXPECT_NE(TestDeviceNAME.get_identity_number(), 2097152);
-	EXPECT_NE(TestDeviceNAME.get_ecu_instance(), 256);
-	EXPECT_NE(TestDeviceNAME.get_function_instance(), 256);
-	EXPECT_NE(TestDeviceNAME.get_manufacturer_code(), 65536);
+	EXPECT_NE(TestDeviceNAME.get_identity_number(), 2097151);
+	EXPECT_NE(TestDeviceNAME.get_ecu_instance(), 8);
+	EXPECT_NE(TestDeviceNAME.get_function_instance(), 32);
+	EXPECT_NE(TestDeviceNAME.get_manufacturer_code(), 2048);
 }
 
 TEST(CAN_NAME_TESTS, NAMEEquals)
 {
-	NAME firstNAME(10376445291390828545);
-	NAME secondNAME(10376445291390828545);
+	NAME firstNAME(10376445291390828545U);
+	NAME secondNAME(10376445291390828545U);
 	EXPECT_EQ(firstNAME, secondNAME);
 }
 


### PR DESCRIPTION
### What's new:
- Add automatic includes of available can drivers with the `isobus/hardware_integration/available_can_drivers.hpp` header file.
- Examples can now always be compiled. It will give a nice logging message if a CAN driver is missing and exit the application.
- Change the CANHardwareInterface to use `std::shared_ptr<CANHardwarePlugin>` instead of raw pointers.
- Minimize the amount of global variables. I think this is a good practice to reduce 'undefined behaviour'.
- Changed `exit` to `_exit` in signal handlers ([reference](https://stackoverflow.com/a/8833602))
- Updated tutorial website according to these changes.

I didn't intend to do so much at once but while I was at it I thought why not. Any feedback on these changes is welcome, I'm nowhere near experienced in c++ haha. 

I also wonder if we should change the other raw pointers to use `shared_ptr` and similar in the future? I think SonarCloud hints at that a bit.