### PR TITLE
[CI] Make sonar-scanner aware of pull request key, branch, base and repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,12 +7,6 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened]
 
-env:
-  BUILD_TYPE: Release
-  BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-
 jobs:
   approve:
     name: Approve
@@ -27,9 +21,14 @@ jobs:
   build_test_analyze:
     name: Build, Test and Analyze
     runs-on: ubuntu-latest
+    env:
+      BUILD_TYPE: Release
+      BUILD_WRAPPER_OUT_DIR: build-wrapper-output
+
     needs: approve
     # Only run if the approve job succeeded or was skipped, as it continues on error
     if: ${{ always() && needs.approve.result == 'success' || needs.approve.result == 'skipped' }} 
+    
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -61,11 +60,23 @@ jobs:
         run: |
           gcovr --sonarqube --exclude-throw-branches > coverage.xml
       - name: Run sonar-scanner
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
         if: "${{ env.SONAR_TOKEN != '' }}"
         run: |
           sonar-scanner \
             --define sonar.cfamily.build-wrapper-output="${{ env.BUILD_WRAPPER_OUT_DIR }}" \
             --define sonar.coverageReportPaths=coverage.xml
+            --define sonar.pullrequest.github.repository=${{ github.event.pull_request.base.repo.full_name }} \
+            --define sonar.scm.revision=${{ github.event.pull_request.head.sha }}
+            --define sonar.pullrequest.key=$PR_NUMBER \
+            --define sonar.pullrequest.branch=$PR_HEAD_REF \
+            --define sonar.pullrequest.base=$PR_BASE_REF
+          echo "SonarCloud analysis finished for PR '$PR_NUMBER' for merge into '$PR_HEAD_REF' from '$PR_BASE_REF'"
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2
         with:


### PR DESCRIPTION
SonarCloud should now be able to know which PR an analysis is run on. With that it should comment on the PR with the results of the analysis.

I think these changes are necessary as I found the following in the logs:
From an old `sonar.yml` action ([source](https://github.com/ad3154/ISO11783-CAN-Stack/actions/runs/4120407728/jobs/7115102457)):
```
INFO: Github event: pull_request
INFO: Auto-configuring pull request 169
```
Where it's now just ([source](https://github.com/ad3154/ISO11783-CAN-Stack/actions/runs/4149001579/jobs/7177575436)):
```
INFO: Github event: pull_request_target
```
where it's not telling us it's auto configuring, so I guess we can configure it manually for now😄 

Let's pray this does the job, I find the use of the `pull_request_target` event still kind of sketchy haha