### PR TITLE
[Core]: Improvements to CANHardwareInterface 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,7 @@ if(BUILD_TESTING)
       test/core_network_management_tests.cpp
       test/virtual_can_plugin_tests.cpp
       test/address_claim_tests.cpp
-      test/can_name_tests.cpp 
+      test/can_name_tests.cpp
       test/hardware_interface_tests.cpp
       test/vt_client_tests.cpp
       test/language_command_interface_tests.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,8 @@ if(BUILD_TESTING)
       test/core_network_management_tests.cpp
       test/virtual_can_plugin_tests.cpp
       test/address_claim_tests.cpp
-      test/can_name_tests.cpp
+      test/can_name_tests.cpp 
+      test/hardware_interface_tests.cpp
       test/vt_client_tests.cpp
       test/language_command_interface_tests.cpp)
 

--- a/hardware_integration/include/isobus/hardware_integration/can_hardware_interface.hpp
+++ b/hardware_integration/include/isobus/hardware_integration/can_hardware_interface.hpp
@@ -9,6 +9,7 @@
 #ifndef CAN_HARDWARE_INTERFACE_HPP
 #define CAN_HARDWARE_INTERFACE_HPP
 
+#include <atomic>
 #include <condition_variable>
 #include <cstdint>
 #include <cstring>
@@ -34,30 +35,6 @@
 class CANHardwareInterface
 {
 public:
-	/// @brief A class to store information about CAN lib update callbacks
-	class CanLibUpdateCallbackInfo
-	{
-	public:
-		/// @brief Allows easy comparison of callback data
-		/// @param obj the object to compare against
-		bool operator==(const CanLibUpdateCallbackInfo &obj) const;
-
-		void (*callback)() = nullptr; ///< The callback
-		void *parent = nullptr; ///< Context variable, the owner of the callback
-	};
-
-	/// @brief A class to store information about Rx callbacks
-	class RawCanMessageCallbackInfo
-	{
-	public:
-		/// @brief Allows easy comparison of callback data
-		/// @param obj the object to compare against
-		bool operator==(const RawCanMessageCallbackInfo &obj) const;
-
-		void (*callback)(isobus::HardwareInterfaceCANFrame &rxFrame, void *parentPointer) = nullptr; ///< The callback
-		void *parent = nullptr; ///< Context variable, the owner of the callback
-	};
-
 	CANHardwareInterface() = delete;
 
 	/// @brief Returns the number of configured CAN channels that the class is managing
@@ -129,6 +106,30 @@ public:
 	static bool remove_can_lib_update_callback(void (*callback)(), void *parentPointer);
 
 private:
+	/// @brief A class to store information about CAN lib update callbacks
+	class CanLibUpdateCallbackInfo
+	{
+	public:
+		/// @brief Allows easy comparison of callback data
+		/// @param obj the object to compare against
+		bool operator==(const CanLibUpdateCallbackInfo &obj) const;
+
+		void (*callback)() = nullptr; ///< The callback
+		void *parent = nullptr; ///< Context variable, the owner of the callback
+	};
+
+	/// @brief A class to store information about Rx callbacks
+	class RawCanMessageCallbackInfo
+	{
+	public:
+		/// @brief Allows easy comparison of callback data
+		/// @param obj the object to compare against
+		bool operator==(const RawCanMessageCallbackInfo &obj) const;
+
+		void (*callback)(isobus::HardwareInterfaceCANFrame &rxFrame, void *parentPointer) = nullptr; ///< The callback
+		void *parent = nullptr; ///< Context variable, the owner of the callback
+	};
+
 	/// @brief Stores the Tx/Rx queues, mutexes, and driver needed to run a single CAN channel
 	struct CANHardware
 	{

--- a/hardware_integration/include/isobus/hardware_integration/can_hardware_interface.hpp
+++ b/hardware_integration/include/isobus/hardware_integration/can_hardware_interface.hpp
@@ -35,8 +35,6 @@
 class CANHardwareInterface
 {
 public:
-	CANHardwareInterface() = delete;
-
 	/// @brief Returns the number of configured CAN channels that the class is managing
 	/// @returns The number of configured CAN channels that the class is managing
 	static std::uint8_t get_number_of_can_channels();
@@ -144,6 +142,16 @@ private:
 		std::shared_ptr<CANHardwarePlugin> frameHandler; ///< The CAN driver to use for a CAN channel
 	};
 
+	/// @brief Singleton instance of the CANHardwareInterface class
+	/// @details This is a little hack that allows to have the destructor called
+	static CANHardwareInterface SINGLETON;
+
+	/// @brief Constructor for the CANHardwareInterface class
+	CANHardwareInterface() = default;
+
+	/// @brief Deconstructor for the CANHardwareInterface class
+	virtual ~CANHardwareInterface();
+
 	/// @brief The default update interval for the CAN stack. Mostly arbitrary
 	static constexpr std::uint32_t PERIODIC_UPDATE_INTERVAL = 4;
 
@@ -160,6 +168,9 @@ private:
 
 	/// @brief The periodic update thread executes this function
 	static void update_can_lib_periodic_function();
+
+	/// @brief Stops all threads related to the hardware interface
+	static void stop_threads();
 
 	static std::unique_ptr<std::thread> canThread; ///< The main CAN thread
 	static std::unique_ptr<std::thread> periodicUpdateThread; ///< A thread that periodically wakes up to update the CAN stack

--- a/hardware_integration/include/isobus/hardware_integration/virtual_can_plugin.hpp
+++ b/hardware_integration/include/isobus/hardware_integration/virtual_can_plugin.hpp
@@ -37,6 +37,9 @@ public:
 	/// @param[in] receiveOwnMessages If `true`, the driver will receive its own messages.
 	VirtualCANPlugin(const std::string channel = "", const bool receiveOwnMessages = false);
 
+	/// @brief Destructor for the virtual CAN driver
+	virtual ~VirtualCANPlugin();
+
 	/// @brief Returns if the socket connection is valid
 	/// @returns `true` if connected, `false` if not connected
 	bool get_is_valid() const override;
@@ -61,6 +64,10 @@ public:
 	/// @returns `true` if the frame was written, otherwise `false`
 	bool write_frame(const isobus::HardwareInterfaceCANFrame &canFrame) override;
 
+	/// @brief Allows us to write messages as if we received them from the bus
+	/// @param[in] canFrame The frame to write to the bus
+	void write_frame_as_if_received(const isobus::HardwareInterfaceCANFrame &canFrame);
+
 private:
 	/// @brief A struct holding information about a virtual CAN device
 	struct VirtualDevice
@@ -78,7 +85,7 @@ private:
 	const bool receiveOwnMessages; ///< If `true`, the driver will receive its own messages
 
 	std::shared_ptr<VirtualDevice> ourDevice; ///< A pointer to the virtual device of this instance
-	bool running; ///< If `true`, the driver is running
+	std::atomic_bool running; ///< If `true`, the driver is running
 };
 
 #endif // VIRTUAL_CAN_PLUGIN_HPP

--- a/hardware_integration/include/isobus/hardware_integration/virtual_can_plugin.hpp
+++ b/hardware_integration/include/isobus/hardware_integration/virtual_can_plugin.hpp
@@ -14,6 +14,7 @@
 #include "isobus/isobus/can_frame.hpp"
 #include "isobus/isobus/can_hardware_abstraction.hpp"
 
+#include <atomic>
 #include <condition_variable>
 #include <deque>
 #include <map>

--- a/hardware_integration/include/isobus/hardware_integration/virtual_can_plugin.hpp
+++ b/hardware_integration/include/isobus/hardware_integration/virtual_can_plugin.hpp
@@ -67,7 +67,7 @@ public:
 
 	/// @brief Allows us to write messages as if we received them from the bus
 	/// @param[in] canFrame The frame to write to the bus
-	void write_frame_as_if_received(const isobus::HardwareInterfaceCANFrame &canFrame);
+	void write_frame_as_if_received(const isobus::HardwareInterfaceCANFrame &canFrame) const;
 
 private:
 	/// @brief A struct holding information about a virtual CAN device

--- a/hardware_integration/src/virtual_can_plugin.cpp
+++ b/hardware_integration/src/virtual_can_plugin.cpp
@@ -22,7 +22,9 @@ VirtualCANPlugin::VirtualCANPlugin(const std::string channel, const bool receive
 
 VirtualCANPlugin::~VirtualCANPlugin()
 {
-	close();
+	// Prevent a deadlock in the read_frame() function
+	running = false;
+	ourDevice->condition.notify_one();
 }
 
 bool VirtualCANPlugin::get_is_valid() const
@@ -65,7 +67,7 @@ bool VirtualCANPlugin::write_frame(const isobus::HardwareInterfaceCANFrame &canF
 	return retVal;
 }
 
-void VirtualCANPlugin::write_frame_as_if_received(const isobus::HardwareInterfaceCANFrame &canFrame)
+void VirtualCANPlugin::write_frame_as_if_received(const isobus::HardwareInterfaceCANFrame &canFrame) const
 {
 	const std::lock_guard<std::mutex> lock(mutex);
 	ourDevice->queue.push_back(canFrame);

--- a/hardware_integration/src/virtual_can_plugin.cpp
+++ b/hardware_integration/src/virtual_can_plugin.cpp
@@ -20,6 +20,11 @@ VirtualCANPlugin::VirtualCANPlugin(const std::string channel, const bool receive
 	channels[channel].push_back(ourDevice);
 }
 
+VirtualCANPlugin::~VirtualCANPlugin()
+{
+	close();
+}
+
 bool VirtualCANPlugin::get_is_valid() const
 {
 	return running;
@@ -58,6 +63,13 @@ bool VirtualCANPlugin::write_frame(const isobus::HardwareInterfaceCANFrame &canF
 		}
 	}
 	return retVal;
+}
+
+void VirtualCANPlugin::write_frame_as_if_received(const isobus::HardwareInterfaceCANFrame &canFrame)
+{
+	const std::lock_guard<std::mutex> lock(mutex);
+	ourDevice->queue.push_back(canFrame);
+	ourDevice->condition.notify_one();
 }
 
 bool VirtualCANPlugin::read_frame(isobus::HardwareInterfaceCANFrame &canFrame)

--- a/test/hardware_interface_tests.cpp
+++ b/test/hardware_interface_tests.cpp
@@ -1,0 +1,80 @@
+#include <gtest/gtest.h>
+
+#include "isobus/hardware_integration/can_hardware_interface.hpp"
+#include "isobus/hardware_integration/virtual_can_plugin.hpp"
+
+#include <chrono>
+#include <future>
+#include <thread>
+
+using namespace isobus;
+
+TEST(HARDWARE_INTERFACE_TESTS, SendMessageToHardware)
+{
+	auto sender = std::make_shared<VirtualCANPlugin>();
+	auto receiver = std::make_shared<VirtualCANPlugin>();
+	CANHardwareInterface::set_number_of_can_channels(1);
+	CANHardwareInterface::assign_can_channel_frame_handler(0, sender);
+	CANHardwareInterface::start();
+
+	HardwareInterfaceCANFrame fakeFrame;
+	memset(&fakeFrame, 0, sizeof(HardwareInterfaceCANFrame));
+	fakeFrame.identifier = 0x613;
+	fakeFrame.isExtendedFrame = false;
+	fakeFrame.dataLength = 1;
+	fakeFrame.data[0] = 0x01;
+	fakeFrame.channel = 0;
+
+	HardwareInterfaceCANFrame receiveFrame;
+	memset(&receiveFrame, 0, sizeof(HardwareInterfaceCANFrame));
+	auto future = std::async(std::launch::async, [&] { receiver->read_frame(receiveFrame); });
+
+	isobus::send_can_message_to_hardware(fakeFrame);
+
+	EXPECT_TRUE(future.wait_for(std::chrono::seconds(5)) != std::future_status::timeout);
+
+	EXPECT_EQ(fakeFrame.identifier, 0x613);
+	EXPECT_EQ(fakeFrame.isExtendedFrame, false);
+	EXPECT_EQ(fakeFrame.dataLength, 1);
+	EXPECT_EQ(fakeFrame.data[0], 0x01);
+
+	CANHardwareInterface::stop();
+}
+
+TEST(HARDWARE_INTERFACE_TESTS, ReceiveMessageFromHardware)
+{
+	auto device = std::make_shared<VirtualCANPlugin>();
+	CANHardwareInterface::set_number_of_can_channels(1);
+	CANHardwareInterface::assign_can_channel_frame_handler(0, device);
+	CANHardwareInterface::start();
+
+	HardwareInterfaceCANFrame fakeFrame;
+	memset(&fakeFrame, 0, sizeof(HardwareInterfaceCANFrame));
+	fakeFrame.identifier = 0x613;
+	fakeFrame.isExtendedFrame = false;
+	fakeFrame.dataLength = 1;
+	fakeFrame.data[0] = 0x01;
+	fakeFrame.channel = 0;
+
+	int message_count = 0;
+	CANHardwareInterface::add_raw_can_message_rx_callback(
+	  [](HardwareInterfaceCANFrame &frame, void *parent) {
+		  int *count = static_cast<int *>(parent);
+		  *count += 1;
+
+		  EXPECT_EQ(frame.identifier, 0x613);
+		  EXPECT_EQ(frame.isExtendedFrame, false);
+		  EXPECT_EQ(frame.dataLength, 1);
+		  EXPECT_EQ(frame.data[0], 0x01);
+	  },
+	  &message_count);
+
+	device->write_frame_as_if_received(fakeFrame);
+
+	//! @todo This is a hack to wait for the message to be received.  We should
+	//!       have a way to wait for the message to be received.
+	std::this_thread::sleep_for(std::chrono::milliseconds(250));
+	EXPECT_EQ(message_count, 1);
+
+	CANHardwareInterface::stop();
+}


### PR DESCRIPTION
This PR is mostly refactoring the CANHardwareInterface class and adding some basic tests to it. I planned to change it up more, but before doing that I think it's useful to get thoughts of others on this changed version. 

The changes I made:
- Replace raw pointers with smart pointers.
- Reduce number of raw locks with gaurded and unique locks.
- Switch canLibNeedsUpdate from bool with mutex, to atomic_bool
- Improved consistency in naming, e.g. camelCase for variables and snake_case for functions

It's been some time since I made these changes and I notice now that I went away from the single-return path for some smaller functions (mostly to use early-returns instead). I know not everyone likes it, but I see a few benefits for it:
- Have the logging message close to the if condition that fails
- Not have a lot of indented if-statements (easier to read on mobile platforms)
- Most of the time reduces the lines of code
- Don't have to trace which else-statement belongs to which if-statement

That said, I'm open to hear the disadvantages.