### PR TITLE
[CI]: Make sonar-scanner run on regular push to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,8 +27,8 @@ jobs:
 
     needs: approve
     # Only run if the approve job succeeded or was skipped, as it continues on error
-    if: ${{ always() && needs.approve.result == 'success' || needs.approve.result == 'skipped' }} 
-    
+    if: ${{ always() && needs.approve.result == 'success' || needs.approve.result == 'skipped' }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -59,14 +59,23 @@ jobs:
       - name: Collect coverage into one XML report
         run: |
           gcovr --sonarqube --exclude-throw-branches > coverage.xml
-      - name: Run sonar-scanner
+      - name: Run sonar-scanner for push
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        if: "${{ env.SONAR_TOKEN != '' && github.event_name == 'push' }}"
+        run: |
+          sonar-scanner \
+            --define sonar.cfamily.build-wrapper-output="${{ env.BUILD_WRAPPER_OUT_DIR }}" \
+            --define sonar.coverageReportPaths=coverage.xml
+      - name: Run sonar-scanner for PR
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
           PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
-        if: "${{ env.SONAR_TOKEN != '' }}"
+        if: "${{ env.SONAR_TOKEN != '' && github.event_name == 'pull_request_target' }}"
         run: |
           sonar-scanner \
             --define sonar.cfamily.build-wrapper-output="${{ env.BUILD_WRAPPER_OUT_DIR }}" \
@@ -76,7 +85,7 @@ jobs:
             --define sonar.pullrequest.key=$PR_NUMBER \
             --define sonar.pullrequest.branch=$PR_HEAD_REF \
             --define sonar.pullrequest.base=$PR_BASE_REF
-          echo "SonarCloud analysis finished for PR '$PR_NUMBER' for merge into '$PR_HEAD_REF' from '$PR_BASE_REF'"
+          echo "SonarCloud analysis finished for PR '$PR_NUMBER' for merge into '$PR_BASE_REF' from '$PR_HEAD_REF'"
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2
         with:

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,8 +2,7 @@ sonar.projectKey=ad3154_ISO11783-CAN-Stack
 sonar.organization=isobus-plusplus
 
 # This is the name and version displayed in the SonarCloud UI.
-#sonar.projectName=ISO11783-CAN-Stack
-#sonar.projectVersion=1.0
+#sonar.projectVersion=1.0.0
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=isobus,examples,hardware_integration,utility
@@ -11,8 +10,3 @@ sonar.tests=test
 
 # Exclude some files from the analysis.
 sonar.exclusions=**/PCANBasic.h,**/libusb.h,**/InnoMakerUsb2CanLib.h
-
-# Encoding of the source code. Default is default system encoding
-#sonar.sourceEncoding=UTF-8
-
-sonar.cfamily.cache.enabled=false


### PR DESCRIPTION
SonarCloud stopped producing useable analysis for the main branch, which is kind of obvious as it treated every workflow event as an PR... With this PR it should be able to run the analysis on the main branch again 😄 