### PR TITLE
[Meta]: Run build workflow when approve job is skipped

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,7 @@ jobs:
     name: Setup
     runs-on: ubuntu-latest
     needs: approve
+    if: ${{ needs.approve.result == 'success' || needs.approve.result == 'skipped' }}
     steps:
       - name: Set up Python 3.8 for gcovr
         uses: actions/setup-python@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,8 +24,8 @@ jobs:
       - name: Approve
         run: echo For security reasons, all pull requests need to be approved first before running any automated build CI.
 
-  setup:
-    name: Setup
+  build_test_analyze:
+    name: Build, Test and Analyze
     runs-on: ubuntu-latest
     needs: approve
     if: ${{ needs.approve.result == 'success' || needs.approve.result == 'skipped' }}
@@ -43,12 +43,6 @@ jobs:
         uses: github/codeql-action/init@v2
         with:
           languages: "cpp"
-
-  build:
-    name: Build
-    runs-on: ubuntu-latest
-    needs: setup
-    steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
@@ -59,22 +53,9 @@ jobs:
           mkdir build
           cmake -S . -B build -DBUILD_EXAMPLES=ON -DBUILD_TESTING=ON -DCAN_DRIVER=SocketCAN
           build-wrapper-linux-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} cmake --build build/ --config ${{ env.BUILD_TYPE }}
-
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
       - name: Run
         working-directory: ${{github.workspace}}/build
         run: ctest -C ${{ env.BUILD_TYPE }}
-
-  analyze:
-    name: Analyze
-    runs-on: ubuntu-latest
-    needs: test
-
-    steps:
       - name: Collect coverage into one XML report
         run: |
           gcovr --sonarqube > coverage.xml


### PR DESCRIPTION
This was the case when the workflow trigger event ran when a commit was pushed to main branch. See [runs/4136493254](https://github.com/ad3154/ISO11783-CAN-Stack/actions/runs/4136493254)