### PR TITLE
[Core]: Mitigate an order of operations issue with static destructors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,9 +70,9 @@ jobs:
         run: |
           sonar-scanner \
             --define sonar.cfamily.build-wrapper-output="${{ env.BUILD_WRAPPER_OUT_DIR }}" \
-            --define sonar.coverageReportPaths=coverage.xml
+            --define sonar.coverageReportPaths=coverage.xml \
             --define sonar.pullrequest.github.repository=${{ github.event.pull_request.base.repo.full_name }} \
-            --define sonar.scm.revision=${{ github.event.pull_request.head.sha }}
+            --define sonar.scm.revision=${{ github.event.pull_request.head.sha }} \
             --define sonar.pullrequest.key=$PR_NUMBER \
             --define sonar.pullrequest.branch=$PR_HEAD_REF \
             --define sonar.pullrequest.base=$PR_BASE_REF

--- a/isobus/src/can_internal_control_function.cpp
+++ b/isobus/src/can_internal_control_function.cpp
@@ -40,8 +40,15 @@ namespace isobus
 	InternalControlFunction::~InternalControlFunction()
 	{
 		const std::lock_guard<std::mutex> lock(ControlFunction::controlFunctionProcessingMutex);
-		auto thisObject = std::find(internalControlFunctionList.begin(), internalControlFunctionList.end(), this);
-		*thisObject = nullptr; // Don't erase, just null it out. Erase could cause a double free.
+		if (0 != internalControlFunctionList.size())
+		{
+			auto thisObject = std::find(internalControlFunctionList.begin(), internalControlFunctionList.end(), this);
+
+			if (internalControlFunctionList.end() != thisObject)
+			{
+				*thisObject = nullptr; // Don't erase, just null it out. Erase could cause a double free.
+			}
+		}
 	}
 
 	InternalControlFunction *InternalControlFunction::get_internal_control_function(std::uint32_t index)

--- a/isobus/src/can_partnered_control_function.cpp
+++ b/isobus/src/can_partnered_control_function.cpp
@@ -49,9 +49,16 @@ namespace isobus
 	PartneredControlFunction::~PartneredControlFunction()
 	{
 		const std::lock_guard<std::mutex> lock(ControlFunction::controlFunctionProcessingMutex);
-		auto thisObject = std::find(partneredControlFunctionList.begin(), partneredControlFunctionList.end(), this);
-		*thisObject = nullptr; // Don't erase, in case the object was already deleted. Just make room for a new partner.
-		CANNetworkManager::CANNetwork.on_partner_deleted(this, {}); // Tell the network manager to purge this partner from all tables
+		if (0 != partneredControlFunctionList.size())
+		{
+			auto thisObject = std::find(partneredControlFunctionList.begin(), partneredControlFunctionList.end(), this);
+
+			if (partneredControlFunctionList.end() != thisObject)
+			{
+				*thisObject = nullptr; // Don't erase, in case the object was already deleted. Just make room for a new partner.
+				CANNetworkManager::CANNetwork.on_partner_deleted(this, {}); // Tell the network manager to purge this partner from all tables
+			}
+		}
 	}
 
 	void PartneredControlFunction::add_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent)


### PR DESCRIPTION
Sometimes the order of static object destruction can be a bit unpredictable, so sometimes I was seeing that the lists that contain the internal and partner control functions would be cleared before we could access them in the destructors of those objects specifically when those objects were global statics (like in the examples). So I added a trivial check to ensure those lists contains > 0 objects before trying to do any further operations with it inside those destructors.