### PR TITLE
[Core]: Optimize get pgn callback by returning ptr

### DIFF
--- a/examples/diagnostic_protocol/CMakeLists.txt
+++ b/examples/diagnostic_protocol/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.16)
 project(diagnostic_protocol_example)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if(NOT BUILD_EXAMPLES)

--- a/examples/nmea2000/CMakeLists.txt
+++ b/examples/nmea2000/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.16)
 project(nmea2000_example)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if(NOT BUILD_EXAMPLES)

--- a/examples/pgn_requests/CMakeLists.txt
+++ b/examples/pgn_requests/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.16)
 project(pgn_requests_example)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if(NOT BUILD_EXAMPLES)

--- a/examples/transport_layer/CMakeLists.txt
+++ b/examples/transport_layer/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.16)
 project(transport_layer_example)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if(NOT BUILD_EXAMPLES)

--- a/examples/vt_aux_n/CMakeLists.txt
+++ b/examples/vt_aux_n/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.16)
 project(vt_aux_n_example)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if(NOT BUILD_EXAMPLES)

--- a/examples/vt_version_3_object_pool/CMakeLists.txt
+++ b/examples/vt_version_3_object_pool/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.16)
 project(vt3_version_3_object_pool_example)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if(NOT BUILD_EXAMPLES)

--- a/hardware_integration/CMakeLists.txt
+++ b/hardware_integration/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Set source and include directories

--- a/hardware_integration/src/can_hardware_interface.cpp
+++ b/hardware_integration/src/can_hardware_interface.cpp
@@ -373,12 +373,11 @@ void CANHardwareInterface::can_thread_function()
 	while (threadsStarted)
 	{
 		std::unique_lock<std::mutex> lMutex(threadMutex);
+		threadConditionVariable.wait(lMutex);
 		CanHardware *pCANHardware;
 
 		if (threadsStarted)
 		{
-			threadConditionVariable.wait(lMutex, [] { return true; }); // Always wake up
-
 			for (std::uint32_t i = 0; i < hardwareChannels.size(); i++)
 			{
 				pCANHardware = hardwareChannels[i];

--- a/isobus/CMakeLists.txt
+++ b/isobus/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Set library public name

--- a/isobus/include/isobus/isobus/can_partnered_control_function.hpp
+++ b/isobus/include/isobus/isobus/can_partnered_control_function.hpp
@@ -64,23 +64,23 @@ namespace isobus
 
 		/// @brief Returns the number of parameter group number callbacks associated with this control function
 		/// @returns The number of parameter group number callbacks associated with this control function
-		std::uint32_t get_number_parameter_group_number_callbacks() const;
+		std::size_t get_number_parameter_group_number_callbacks() const;
 
 		/// @brief Returns the number of NAME filter objects that describe the identity of this control function
 		/// @returns The number of NAME filter objects that describe the identity of this control function
-		std::uint32_t get_number_name_filters() const;
+		std::size_t get_number_name_filters() const;
 
 		/// @brief Returns the number of NAME filters with a specific NAME parameter component, like manufacturer code
 		/// @param[in] parameter The NAME parameter to check against
 		/// @returns The number of NAME filters with a specific NAME parameter component
-		std::uint32_t get_number_name_filters_with_parameter_type(NAME::NAMEParameters parameter);
+		std::size_t get_number_name_filters_with_parameter_type(NAME::NAMEParameters parameter);
 
 		/// @brief Returns a NAME filter by index
 		/// @param[in] index The index of the filter to get
 		/// @param[out] parameter The returned parameter type
 		/// @param[out] filterValue The raw value of the filter associated with the `parameter`
 		/// @returns true if a filter was returned successfully, false if the index was out of range
-		bool get_name_filter_parameter(std::uint32_t index, NAME::NAMEParameters &parameter, std::uint32_t &filterValue) const;
+		bool get_name_filter_parameter(std::size_t index, NAME::NAMEParameters &parameter, std::uint32_t &filterValue) const;
 
 		/// @brief Checks to see if a NAME matches this CF's NAME filters
 		/// @param[in] NAMEToCheck The NAME to check against this control function's filters
@@ -90,19 +90,19 @@ namespace isobus
 		/// @brief Gets a PartneredControlFunction by index
 		/// @param[in] index The index of the PartneredControlFunction to get
 		/// @returns a PartneredControlFunction at the index specified from `partneredControlFunctionList`
-		static PartneredControlFunction *get_partnered_control_function(std::uint32_t index);
+		static PartneredControlFunction *get_partnered_control_function(std::size_t index);
 
 		/// @brief Returns the number of created partner control functions
 		/// @returns The number of created partner control functions from the static list of all of them
-		static std::uint32_t get_number_partnered_control_functions();
+		static std::size_t get_number_partnered_control_functions();
 
 	private:
 		friend class CANNetworkManager; ///< Allows the network manager to use get_parameter_group_number_callback
 
 		/// @brief Returns a parameter group number associated with this control function by index
-		/// @param[in] index  The index from which to get the PGN callback data object
-		/// @returns The PGN callback data associated with the index that was passed in
-		ParameterGroupNumberCallbackData get_parameter_group_number_callback(std::uint32_t index) const;
+		/// @param[in] index The index from which to get the PGN callback data object
+		/// @returns A reference to the PGN callback data object at the index specified
+		ParameterGroupNumberCallbackData &get_parameter_group_number_callback(std::size_t index);
 
 		static std::vector<PartneredControlFunction *> partneredControlFunctionList; ///< A list of all created partnered control functions
 		static bool anyPartnerNeedsInitializing; ///< A way for the network manager to know if it needs to parse the partner list to match partners with existing CFs

--- a/isobus/src/can_network_manager.cpp
+++ b/isobus/src/can_network_manager.cpp
@@ -696,7 +696,7 @@ namespace isobus
 			      (NULL_CAN_ADDRESS == message->get_identifier().get_source_address()))))
 			{
 				// Message destined to global
-				for (std::uint32_t i = 0; i < get_number_global_parameter_group_number_callbacks(); i++)
+				for (std::size_t i = 0; i < get_number_global_parameter_group_number_callbacks(); i++)
 				{
 					if ((message->get_identifier().get_parameter_group_number() == get_global_parameter_group_number_callback(i).get_parameter_group_number()) &&
 					    (nullptr != get_global_parameter_group_number_callback(i).get_callback()))
@@ -709,12 +709,12 @@ namespace isobus
 			else
 			{
 				// Message is destination specific
-				for (std::uint32_t i = 0; i < InternalControlFunction::get_number_internal_control_functions(); i++)
+				for (std::size_t i = 0; i < InternalControlFunction::get_number_internal_control_functions(); i++)
 				{
 					if (messageDestination == InternalControlFunction::get_internal_control_function(i))
 					{
 						// Message is destined to us
-						for (std::uint32_t j = 0; j < PartneredControlFunction::get_number_partnered_control_functions(); j++)
+						for (std::size_t j = 0; j < PartneredControlFunction::get_number_partnered_control_functions(); j++)
 						{
 							PartneredControlFunction *currentControlFunction = PartneredControlFunction::get_partnered_control_function(j);
 
@@ -722,7 +722,7 @@ namespace isobus
 							    (currentControlFunction->get_can_port() == message->get_can_port_index()))
 							{
 								// Message matches CAN port for a partnered control function
-								for (std::uint32_t k = 0; k < currentControlFunction->get_number_parameter_group_number_callbacks(); k++)
+								for (std::size_t k = 0; k < currentControlFunction->get_number_parameter_group_number_callbacks(); k++)
 								{
 									if ((message->get_identifier().get_parameter_group_number() == currentControlFunction->get_parameter_group_number_callback(k).get_parameter_group_number()) &&
 									    (nullptr != currentControlFunction->get_parameter_group_number_callback(k).get_callback()))

--- a/isobus/src/can_partnered_control_function.cpp
+++ b/isobus/src/can_partnered_control_function.cpp
@@ -13,6 +13,7 @@
 #include "isobus/isobus/can_network_manager.hpp"
 
 #include <algorithm>
+#include <cassert>
 
 namespace isobus
 {
@@ -68,17 +69,17 @@ namespace isobus
 		}
 	}
 
-	std::uint32_t PartneredControlFunction::get_number_parameter_group_number_callbacks() const
+	std::size_t PartneredControlFunction::get_number_parameter_group_number_callbacks() const
 	{
 		return parameterGroupNumberCallbacks.size();
 	}
 
-	std::uint32_t PartneredControlFunction::get_number_name_filters() const
+	std::size_t PartneredControlFunction::get_number_name_filters() const
 	{
 		return NAMEFilterList.size();
 	}
 
-	bool PartneredControlFunction::get_name_filter_parameter(std::uint32_t index, NAME::NAMEParameters &parameter, std::uint32_t &filterValue) const
+	bool PartneredControlFunction::get_name_filter_parameter(std::size_t index, NAME::NAMEParameters &parameter, std::uint32_t &filterValue) const
 	{
 		bool retVal = false;
 
@@ -91,11 +92,11 @@ namespace isobus
 		return retVal;
 	}
 
-	std::uint32_t PartneredControlFunction::get_number_name_filters_with_parameter_type(NAME::NAMEParameters parameter)
+	std::size_t PartneredControlFunction::get_number_name_filters_with_parameter_type(NAME::NAMEParameters parameter)
 	{
-		std::uint32_t retVal = 0;
+		std::size_t retVal = 0;
 
-		for (uint32_t i = 0; i < NAMEFilterList.size(); i++)
+		for (std::size_t i = 0; i < NAMEFilterList.size(); i++)
 		{
 			if (parameter == NAMEFilterList[i].get_parameter())
 			{
@@ -191,7 +192,7 @@ namespace isobus
 		return retVal;
 	}
 
-	PartneredControlFunction *PartneredControlFunction::get_partnered_control_function(std::uint32_t index)
+	PartneredControlFunction *PartneredControlFunction::get_partnered_control_function(std::size_t index)
 	{
 		PartneredControlFunction *retVal = nullptr;
 
@@ -205,20 +206,15 @@ namespace isobus
 		return retVal;
 	}
 
-	std::uint32_t PartneredControlFunction::get_number_partnered_control_functions()
+	std::size_t PartneredControlFunction::get_number_partnered_control_functions()
 	{
 		return partneredControlFunctionList.size();
 	}
 
-	ParameterGroupNumberCallbackData PartneredControlFunction::get_parameter_group_number_callback(std::uint32_t index) const
+	ParameterGroupNumberCallbackData &PartneredControlFunction::get_parameter_group_number_callback(std::size_t index)
 	{
-		ParameterGroupNumberCallbackData retVal(0, nullptr, nullptr);
-
-		if (index < get_number_parameter_group_number_callbacks())
-		{
-			retVal = parameterGroupNumberCallbacks[index];
-		}
-		return retVal;
+		assert(index < get_number_parameter_group_number_callbacks());
+		return parameterGroupNumberCallbacks[index];
 	}
 
 } // namespace isobus

--- a/utility/CMakeLists.txt
+++ b/utility/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Set source and include directories


### PR DESCRIPTION
- Don't always wake up hardware interface thread as it raises watchdog timer exceptions on some platforms (e.g. ESP32). I know sonar doesn't like it, but I guess it gets enough inputs for it to wake up such that is safe to ignore the warning.
- Switch from copying `ParameterGroupNumberCallbackData` to returning a pointer to optimize memory performance.