### PR TITLE
[DP]: Fix diagnostic protocol create/destroy bugs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,7 @@ if(BUILD_TESTING)
   # Set test source files
   set(TEST_SRC
       test/identifier_tests.cpp
-      test/dm_13_tests.cpp
+      test/diagnostic_protocol_tests.cpp
       test/core_network_management_tests.cpp
       test/virtual_can_plugin_tests.cpp
       test/address_claim_tests.cpp

--- a/isobus/src/isobus_diagnostic_protocol.cpp
+++ b/isobus/src/isobus_diagnostic_protocol.cpp
@@ -133,7 +133,6 @@ namespace isobus
 		if (retVal)
 		{
 			DiagnosticProtocol *newProtocol = new DiagnosticProtocol(internalControlFunction);
-			diagnosticProtocolList.push_back(newProtocol);
 			// PGN protocol will check for duplicates, so no worries if there's already a request protocol registered.
 			ParameterGroupNumberRequestProtocol::assign_pgn_request_protocol_to_internal_control_function(internalControlFunction);
 			ParameterGroupNumberRequestProtocol::get_pgn_request_protocol_by_internal_control_function(internalControlFunction)->register_pgn_request_callback(static_cast<std::uint32_t>(CANLibParameterGroupNumber::DiagnosticMessage2), process_parameter_group_number_request, newProtocol);
@@ -170,11 +169,11 @@ namespace isobus
 
 	void DiagnosticProtocol::deassign_all_diagnostic_protocol_to_internal_control_functions()
 	{
-		for (isobus::DiagnosticProtocol *protocol : diagnosticProtocolList)
+		while (0 != diagnosticProtocolList.size())
 		{
-			// First, remove callbacks from PGN requests
-			protocol->deregister_all_pgns();
-			delete protocol;
+			DiagnosticProtocol *tempProtocol = diagnosticProtocolList.front();
+			tempProtocol->deregister_all_pgns();
+			delete tempProtocol; // The destructor removes it from the list, so just deleting it is enough to prune it
 		}
 	}
 

--- a/test/diagnostic_protocol_tests.cpp
+++ b/test/diagnostic_protocol_tests.cpp
@@ -5,7 +5,7 @@
 
 using namespace isobus;
 
-TEST(DM13_TESTS, TestNetworkParsing)
+TEST(DIAGNOSTIC_PROTOCOL_TESTS, DM13TestNetworkParsing)
 {
 	std::uint32_t testNetworkStates = 0;
 	CANIdentifier testID(CANIdentifier::Type::Extended,
@@ -19,7 +19,7 @@ TEST(DM13_TESTS, TestNetworkParsing)
 	EXPECT_EQ(true, DiagnosticProtocol::parse_j1939_network_states(&testDM13Message, testNetworkStates));
 }
 
-TEST(DM13_TESTS, TestInvalidDM13Rejection)
+TEST(DIAGNOSTIC_PROTOCOL_TESTS, TestInvalidDM13Rejection)
 {
 	std::uint32_t testNetworkStates = 0;
 	CANIdentifier testID(CANIdentifier::Type::Extended,
@@ -31,4 +31,21 @@ TEST(DM13_TESTS, TestInvalidDM13Rejection)
 	testDM13Message.set_identifier(testID);
 	testDM13Message.set_data_size(4);
 	EXPECT_EQ(false, DiagnosticProtocol::parse_j1939_network_states(&testDM13Message, testNetworkStates));
+}
+
+TEST(DIAGNOSTIC_PROTOCOL_TESTS, CreateAndDestroyProtocolObjects)
+{
+	NAME TestDeviceNAME(0);
+
+	auto TestInternalECU = std::make_shared<InternalControlFunction>(TestDeviceNAME, 0x1C, 0);
+
+	DiagnosticProtocol::assign_diagnostic_protocol_to_internal_control_function(TestInternalECU);
+	DiagnosticProtocol *diagnosticProtocol = DiagnosticProtocol::get_diagnostic_protocol_by_internal_control_function(TestInternalECU);
+	EXPECT_NE(nullptr, diagnosticProtocol);
+
+	if (nullptr != diagnosticProtocol)
+	{
+		EXPECT_NO_THROW(DiagnosticProtocol::deassign_all_diagnostic_protocol_to_internal_control_functions());
+		EXPECT_EQ(nullptr, DiagnosticProtocol::get_diagnostic_protocol_by_internal_control_function(TestInternalECU));
+	}
 }


### PR DESCRIPTION
* Fixed an issue where duplicate instances of the diagnostic protocol would be created when only 1 should exist. 
* Fixed an issue when deleting a diagnostic protocol, where we might throw an exception when traversing the list of protocols due to us deleting objects from within that list while traversing it. 
* Renamed the DM13 test to be more inclusive of all diagnostic protocol tests. 
* Added a test for creating and destroying diagnostic protocols.