### PR TITLE
[Meta]: Fix build workflow not running on main branch commit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,8 +28,14 @@ jobs:
     name: Build, Test and Analyze
     runs-on: ubuntu-latest
     needs: approve
-    if: ${{ needs.approve.result == 'success' || needs.approve.result == 'skipped' }}
+    # Only run if the approve job succeeded or was skipped, as it continues on error
+    if: ${{ always() && needs.approve.result == 'success' || needs.approve.result == 'skipped' }} 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
+          ref: ${{ github.event.pull_request.head.sha }} # Check out the code of the PR head
       - name: Set up Python 3.8 for gcovr
         uses: actions/setup-python@v4
         with:
@@ -43,11 +49,6 @@ jobs:
         uses: github/codeql-action/init@v2
         with:
           languages: "cpp"
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
-          ref: ${{ github.event.pull_request.head.sha }} # Check out the code of the PR head
       - name: Run build-wrapper
         run: |
           mkdir build


### PR DESCRIPTION
- Moved checkout step to the top of the job
- Add always condition to if statement of build workflow

It should now finally run successful, I tested it here:
https://github.com/GwnDaan/ISO11783-CAN-Stack/actions/runs/4146377330/jobs/7171955224

**Note:** the build workflow will fail on this PR as the checkout step is not at the top of the job for the base commit of this PR. We can't do anything about it because of the nature of the `pull_request_target` trigger.