### PR TITLE
[Examples]: Change `_exit` to `_Exit`

### DIFF
--- a/examples/diagnostic_protocol/main.cpp
+++ b/examples/diagnostic_protocol/main.cpp
@@ -16,7 +16,7 @@ void signal_handler(int)
 {
 	isobus::DiagnosticProtocol::deassign_all_diagnostic_protocol_to_internal_control_functions();
 	CANHardwareInterface::stop();
-	_exit(EXIT_FAILURE);
+	_Exit(EXIT_FAILURE);
 }
 
 void update_CAN_network()

--- a/examples/nmea2000/main.cpp
+++ b/examples/nmea2000/main.cpp
@@ -38,7 +38,7 @@ void signal_handler(int)
 {
 	CANHardwareInterface::stop();
 	isobus::FastPacketProtocol::Protocol.remove_multipacket_message_callback(0x1F001, nmea2k_callback, nullptr);
-	_exit(EXIT_FAILURE);
+	_Exit(EXIT_FAILURE);
 }
 
 void update_CAN_network()

--- a/examples/pgn_requests/main.cpp
+++ b/examples/pgn_requests/main.cpp
@@ -6,6 +6,7 @@
 #include "isobus/isobus/can_network_manager.hpp"
 #include "isobus/isobus/can_parameter_group_number_request_protocol.hpp"
 
+#include <atomic>
 #include <csignal>
 #include <iostream>
 #include <memory>
@@ -13,13 +14,13 @@
 //! It is discouraged to use global variables, but it is done here for simplicity.
 static std::uint32_t propARepetitionRate_ms = 0xFFFFFFFF;
 static isobus::ControlFunction *repetitionRateRequestor = nullptr;
+static std::atomic_bool running = { true };
 
 using namespace std;
 
 void signal_handler(int)
 {
-	CANHardwareInterface::stop();
-	_Exit(EXIT_FAILURE);
+	running = false;
 }
 
 void update_CAN_network()
@@ -172,7 +173,7 @@ int main()
 		isobus::ParameterGroupNumberRequestProtocol::request_parameter_group_number(static_cast<std::uint32_t>(isobus::CANLibParameterGroupNumber::ProprietaryA), TestInternalECU.get(), nullptr);
 	}
 
-	while (true)
+	while (running)
 	{
 		if (0xFFFFFFFF != propARepetitionRate_ms)
 		{

--- a/examples/pgn_requests/main.cpp
+++ b/examples/pgn_requests/main.cpp
@@ -19,7 +19,7 @@ using namespace std;
 void signal_handler(int)
 {
 	CANHardwareInterface::stop();
-	_exit(EXIT_FAILURE);
+	_Exit(EXIT_FAILURE);
 }
 
 void update_CAN_network()

--- a/examples/transport_layer/main.cpp
+++ b/examples/transport_layer/main.cpp
@@ -20,7 +20,7 @@ using namespace std;
 void signal_handler(int)
 {
 	CANHardwareInterface::stop();
-	_exit(EXIT_FAILURE);
+	_Exit(EXIT_FAILURE);
 }
 
 void update_CAN_network()

--- a/examples/vt_aux_n/main.cpp
+++ b/examples/vt_aux_n/main.cpp
@@ -10,23 +10,20 @@
 #include "console_logger.cpp"
 #include "object_pool_ids.h"
 
+#include <atomic>
 #include <csignal>
 #include <iostream>
 #include <memory>
 
 //! It is discouraged to use global variables, but it is done here for simplicity.
 static std::shared_ptr<isobus::VirtualTerminalClient> TestVirtualTerminalClient = nullptr;
+static std::atomic_bool running = { true };
 
 using namespace std;
 
 void signal_handler(int)
 {
-	CANHardwareInterface::stop();
-	if (nullptr != TestVirtualTerminalClient)
-	{
-		TestVirtualTerminalClient->terminate();
-	}
-	_Exit(EXIT_FAILURE);
+	running = false;
 }
 
 void update_CAN_network()
@@ -119,12 +116,13 @@ int main()
 	TestVirtualTerminalClient->register_auxiliary_input_event_callback(handle_aux_input);
 	TestVirtualTerminalClient->initialize(true);
 
-	while (true)
+	while (running)
 	{
 		// CAN stack runs in other threads. Do nothing forever.
 		std::this_thread::sleep_for(std::chrono::milliseconds(1000));
 	}
 
+	TestVirtualTerminalClient->terminate();
 	CANHardwareInterface::stop();
 	return 0;
 }

--- a/examples/vt_aux_n/main.cpp
+++ b/examples/vt_aux_n/main.cpp
@@ -26,7 +26,7 @@ void signal_handler(int)
 	{
 		TestVirtualTerminalClient->terminate();
 	}
-	_exit(EXIT_FAILURE);
+	_Exit(EXIT_FAILURE);
 }
 
 void update_CAN_network()

--- a/examples/vt_version_3_object_pool/main.cpp
+++ b/examples/vt_version_3_object_pool/main.cpp
@@ -26,7 +26,7 @@ void signal_handler(int)
 	{
 		TestVirtualTerminalClient->terminate();
 	}
-	_exit(EXIT_FAILURE);
+	_Exit(EXIT_FAILURE);
 }
 
 void update_CAN_network()


### PR DESCRIPTION
Pushed this to fix the following issue when building examples under linux:

```
../../../examples/nmea2000/main.cpp:41:2: error: ‘_exit’ was not declared in this scope; did you mean ‘_Exit’?
   41 |  _exit(EXIT_FAILURE);
      |  ^~~~~
      |  _Exit
```